### PR TITLE
Advisor fix logging conf hide metrics

### DIFF
--- a/api/advisor/logging_conf.py
+++ b/api/advisor/logging_conf.py
@@ -35,13 +35,13 @@ def hide_metrics(record):
         return True
 
     # otherwise do not
-    record_name = getattr(record, "name")
-    record_args = getattr(record, "args")
-    if record_name in ('django.request', 'django.server') and record_args:
-        args = record_args[0].split()
+    record_name = getattr(record, "name", 'none')
+    record_args = getattr(record, "args", None)
+    if record_name in ('django.request', 'django.server') and record_args and isinstance(record_args, str):
+        args = record_args.split()
         if len(args) > 1 and args[0] == 'GET' and args[1] == '/metrics':
             return False
-    elif record_name == 'gunicorn.access' and record_args and record_args.get('U') == '/metrics':
+    elif record_name == 'gunicorn.access' and record_args and isinstance(record_args, dict) and record_args.get('U') == '/metrics':
         return False
     return True
 

--- a/api/advisor/middleware/tasks_rewrite_internal_urls.py
+++ b/api/advisor/middleware/tasks_rewrite_internal_urls.py
@@ -47,6 +47,9 @@ def rewrite_urls(get_response):
             return response
 
         full_url = request.build_absolute_uri()
+        if "/api/tasks/v1/" not in full_url:
+            return response
+
         logger.info(f'Rewriting internal URLs in html document: {full_url}')
         url_components = urlparse(full_url)
         url_location = url_components.scheme + '://' + url_components.netloc


### PR DESCRIPTION
The `hide_metrics` function seems to have been failing in Stage because it
assumed there were attributes of the log record which weren't there.

This fixes that problem and tests the full range of paths we expect through
this function.

Also fixes an incorrect string split attempt on the first character of a string.