### PR TITLE
Make sure 'summary' field changes are also recorded

### DIFF
--- a/api/advisor/api/scripts/import_content.py
+++ b/api/advisor/api/scripts/import_content.py
@@ -272,16 +272,16 @@ def update_ruleset_with_content(content):
     have changed or are new.
     """
     logger.info("*** Updating rules from content")
-    fields_we_might_change = (
-        'description', 'reboot_required', 'publish_date',
-        'generic', 'reason', 'more_info', 'active', 'category',
-        'impact', 'likelihood', 'node_id', 'total_risk',
-    )
     # Fields which can be copied as is.  Everything else needs some kind of
     # special handling.
     standard_fields = ('description', 'reboot_required', 'summary', )
     # Fields where nulls are converted to ''
     null_to_blank_fields = ('generic', 'reason', 'more_info', 'node_id')
+    # So the fields we actually need to track are:
+    fields_we_might_change = standard_fields + null_to_blank_fields + (
+        'publish_date', 'active', 'category',
+        'impact', 'likelihood', 'total_risk',
+    )
     # Note that we never delete a rule here.  We assume that old rules get
     # deactivated instead.  It's using a Paranoid model anyway.
     stats = {'added': 0, 'updated': 0, 'same': 0, 'deleted': 0}


### PR DESCRIPTION
In investigating why the 'summary' field in many rules is the same as the
'generic' field, I found that changes to the 'summary' field were not being
tracked in trying to determine whether to update the rule model of an
existing rule.  This fix makes sure that fields we check and possibly modify
are always included in the list of fields checked for updates.

(Hopefully) fixes RHINENG-17698