### PR TITLE
Empty instead of removing the `args` property

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,10 +9,10 @@ USER root
 ADD https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo group_insights-postgresql-16-epel-9.repo
 # Install & upgrade RHEL packages
 RUN (microdnf module enable -y postgresql:16 || \
-     cp group_insights-postgresql-16-epel-9.repo /etc/yum.repos.d/postgresql.repo \
+    cp group_insights-postgresql-16-epel-9.repo /etc/yum.repos.d/postgresql.repo \
     ) && \
     microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
-      python3.12 postgresql git-core && \
+    python3.12 postgresql git-core && \
     microdnf -y upgrade && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
@@ -34,14 +34,14 @@ RUN microdnf -y install python3.12-pip python3.12-devel gcc libpq-devel && \
     pip3 -q install pipenv && \
     pipenv install && \
     microdnf remove -y python3.12-devel gcc libpq-devel \
-      acl binutils binutils-gold cpp \
-      elfutils-debuginfod-client elfutils-default-yama-scope elfutils-libelf \
-      elfutils-libs libxcrypt-devel glibc-devel make libgomp libmpc \
-      libpkgconf pkgconf pkgconf-pkg-config \
-      glibc-headers kernel-headers && \
+    acl binutils binutils-gold cpp \
+    elfutils-debuginfod-client elfutils-default-yama-scope elfutils-libelf \
+    elfutils-libs libxcrypt-devel glibc-devel make libgomp libmpc \
+    libpkgconf pkgconf pkgconf-pkg-config \
+    glibc-headers kernel-headers && \
+    chown -R 1001 .cache .local
 # The unit tests need to install --dev packages, which needs to write to
 # .local, so we need to set the permissions so 1001 can do that here
-    chown -R 1001 .cache .local
 
 # Set Django 5.2+ minimum PostgreSQL version to 13
 RUN sed -i s/\(14,\)/\(13,\)/g $(pipenv --venv)/lib/python3.12/site-packages/django/db/backends/postgresql/features.py
@@ -57,6 +57,6 @@ USER 1001
 COPY ./api ./api
 COPY ./service ./service
 
-COPY container_init.sh container_init.sh
+COPY container_init.sh cgroup-limits ./
 
 EXPOSE 8000

--- a/api/advisor/advisor_logging.py
+++ b/api/advisor/advisor_logging.py
@@ -183,7 +183,7 @@ class OurFormatter(LogstashFormatterV1):
             modify_gunicorn_logs_record(record, record_args)
             # We've now put everything we want in the record, we can
             # remove the args entirely
-            delattr(record, "args")
+            record.args = {}
 
         post = thread_storage.get_value('post')
         if post:

--- a/api/advisor/advisor_logging.py
+++ b/api/advisor/advisor_logging.py
@@ -172,18 +172,22 @@ class OurFormatter(LogstashFormatterV1):
 
         record_name = getattr(record, "name")
         record_args = getattr(record, "args")
-        if record_name in ('django.request', 'django.server') and record_args:
+        if record_name in ('django.request', 'django.server') and record_args and isinstance(record_args, str):
             # args="GET /api/insights/v1/... HTTP/1.1, 200, 603"
             args = record_args.split()
             if len(args) > 1 and args[0] in ('GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS'):
                 setattr(record, 'method', args[0])
                 setattr(record, 'url', args[1])
                 setattr(record, 'http_version', args[2][:-1])  # minus comma
-        elif record_name == 'gunicorn.access' and record_args:
+        elif record_name == 'gunicorn.access' and record_args and isinstance(record_args, dict):
             modify_gunicorn_logs_record(record, record_args)
-            # We've now put everything we want in the record, we can
-            # remove the args entirely
-            record.args = {}
+            # record.args is used in % with the message of:
+            # "%(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"
+            # so we need to include those keys and only those keys.
+            record.args = {
+                key: record_args[key]
+                for key in ('h', 'l', 'u', 't', 'r', 's', 'b', 'f', 'a')
+            }
 
         post = thread_storage.get_value('post')
         if post:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -75,7 +75,7 @@ services:
         condition: service_healthy
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Containerfile
     environment:
       - BOOTSTRAP_SERVERS=kafka:29092
       - ADVISOR_DB_HOST=advisor-db
@@ -83,7 +83,7 @@ services:
   advisor-api:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Containerfile
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
We can't remove the `args` attribute because the `logger` library relies
on it.  So instead we empty it out to be an empty set.

Also, somehow we haven't noticed that the `podman compose` config
referenced the old `Dockerfile` instead of the new `Containerfile`.