### PR TITLE
Draft: System CN property can be any string, not just a UUID

### DIFF
--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -737,8 +737,9 @@ class HostAck(ExportModelOperationsMixin('hostack'), TimestampedModel):
     )
 
     def __str__(self):
-        return u'ack for {r} for account {a} by org {o} for {s}'.format(r=self.rule, a=self.account,
-                                                                    o=self.org_id, s=self.host_id)
+        return u'ack for {r} for account {a} by org {o} for {s}'.format(
+            r=self.rule, a=self.account, o=self.org_id, s=self.host_id
+        )
 
     class Meta:
         ordering = ('org_id', 'host', 'rule__rule_id', )

--- a/api/advisor/api/tests/test_cert_auth.py
+++ b/api/advisor/api/tests/test_cert_auth.py
@@ -23,7 +23,7 @@ from api.tests import constants, update_stale_dates
 from api.permissions import auth_header_for_testing, auth_header_key
 
 
-def bad_header(json_str):
+def bad_header(json_str) -> dict:
     return {auth_header_key: base64.b64encode(json_str.encode())}
 
 
@@ -78,11 +78,15 @@ class CertAuthTestCase(TestCase):
             **bad_header(bad_start + '"type": "System", "system": {"cn": 3}}}'),
         )
         self.assertEqual(response.status_code, 403, "System property has non-string cn check failed")
+        # We now allow the CN value to be anything, not just a UUID.
         response = self.client.get(
             reverse('system-list'),
             **bad_header(bad_start + '"type": "System", "system": {"cn": "banana"}}}'),
         )
-        self.assertEqual(response.status_code, 403, "System property has non-UUID cn check failed")
+        self.assertEqual(
+            response.status_code, 200,
+            "System property has non-UUID cn check should be allowed"
+        )
 
     def test_list_system_satellite(self):
         # Host 03 is the nominal Satellite, so it should see all the systems

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -326,17 +326,13 @@ class BadUseOfCertAuthPermission(TestCase):
             cap.message,
             "'identity.system.cn' is not a string in Cert authentication check"
         )
-        # system dict 'cn' value not a UUID
+        # system dict 'cn' value is now allowed just a string, not just a UUID
         request.auth = {
             'org_id': constants.standard_org, 'type': 'System',
             'system': {'cn': constants.host_01_name}
         }
         result = cap.has_permission(request, view)
-        self.assertFalse(result)
-        self.assertEqual(
-            cap.message,
-            "'identity.system.cn' is not a UUID in Cert authentication check"
-        )
+        self.assertTrue(result)
 
         # Finally we should be able to validate with a valid identity
         request.auth = {


### PR DESCRIPTION
It turns out that Satellite sometimes uses arbitrary strings, not just UUIDs,
to identify itself in the `identity.system.cn` property of the system certificate
authentication.  This relaxes our checks to not enforce this property being
a UUID.

Signed-off-by: Paul Wayper <paulway@redhat.com>