### PR TITLE
The `import_content` code no longer runs as a script

### DIFF
--- a/api/advisor/api/scripts/import_content.py
+++ b/api/advisor/api/scripts/import_content.py
@@ -31,16 +31,9 @@ TODO: work on tracking what's changed between the rule content and the model.
 from datetime import datetime
 import django
 import os
-import sys
 from django.conf import settings
 from django.db.models import Count, Exists, OuterRef
 
-# Need to get the API models, so we set up django environment regardless of
-# whether we're running as a script or being called as a module.  Fortunately,
-# Django is fine with this.
-sys.path.append(os.curdir)
-# Rely on DJANGO_SETTINGS_MODULE env here
-django.setup()
 from api import models  # noqa
 from advisor_logging import logger  # noqa
 from kafka_utils import send_webhook_event  # noqa

--- a/api/advisor/api/views/import_content.py
+++ b/api/advisor/api/views/import_content.py
@@ -40,7 +40,9 @@ class ImportContentViewSet(viewsets.ViewSet):
         """
         if not ('config' in request.data and 'content' in request.data):
             # Data is not valid for some reason.
-            return HttpResponseBadRequest("Config or content fields were not present")
+            return HttpResponseBadRequest(
+                content=b"Config or content fields were not present"
+            )
 
         if 'application/json' in request.content_type:
             # application/json is the recommended content-type for import content
@@ -51,18 +53,26 @@ class ImportContentViewSet(viewsets.ViewSet):
             try:
                 config_data = loads(request.data['config'])
                 content_data = loads(request.data['content'])
-            except Exception as e:
-                return HttpResponseBadRequest(e)
+            except:
+                return HttpResponseBadRequest(
+                    content=b"Could not read config and content as JSON"
+                )
 
         # Some basic data checks:
         if not isinstance(config_data, dict):
-            return HttpResponseBadRequest(content="Config parses as JSON but isn't a dictionary")
+            return HttpResponseBadRequest(
+                content=b"Config parses as JSON but isn't a dictionary"
+            )
         if 'resolution_risk' not in config_data:
-            return HttpResponseBadRequest(content="Config parses as JSON but doesn't have resolution_risk data")
+            return HttpResponseBadRequest(
+                content=b"Config parses as JSON but doesn't have resolution_risk data"
+            )
         all_rule_apis_are_dicts = all(isinstance(rule_api, dict) for rule_api in content_data)
         all_rule_apis_have_rule_id = all('rule_id' in rule_api for rule_api in content_data)
         if not (isinstance(content_data, list) and all_rule_apis_are_dicts and all_rule_apis_have_rule_id):
-            return HttpResponseBadRequest(content="Content parses as JSON but doesn't look like a list of rules")
+            return HttpResponseBadRequest(
+                content=b"Content parses as JSON but doesn't look like a list of rules"
+            )
         # Rely on the import_content routines to validate the data.
         stats = import_content.import_all(config_data, content_data)
         return Response(ImportStatsSerializer({'stats': stats}).data)


### PR DESCRIPTION
Previously, the `api/scripts/import_content.py` script was expected to run by
itself and read files from the operating system.  This is no longer supported.
However, the legacy of this was that we tried to manually set up the Django
environment, something that is now confusing parts of the WSGI loader.  This
manual setup can easily be removed.