### PR TITLE
Send data to Inventory views

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,24 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      kafka:
+        image: docker.io/confluentinc/cp-kafka
+        ports:
+          - 29092:29092
+          - 9092:9092
+        env:
+          KAFKA_ADVERTISED_LISTENERS: DOCKER://kafka:29092,LOCALHOST://localhost:9092
+          KAFKA_ALLOW_AUTO_CREATE_TOPICS: true
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+          KAFKA_BROKER_ID: 1
+          KAFKA_INTER_BROKER_LISTENER_NAME: DOCKER
+          KAFKA_LISTENERS: DOCKER://0.0.0.0:29092,LOCALHOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:29094
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: DOCKER:PLAINTEXT,LOCALHOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29094
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          CLUSTER_ID: 1234567890
 
     steps:
       - name: Checkout code
@@ -56,6 +74,27 @@ jobs:
             sleep 5
           done
           echo "PostgreSQL is up!"
+
+      - name: Create Kafka topics
+        run: |
+          podman run -it --rm --network host apache/kafka:4.2.0 \
+          /bin/sh -c '
+          /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          echo -e "Creating kafka topics"
+          for topic in platform.engine.results \
+                   platform.insights.rule-hits \
+                   platform.inventory.events \
+                   platform.inventory.host-apps \
+                   platform.insights.rule-deactivation \
+                   platform.sources.event-stream \
+                   platform.playbook-dispatcher.runs \
+                   platform.upload.announce
+          do
+            /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --if-not-exists --topic $topic --replication-factor 1 --partitions 3
+          done
+          echo -e "Successfully created the following topics:"
+          /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+          '
 
       - name: Ugly hack while Foreman upgrades to Postgres 14 or later
         run: |

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -483,6 +483,7 @@ if CLOWDER_ENABLED:
     TASKS_UPDATES_TOPIC = topic('platform.playbook-dispatcher.runs')
     TASKS_SOURCES_TOPIC = topic('platform.sources.event-stream')
     TASKS_UPLOAD_TOPIC = topic('platform.upload.announce')
+    INVENTORY_VIEW_TOPIC = topic('platform.inventory.host-apps')
 
     kafka_broker = LoadedConfig.kafka.brokers[0]
     BOOTSTRAP_SERVERS = ",".join(KafkaServers)
@@ -512,6 +513,7 @@ else:
     TASKS_UPDATES_TOPIC = os.environ.get('TASKS_UPDATES_TOPIC', 'platform.playbook-dispatcher.runs')
     TASKS_SOURCES_TOPIC = os.environ.get('TASKS_SOURCES_TOPIC', 'platform.sources.event-stream')
     TASKS_UPLOAD_TOPIC = os.environ.get('TASKS_UPLOAD_TOPIC', 'platform.upload.announce')
+    INVENTORY_VIEW_TOPIC = os.environ.get('INVENTORY_VIEW_TOPIC', 'platform.inventory.host-apps')
     BOOTSTRAP_SERVERS = os.environ.get('BOOTSTRAP_SERVERS')
     ENABLE_KAFKA_SSL = os.environ.get('ENABLE_KAFKA_SSL', '').lower() == "true"
     KAFKA_SSL_CERT = os.environ.get('KAFKA_SSL_CERT', '/opt/certs/kafka-cacert')

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -13,29 +13,25 @@ services:
       interval: 3s
       timeout: 3s
       retries: 3
-  zookeeper:
-    image: docker.io/confluentinc/cp-zookeeper
-    environment:
-      - ZOOKEEPER_CLIENT_PORT=32181
-      - ZOOKEEPER_SERVER_ID=1
   kafka:
     image: docker.io/confluentinc/cp-kafka
     hostname: kafka
     ports:
       - 29092:29092
       - 9092:9092
-    depends_on:
-      - zookeeper
     environment:
       - KAFKA_ADVERTISED_LISTENERS=DOCKER://kafka:29092,LOCALHOST://localhost:9092
       - KAFKA_ALLOW_AUTO_CREATE_TOPICS=true
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
       - KAFKA_BROKER_ID=1
       - KAFKA_INTER_BROKER_LISTENER_NAME=DOCKER
-      - KAFKA_LISTENERS=DOCKER://0.0.0.0:29092,LOCALHOST://0.0.0.0:9092
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=DOCKER:PLAINTEXT,LOCALHOST:PLAINTEXT
+      - KAFKA_LISTENERS=DOCKER://0.0.0.0:29092,LOCALHOST://0.0.0.0:9092,CONTROLLER://0.0.0.0:29094
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=DOCKER:PLAINTEXT,LOCALHOST:PLAINTEXT,CONTROLLER:PLAINTEXT
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:32181
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:29094
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - CLUSTER_ID=1234567890
   init-kafka:
     image: confluentinc/cp-kafka
     depends_on:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -50,6 +50,7 @@ services:
       for topic in platform.engine.results \
                    platform.insights.rule-hits \
                    platform.inventory.events \
+                   platform.inventory.host-apps \
                    platform.insights.rule-deactivation \
                    platform.sources.event-stream \
                    platform.playbook-dispatcher.runs \

--- a/service/inventory_view.py
+++ b/service/inventory_view.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+# Copyright 2016-2026 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+import json
+import logging
+import datetime
+
+import settings
+from confluent_kafka import Producer
+
+from project_settings.settings import INVENTORY_VIEW_TOPIC, KAFKA_SETTINGS
+
+logger = logging.getLogger(settings.APP_NAME)
+
+INVENTORY_VIEW_APPLICATION = "advisor"
+
+# Setup producer to communicate with inventory view topic
+p = None
+if INVENTORY_VIEW_TOPIC:
+    logger.debug(
+        "Creating producer for inventory view topic %s.",
+        INVENTORY_VIEW_TOPIC,
+    )
+    p = Producer(KAFKA_SETTINGS)
+else:
+    logger.warning("No inventory view topic configured, skipping inventory view events.")
+
+
+def inventory_view_delivery_report(err, msg):
+    """Called once for each message produced to indicate delivery result.
+    Triggered by poll() or flush()."""
+    if err is not None:
+        logger.error(
+            "Inventory view message delivery failed: %s",
+            err,
+        )
+    else:
+        logger.debug(
+            "Inventory view message delivered to %s [%s]",
+            msg.topic(),
+            msg.partition(),
+        )
+
+
+def send_inventory_view_event(event_data):
+    """Send an inventory view event to the INVENTORY_VIEW_TOPIC.
+
+    Args:
+        event_data: dict with the payload data.
+    """
+    if p is None or not INVENTORY_VIEW_TOPIC:
+        return
+    try:
+        headers = [
+            ("application", bytes(INVENTORY_VIEW_APPLICATION, "utf-8")),
+            ("request_id", bytes(event_data["request_id"], "utf-8")),
+        ]
+        payload = {
+            "org-id": event_data["org_id"],
+            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "hosts": [
+                {
+                    "id": event_data["host_id"],
+                    "data": {
+                            "recommendations": event_data["recommendations"],
+                            "incidents": event_data["incidents"],
+                            "critical": event_data["critical"],
+                            "important": event_data["important"],
+                            "moderate": event_data["moderate"],
+                            "low": event_data["low"],
+                    }
+                }
+            ],
+        }
+
+        payload_str = json.dumps(payload).encode("utf-8")
+        logger.debug("Sending inventory view message: %s", payload_str)
+        p.poll(0)
+        p.produce(
+            topic=INVENTORY_VIEW_TOPIC,
+            value=payload_str,
+            headers=headers,
+            callback=inventory_view_delivery_report,
+        )
+        p.flush()
+    except Exception:
+        logger.exception("Hit exception sending inventory view event.")
+
+
+_rule_risks = {1: 'low', 2: 'moderate', 3: 'important', 4: 'critical'}
+
+
+def update_inventory_view_counts(counts, rule):
+    """Update the inventory view counts for the given rule.
+
+    Args:
+        counts: dict with the counts data.
+        rule: dict with the rule data.
+    """
+    if rule.get('has_incident'):
+        counts['incidents'] += 1
+
+    severity = _rule_risks.get(rule.get('total_risk'))
+    if severity:
+        counts[severity] += 1

--- a/service/inventory_view.py
+++ b/service/inventory_view.py
@@ -71,19 +71,12 @@ def send_inventory_view_event(event_data):
             ("request_id", bytes(event_data["request_id"], "utf-8")),
         ]
         payload = {
-            "org-id": event_data["org_id"],
+            "org_id": event_data["org_id"],
             "timestamp": datetime.datetime.utcnow().isoformat(),
             "hosts": [
                 {
                     "id": event_data["host_id"],
-                    "data": {
-                            "recommendations": event_data["recommendations"],
-                            "incidents": event_data["incidents"],
-                            "critical": event_data["critical"],
-                            "important": event_data["important"],
-                            "moderate": event_data["moderate"],
-                            "low": event_data["low"],
-                    }
+                    "data": event_data["data"],
                 }
             ],
         }

--- a/service/inventory_view.py
+++ b/service/inventory_view.py
@@ -95,7 +95,7 @@ def send_inventory_view_event(event_data):
         logger.exception("Hit exception sending inventory view event.")
 
 
-_rule_risks = {1: 'low', 2: 'moderate', 3: 'important', 4: 'critical'}
+_rule_risks = [None, 'low', 'moderate', 'important', 'critical']
 
 
 def update_inventory_view_counts(counts, rule):
@@ -108,6 +108,6 @@ def update_inventory_view_counts(counts, rule):
     if rule.get('has_incident'):
         counts['incidents'] += 1
 
-    severity = _rule_risks.get(rule.get('total_risk'))
+    severity = _rule_risks[rule.get('total_risk')]
     if severity:
         counts[severity] += 1

--- a/service/service.py
+++ b/service/service.py
@@ -25,6 +25,7 @@ import signal
 import traceback
 import logging
 from bounded_executor import BoundedExecutor
+from collections import defaultdict
 
 # Import app libraries
 from confluent_kafka import Consumer, KafkaError
@@ -32,6 +33,7 @@ import settings
 import advisor_logging
 import thread_storage
 import payload_tracker
+import inventory_view
 import prometheus
 import reports as report_hooks
 import utils
@@ -398,6 +400,7 @@ def create_db_reports(
 
             now = timezone.now()
             db_report_rules = [dbr['rule_id'] for dbr in db_report_values]
+            inventory_view_counts = defaultdict(int)
             for report in reports:
                 # Get rule object for report
                 if report['rule_id'] in report_rules_map:
@@ -423,6 +426,8 @@ def create_db_reports(
                         existing_report_objs.append(report_obj)
                     else:
                         new_report_objs.append(report_obj)
+
+                    inventory_view.update_inventory_view_counts(inventory_view_counts, rule)
 
                     logger.debug("%s current report object rule_id: %s, "
                                  "inventory_id: %s, account: %s, org_id: %s",
@@ -496,6 +501,24 @@ def create_db_reports(
             thread_storage.set_value('db_elapsed', db_finished - db_started)
             payload_msg = f'Successfully logged {num_report_objs} reports.'
             payload_tracker.payload_status('success', payload_msg)
+            # Send system data back to inventory views
+            try:
+                inventory_view.send_inventory_view_event({
+                    'request_id': thread_storage.get_value('request_id') or '',
+                    'org_id': org_id,
+                    'host_id': str(inventory_uuid),
+                    'recommendations': num_report_objs,
+                    'incidents': inventory_view_counts.get('incidents', 0),
+                    'critical': inventory_view_counts.get('critical', 0),
+                    'important': inventory_view_counts.get('important', 0),
+                    'moderate': inventory_view_counts.get('moderate', 0),
+                    'low': inventory_view_counts.get('low', 0),
+                })
+            except Exception:
+                logger.exception(
+                    "Error sending inventory view event",
+                    extra={'inventory_id': inventory_uuid, 'account': account, 'org_id': org_id},
+                )
             logger.info(
                 f"Logged {num_report_objs} report{'' if num_report_objs == 1 else 's'}"
                 f" for system UUID (inventory ID) {inventory_uuid} in account {account} and org_id {org_id}",

--- a/service/service.py
+++ b/service/service.py
@@ -502,25 +502,19 @@ def create_db_reports(
             payload_msg = f'Successfully logged {num_report_objs} reports.'
             payload_tracker.payload_status('success', payload_msg)
             # Send system data back to inventory views
-            try:
-                inventory_view.send_inventory_view_event({
-                    'request_id': thread_storage.get_value('request_id') or '',
-                    'org_id': org_id,
-                    'host_id': str(inventory_uuid),
-                    'data': {
-                        'recommendations': num_report_objs,
-                        'incidents': inventory_view_counts['incidents'],
-                        'critical': inventory_view_counts['critical'],
-                        'important': inventory_view_counts['important'],
-                        'moderate': inventory_view_counts['moderate'],
-                        'low': inventory_view_counts['low'],
-                    }
-                })
-            except Exception:
-                logger.exception(
-                    "Error sending inventory view event",
-                    extra={'inventory_id': inventory_uuid, 'account': account, 'org_id': org_id},
-                )
+            inventory_view.send_inventory_view_event({
+                'request_id': thread_storage.get_value('request_id') or '',
+                'org_id': org_id,
+                'host_id': str(inventory_uuid),
+                'data': {
+                    'recommendations': num_report_objs,
+                    'incidents': inventory_view_counts['incidents'],
+                    'critical': inventory_view_counts['critical'],
+                    'important': inventory_view_counts['important'],
+                    'moderate': inventory_view_counts['moderate'],
+                    'low': inventory_view_counts['low'],
+                }
+            })
             logger.info(
                 f"Logged {num_report_objs} report{'' if num_report_objs == 1 else 's'}"
                 f" for system UUID (inventory ID) {inventory_uuid} in account {account} and org_id {org_id}",

--- a/service/service.py
+++ b/service/service.py
@@ -507,12 +507,14 @@ def create_db_reports(
                     'request_id': thread_storage.get_value('request_id') or '',
                     'org_id': org_id,
                     'host_id': str(inventory_uuid),
-                    'recommendations': num_report_objs,
-                    'incidents': inventory_view_counts.get('incidents', 0),
-                    'critical': inventory_view_counts.get('critical', 0),
-                    'important': inventory_view_counts.get('important', 0),
-                    'moderate': inventory_view_counts.get('moderate', 0),
-                    'low': inventory_view_counts.get('low', 0),
+                    'data': {
+                        'recommendations': num_report_objs,
+                        'incidents': inventory_view_counts['incidents'],
+                        'critical': inventory_view_counts['critical'],
+                        'important': inventory_view_counts['important'],
+                        'moderate': inventory_view_counts['moderate'],
+                        'low': inventory_view_counts['low'],
+                    }
                 })
             except Exception:
                 logger.exception(


### PR DESCRIPTION
## Summary by Sourcery

Send Advisor host data and aggregated risk metrics to the Inventory View service via Kafka when reports are processed.

New Features:
- Publish inventory view events with per-host recommendation, incident, and severity counts to a dedicated Kafka topic after processing reports.
- Introduce a dedicated Kafka producer module for Inventory View events with configurable topic and broker settings.

Enhancements:
- Aggregate incident and severity counts per host during report processing to support Inventory View metrics.
- Update local and CI Kafka configurations to use KIP-500-style Kafka without ZooKeeper and to provision the Inventory View topic.

CI:
- Extend CI workflow to start a Kafka container and pre-create required platform topics, including the Inventory View topic.

Deployment:
- Adjust podman-compose Kafka service to run in controller/broker mode without ZooKeeper and to include the Inventory View topic in initialization.