### PR TITLE
Import Advisor content from remote URL path

### DIFF
--- a/api/advisor/api/management/commands/import_content.py
+++ b/api/advisor/api/management/commands/import_content.py
@@ -931,7 +931,6 @@ def load_all_playbooks(all_playbook_data):
         ), all_playbook_data, 'rule_id_type',
         transformer=playbook_transformer
     )
-    return True
 
 
 def process_playbooks_from_path(repo_path):
@@ -947,7 +946,7 @@ def process_playbooks_from_path(repo_path):
     else:
         logger.info("Reading playbook content in %s", repo_path)
         playbook_content = generate_playbook_content(repo_path)
-    return load_all_playbooks(playbook_content)
+    load_all_playbooks(playbook_content)
 
 
 def dump_playbooks(repo_path, compress=False):
@@ -1050,9 +1049,7 @@ class Command(BaseCommand):
                 logger.error("Could not load content configuration - exiting")
                 return
             load_database_maps()  # some of which is loaded from config in models.
-            if not process_content_from_path(options['content_repo_path']):
-                logger.error("Could not process content from file - exiting")
-                return
-            if not process_playbooks_from_path(playbook_repo_path):
-                logger.error("Could not process playbooks from file - exiting")
-                return
+            # These don't return 'false' if it fails - check the logs for
+            # individual things loading or not loading.
+            process_content_from_path(options['content_repo_path'])
+            process_playbooks_from_path(playbook_repo_path)

--- a/api/advisor/api/tests/test_import_content_command.py
+++ b/api/advisor/api/tests/test_import_content_command.py
@@ -922,15 +922,12 @@ class CoverageTestCase(TestCase):
                 )
             # Check that it actually logs the right messages
             self.assertIn(
-                "ERROR:api.management.commands.import_content:Path "
-                "'/home/pwayper/Code/insights/advisor-backend/api/test_content' does not contain "
-                "config.yaml in main or content/ directories",
-                logs.output
+                " does not contain config.yaml in main or content/ directories",
+                logs.output[0]
             )
             self.assertIn(
-                'ERROR:api.management.commands.import_content:Could not load '
-                'content configuration - exiting',
-                logs.output
+                'Could not load content configuration - exiting',
+                logs.output[1]
             )
 
 

--- a/api/advisor/api/tests/test_import_content_command.py
+++ b/api/advisor/api/tests/test_import_content_command.py
@@ -15,7 +15,6 @@
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
 import datetime
-import functools
 from os import remove, rename
 from os.path import basename, exists, join
 import random

--- a/api/test_content/content/fixture_data/test/Second_rule/metadata.yaml
+++ b/api/test_content/content/fixture_data/test/Second_rule/metadata.yaml
@@ -2,7 +2,7 @@ category: Performance
 description: Second rule, which has no node_id
 impact: Best Practice
 likelihood: 1
-node_id: ''
+node_id: null
 product_code: rhev
 publish_date: '2018-09-23 15:38:55+00:00'
 python_module: test_rules

--- a/api/test_content/content/fixture_data/test/summary.md
+++ b/api/test_content/content/fixture_data/test/summary.md
@@ -1,0 +1,1 @@
+Summary not appearing in any rule


### PR DESCRIPTION
This adds the ability of the `import_content` management command to request
rule config and content, and playbook content, from a remote URL base path.
The following URLs are tried (in order):

- (BASE_URL)config.yaml
- (BASE_URL)rule_content.yaml.gz or (BASE_URL)rule_content.yaml (in that order)
- (BASE_URL)playbook_content.yaml.gz or (BASE_URL)playbook_content.yaml (in that order)

At each stage, if all options on that line cannot be fetched (i.e. do not
return content with a status code of 200) then the content import fails (it
logs errors and exits).

The intent of this is to provide a content container that can serve the
latest rule and playbook content.  This would allow us to then deprecate and
remove the current 'content server' system where a separate container POSTs
to the API via a hidden but unauthenticated URL.

We also add some tests of corner cases in the import_content command code to 
improve our code test coverage.