### PR TITLE
Skip content import if directory is missing

### DIFF
--- a/container_init.sh
+++ b/container_init.sh
@@ -69,7 +69,7 @@ elif [ "${ENABLE_INIT_CONTAINER_IMPORT_CONTENT:-false,,}" != "true" ]; then
 fi
 
 # Look for the content files we need
-if [[ ! (
+if [[ -d ${dumped_content_dir} && ! (
     ( -f ${dumped_content_dir}/rule_content.yaml || -f ${dumped_content_dir}/rule_content.yaml.gz ) &&
     ( -f ${dumped_content_dir}/playbook_content.yaml || -f ${dumped_content_dir}/playbook_content.yaml.gz ) &&
     -f ${dumped_content_dir}/config.yaml


### PR DESCRIPTION
Skip content import if the dumped_content folder is missing.  Allows us to avoid conditional installer logic in foreman.