### PR TITLE
Make sure the logs have the 'url' and 'method' fields.

### DIFF
--- a/api/advisor/advisor_logging.py
+++ b/api/advisor/advisor_logging.py
@@ -87,7 +87,7 @@ def modify_gunicorn_logs_record(record, record_args):
     }
     for short_name, rename in gunicorn_record_arg_renames.items():
         if short_name in record_args:
-            value = record_args.[short_name]
+            value = record_args[short_name]
             if 'transform' in rename:
                 value = rename['transform'](value)
             setattr(record, rename['long name'], value)
@@ -121,6 +121,8 @@ def modify_gunicorn_logs_record(record, record_args):
     if record.url == '-':
         if '?' in record.raw_uri:
             record.url, record.query_params = record.raw_uri.split('?', 1)
+        else:
+            record.url = record.raw_uri
 
 
 def copy_attr_to_record(record, request, name, new_name=None):

--- a/api/advisor/advisor_logging.py
+++ b/api/advisor/advisor_logging.py
@@ -71,7 +71,7 @@ def modify_gunicorn_logs_record(record, record_args):
         'H': {'long name': 'http_version'},
         # 'h': {'long name': 'host'},
         'L': {'long name': 'seconds', 'as': 'string float'},
-        # 'l': {},
+        # 'l': {'long name': 'apache remote host identifier', 'is': '-'},
         # 'M': {'long name': 'milliseconds'},
         'm': {'long name': 'method'},
         # 'p': {'long name': 'process ID?', '=': '"<19945>"'},
@@ -83,7 +83,7 @@ def modify_gunicorn_logs_record(record, record_args):
         # 'T': {'long name': 'time taken?'},
         't': {'long name': 'timestamp'},
         'U': {'long name': 'url'},
-        # 'u': {'is': '-'},
+        # 'u': {'long name': 'user', 'is': 'not provided, usually "-"'},
     }
     for short_name, rename in gunicorn_record_arg_renames.items():
         if short_name in record_args:
@@ -197,6 +197,8 @@ class OurFormatter(LogstashFormatterV1):
             # record.args is used in % with the message of:
             # "%(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"
             # so we need to include those keys and only those keys.
+            # This translates roughly to:
+            # "127.0.0.1 - - [06/Aug/2025:05:38:55 +0000] \"GET /api/insights/v1/rule/ HTTP/1.1\" 200 26439 \"-\" \"Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0\""
             record.args = {
                 key: record_args[key]
                 for key in ('h', 'l', 'u', 't', 'r', 's', 'b', 'f', 'a')


### PR DESCRIPTION
For as yet unknown reasons, sometimes the gunicorn log arguments
have `'-'` as the value of the 'U' (URL) and 'm' (method) field.  So we
fill those in from the 'raw_uri' and 'request_method' fields respectively.
We split the raw_uri into query parameters as well if it contains a '?'.