### PR TITLE
chore: Increase the host_type column size

### DIFF
--- a/api/advisor/api/management/commands/inventory_replication_subscriber.py
+++ b/api/advisor/api/management/commands/inventory_replication_subscriber.py
@@ -195,7 +195,7 @@ def check_or_create_system_profile_tables():
             arch varchar(50) NULL,
             bootc_status jsonb NULL,
             dnf_modules _jsonb NULL,
-            host_type varchar(4) NULL,
+            host_type varchar(12) NULL,
             image_builder jsonb NULL,
             operating_system jsonb NULL,
             owner_id uuid NULL,


### PR DESCRIPTION
We recently merged a column size change on HBI side https://github.com/RedHatInsights/insights-host-inventory/pull/3037, so we need to replicate the change on the logical replication table.