### PR TITLE
Updating tests to use/expect a UUID user_id

### DIFF
--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -1132,10 +1132,10 @@ def request_to_org(request):
 
 
 def auth_header_for_testing(
-    org_id=None, account=None, supply_http_header=False,
-    username='testing', user_id='123', user_opts={}, system_opts=None, unencoded=False,
-    raw=None, service_account=None
-):
+    org_id=None, account=None, supply_http_header=False, username='testing',
+    user_id='01234567-0123-0123-0123-0123456789ab', user_opts={},
+    system_opts=None, unencoded=False, raw=None, service_account=None
+) -> dict[str, str]:
     """
     Provide a JSON string which can be loaded into the 'x-rh-identity'
     header to provide access for testing.
@@ -1239,10 +1239,14 @@ def auth_header_for_testing(
         if username is not None:
             user_section['username'] = username
         if user_id is not None:
-            if not isinstance(user_id, str):
-                raise TypeError(
+            # Don't actually store the user_id as a UUID, just validate that
+            # it is one.
+            try:
+                uuid.UUID(user_id)
+            except ValueError:
+                raise ValueError(
                     "'user_id' argument to auth_header_for_testing must be a "
-                    "string"
+                    "valid UUID"
                 )
             user_section['user_id'] = user_id
         identity['user'] = user_section

--- a/api/advisor/api/tests/__init__.py
+++ b/api/advisor/api/tests/__init__.py
@@ -42,7 +42,8 @@ class constants(object):
     standard_org = '9876543'
     alternate_org = '9988776'
     host_tag_org = '1000000'
-    standard_user_id = '123'
+    test_username = 'testing'
+    test_user_id = '01234567-0123-0123-0123-0123456789ab'
 
     service_account = {
         'client_id': '10203040-5060-7080-90a0-b0c0d0e0f000',
@@ -288,9 +289,9 @@ class constants(object):
     # kessel_std_principal = {'object': {'object_type': 'rbac/principal', 'object_id': '123'}}
     kessel_std_principal = kessel.ObjectType("rbac", "principal")
     kessel_std_user_id = kessel.SubjectRef(kessel.ObjectRef(
-        type=kessel_std_principal, id=standard_user_id
+        type=kessel_std_principal, id=test_user_id
     )).to_zed()
-    kessel_std_user_identity_dict = {'user': {'user_id': standard_user_id}}
+    kessel_std_user_identity_dict = {'user': {'user_id': test_user_id}}
     kessel_std_workspace = kessel.ObjectType('rbac', 'workspace').to_zed()
     kessel_host_01_ref = kessel.HostId(host_01_uuid).to_ref().to_zed()
 

--- a/api/advisor/api/tests/test_advisor_logging.py
+++ b/api/advisor/api/tests/test_advisor_logging.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 from django.test import TestCase
 
 from api.permissions import request_object_for_testing
+from api.tests import constants
 
 import advisor_logging
 import logging_conf
@@ -209,10 +210,10 @@ class AdvisorLoggingTestCase(TestCase):
 
         self.assertEqual(record.headers['REMOTE-ADDR'], 'test')
         self.assertEqual(record.headers['X-RH-IDENTITY'], request.META['HTTP_X_RH_IDENTITY'])
-        self.assertEqual(record.account_number, '1234567')
-        self.assertEqual(record.org_id, '9876543')
-        self.assertEqual(record.username, 'testing')
-        self.assertEqual(record.user_id, '123')
+        self.assertEqual(record.account_number, constants.standard_acct)
+        self.assertEqual(record.org_id, constants.standard_org)
+        self.assertEqual(record.username, constants.test_username)
+        self.assertEqual(record.user_id, constants.test_user_id)
         self.assertEqual(record.request_id, 'request_id')
         self.assertEqual(record.rbac_elapsed_time_millis, 123)
 
@@ -281,10 +282,10 @@ class AdvisorLoggingTestCase(TestCase):
             str(request.META['HTTP_X_RH_IDENTITY'])
         )
         # Fields derived from that:
-        self.assertEqual(formatted_rec['account_number'], '1234567')
-        self.assertEqual(formatted_rec['org_id'], '9876543')
-        self.assertEqual(formatted_rec['username'], 'testing')
-        self.assertEqual(formatted_rec['user_id'], '123')
+        self.assertEqual(formatted_rec['account_number'], constants.standard_acct)
+        self.assertEqual(formatted_rec['org_id'], constants.standard_org)
+        self.assertEqual(formatted_rec['username'], constants.test_username)
+        self.assertEqual(formatted_rec['user_id'], constants.test_user_id)
         self.assertEqual(formatted_rec['request_id'], 'request_id')
         self.assertEqual(formatted_rec['rbac_elapsed_time_millis'], 123)
         self.assertEqual(formatted_rec['post'], post_data)

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -449,7 +449,7 @@ class BadUsesOfAuthHeaderTestCase(TestCase):
             'account_number': constants.standard_acct,
             'org_id': constants.standard_org,
             'type': 'User',
-            'user': {'user_id': '123', 'username': 'testing'}
+            'user': {'user_id': constants.test_user_id, 'username': constants.test_username}
         }})
 
     def test_system_and_user_auth(self):
@@ -514,7 +514,7 @@ class TestInsightsRBACPermissionKessel(TestCase):
         # Identity has no 'username'
         request.auth = {
             'org_id': constants.standard_org, 'type': 'User',
-            'user': {'id': constants.standard_user_id}
+            'user': {'id': constants.test_user_id}
         }
         self.assertFalse(irbp.has_permission(request, view))
         # Identity 'username' key is not a string
@@ -529,14 +529,14 @@ class TestInsightsRBACPermissionKessel(TestCase):
         # Set up the various permissions objects
         rhia = RHIdentityAuthentication()
         request = request_object_for_testing()
-        user_id, _ = rhia.authenticate(request)
+        org_id, _ = rhia.authenticate(request)
         self.assertFalse(hasattr(request, 'user'))
-        request.user = user_id
+        request.user = org_id
         request.auth = {
             'org_id': constants.standard_org, 'type': 'User',
-            'user': {'username': 'Barry Jones', 'user_id': constants.standard_user_id}
+            'user': {'username': 'Barry Jones', 'user_id': constants.test_user_id}
         }
-        self.assertEqual(user_id, constants.standard_org)
+        self.assertEqual(org_id, constants.standard_org)
         self.assertTrue(hasattr(request, 'auth'))
         view = FakeView()
         setattr(view, 'resource_name', 'recommendation_results')


### PR DESCRIPTION
Though the `kessel.py` code never explicitly enforced this, we assumed from examples
that the user_id field would be the string representation of a positive integer.  It turns
out that it should be a user_id.  This updates the test code to supply and expect this.