### PR TITLE
RHINENG-3644: Combine Satellite runs into one group per Satellite

### DIFF
--- a/api/advisor/tasks/tests/test_executed_task_views.py
+++ b/api/advisor/tasks/tests/test_executed_task_views.py
@@ -432,37 +432,46 @@ class ExecutedTaskViewTestCase(TestCase):
         self.assertEqual(len(data['jobs']), 3)
         # Check that the data passed in was for the 'right' recipients:
         self.assertEqual(len(responses.calls), 1)
+        # Decode the raw list to as a dict based on recipient, for comparison
+        recipients = {
+            run_item['recipient']: run_item
+            for run_item in json.loads(responses.calls[0].request.body)
+        }
         self.assertEqual(
-            json.loads(responses.calls[0].request.body),
-            [
-                {
-                    "recipient": constants.host_01_clid,
-                    "org_id": constants.standard_org,
-                    "url": "https://cert.console.stage.redhat.com/api/tasks/v1/task/log4shell/playbook",
-                    "principal": constants.test_user,
-                    "name": "Log4Shell vulnerability detection",
-                }, {
-                    "recipient": constants.host_03_clid,
-                    "org_id": constants.standard_org,
-                    "url": "https://cert.console.stage.redhat.com/api/tasks/v1/task/log4shell/playbook",
-                    "principal": constants.test_user,
-                    "name": "Log4Shell vulnerability detection",
-                }, {
-                    "recipient": constants.host_04_recip,
-                    "org_id": constants.standard_org,
-                    "url": "https://cert.console.stage.redhat.com/api/tasks/v1/task/log4shell/playbook?inventory_id=00112233-4455-6677-8899-012345678904",
-                    "principal": constants.test_user,
-                    "name": "Log4Shell vulnerability detection",
-                    "recipient_config": {
-                        "sat_id": constants.host_04_satid,
-                        "sat_org_id": "1"
-                    },
-                    "hosts": [
-                        {"inventory_id": constants.host_04_uuid}
-                    ]
-                }
-            ]
+            recipients[constants.host_01_clid], {
+                "recipient": constants.host_01_clid,
+                "org_id": constants.standard_org,
+                "url": "https://cert.console.stage.redhat.com/api/tasks/v1/task/log4shell/playbook",
+                "principal": constants.test_user,
+                "name": "Log4Shell vulnerability detection",
+            }
         )
+        self.assertEqual(
+            recipients[constants.host_03_clid], {
+                "recipient": constants.host_03_clid,
+                "org_id": constants.standard_org,
+                "url": "https://cert.console.stage.redhat.com/api/tasks/v1/task/log4shell/playbook",
+                "principal": constants.test_user,
+                "name": "Log4Shell vulnerability detection",
+            }
+        )
+        self.assertEqual(
+            recipients[constants.host_04_recip], {
+                "recipient": constants.host_04_recip,
+                "org_id": constants.standard_org,
+                "url": "https://cert.console.stage.redhat.com/api/tasks/v1/task/log4shell/playbook",
+                "principal": constants.test_user,
+                "name": "Log4Shell vulnerability detection",
+                "recipient_config": {
+                    "sat_id": constants.host_04_satid,
+                    "sat_org_id": "1"
+                },
+                "hosts": [
+                    {"inventory_id": constants.host_04_uuid}
+                ]
+            }
+        )
+        self.assertEqual(len(recipients), 3)
 
         # Also check that the jobs were given the run IDs our fake playbook
         # dispatcher gave them

--- a/api/advisor/tasks/views/executed_task.py
+++ b/api/advisor/tasks/views/executed_task.py
@@ -122,25 +122,58 @@ def satellite_id_from_tags(tags):
 
 
 def execute_playbook_dispatcher(hosts, org_id, task, user, executed_task_url):
-    dispatch_body = []
+    # First assemble the hosts by recipient - Satellite or individual
+    individual_hosts = []
+    satellite_hosts = dict()
     for host in hosts:
         if host['rhc_client_id'] is None:
-            raise ValidationError({'hosts': f'host {host["id"]} does not have an associated RHC client id'})
+            raise ValidationError({
+                'hosts': f'host {host["id"]} does not have an associated RHC client id'
+            })
+        if host['satellite_instance_id']:
+            if host['satellite_instance_id'] not in satellite_hosts:
+                satellite_hosts[host['satellite_instance_id']] = {
+                    'sat_rhc_id': str(host['rhc_client_id']),
+                    'org_id': host['satellite_org_id'],
+                    'hosts': []
+                }
+            satellite_hosts[host['satellite_instance_id']]['hosts'].append(
+                str(host['id'])
+            )
+        else:
+            individual_hosts.append(str(host['rhc_client_id']))
+
+    dispatch_body = []
+    # Now assemble the runs to be dispatched: by Satellite then individual
+    for satellite_id, sat_data in satellite_hosts.items():
         run = {
-            'recipient': str(host['rhc_client_id']),
+            'recipient': sat_data['sat_rhc_id'],
+            'recipient_config': {
+                "sat_id": satellite_id,
+                "sat_org_id": sat_data['org_id'],
+            },
+            'org_id': org_id,
+            'url': executed_task_url,
+            'principal': user,
+            'name': task.title,
+            'hosts': [
+                {'inventory_id': host_id}
+                for host_id in sat_data['hosts']
+            ],
+        }
+        dispatch_body.append(run)
+
+    for host_id in individual_hosts:
+        run = {
+            'recipient': host_id,
             'org_id': org_id,
             'url': executed_task_url,
             'principal': user,
             'name': task.title,
         }
-        if host['satellite_instance_id']:
-            run['recipient_config'] = {
-                "sat_id": host['satellite_instance_id'],
-                "sat_org_id": host['satellite_org_id']
-            }
-            run['hosts'] = [{'inventory_id': str(host['id'])}]
-            run['url'] = f"{run['url']}?inventory_id={str(host['id'])}"
         dispatch_body.append(run)
+
+    # Now we can actually dispatch the run list
     logger.info(dispatch_body)
     (response, elapsed) = retry_request(
         'Playbook Dispatcher', settings.PLAYBOOK_DISPATCHER_URL + '/internal/v2/dispatch',


### PR DESCRIPTION
Previously we created one run for each host, regardless of whether it was on a Satellite or not.  This may cause too many requests, and the multiple jobs would be hard to track.  This now rearranges the run list so that Satellite jobs are combined into one job per Satellite.

The tests now compare individual recipient data structures rather than one big JSON list.