### PR TITLE
fix(Kessel): Fix permission check

### DIFF
--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -518,33 +518,17 @@ def get_workspace_id(
 
 
 def _kessel_org_workspace_ids_for_permission_check(
-    request: Request, subject: kessel.SubjectRef
+    subject: kessel.SubjectRef,
 ) -> tuple[list[str], float]:
     """
     Workspace IDs to try for ORG-scoped Kessel checks.
-
-    Always includes the org default workspace (RBAC v2). Also includes every
-    workspace the subject has inventory_host_view on, matching the graph
-    where advisor_recommendation_results_read intersects inventory_host_view
-    (see schema rbac/platform).
     """
-    elapsed = 0.0
-    seen: set[str] = set()
-    ordered: list[str] = []
-    default_id, t = get_workspace_id(request)
-    elapsed += t
-    if default_id:
-        seen.add(default_id)
-        ordered.append(default_id)
-    inv_workspaces, t2 = kessel.client.host_groups_for(subject)
-    elapsed += t2
+    inv_workspaces, elapsed = kessel.client.host_groups_for(subject)
     if isinstance(inv_workspaces, list):
-        for wid in inv_workspaces:
-            w = str(wid)
-            if w not in seen:
-                seen.add(w)
-                ordered.append(w)
-    return ordered, elapsed
+        workspace_ids = [str(wid) for wid in inv_workspaces]
+    else:
+        workspace_ids = []
+    return workspace_ids, elapsed
 
 
 def has_kessel_permission(
@@ -590,7 +574,7 @@ def has_kessel_permission(
                 and permission.method == 'read'
             ):
                 workspace_ids, extra_elapsed = _kessel_org_workspace_ids_for_permission_check(
-                    request, subject
+                    subject
                 )
                 elapsed += extra_elapsed
                 if not workspace_ids:

--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -517,6 +517,36 @@ def get_workspace_id(
     return workspace_id, elapsed
 
 
+def _kessel_org_workspace_ids_for_permission_check(
+    request: Request, subject: kessel.SubjectRef
+) -> tuple[list[str], float]:
+    """
+    Workspace IDs to try for ORG-scoped Kessel checks.
+
+    Always includes the org default workspace (RBAC v2). Also includes every
+    workspace the subject has inventory_host_view on, matching the graph
+    where advisor_recommendation_results_read intersects inventory_host_view
+    (see schema rbac/platform).
+    """
+    elapsed = 0.0
+    seen: set[str] = set()
+    ordered: list[str] = []
+    default_id, t = get_workspace_id(request)
+    elapsed += t
+    if default_id:
+        seen.add(default_id)
+        ordered.append(default_id)
+    inv_workspaces, t2 = kessel.client.host_groups_for(subject)
+    elapsed += t2
+    if isinstance(inv_workspaces, list):
+        for wid in inv_workspaces:
+            w = str(wid)
+            if w not in seen:
+                seen.add(w)
+                ordered.append(w)
+    return ordered, elapsed
+
+
 def has_kessel_permission(
     scope: "ResourceScope", permission: RBACPermission, request: Request,
     host_id: str | None = None
@@ -550,22 +580,55 @@ def has_kessel_permission(
     try:
         logger.debug("Checking %s has %s in %s...", identity, permission, scope)
         if scope == ResourceScope.ORG:
-            # We actually translate this into the default workspace of that org.
-            workspace_id, elapsed = get_workspace_id(request)
-            if not workspace_id:
-                # Log created by exception catch below
-                raise ValueError("No workspace found for org")
-            logger.debug(
-                "KESSEL: checking access for org %s workspace %s",
-                identity['org_id'], workspace_id
-            )
-            # Kessel check requires a 'user_id' in the identity's user data.
-            # This is checked in InsightsRBACPermission, the caller.
-            result, elapsed = kessel.client.check(
-                kessel.Workspace(workspace_id).to_ref(),
-                permission.as_kessel_permission(),
-                identity_to_subject(identity)
-            )
+            subject = identity_to_subject(identity)
+            relation = permission.as_kessel_permission()
+            # recommendation-results read is workspace- and host-scoped in Kessel
+            # (binding & inventory_host_view).
+            if (
+                permission.app == 'advisor'
+                and permission.resource == 'recommendation-results'
+                and permission.method == 'read'
+            ):
+                workspace_ids, extra_elapsed = _kessel_org_workspace_ids_for_permission_check(
+                    request, subject
+                )
+                elapsed += extra_elapsed
+                if not workspace_ids:
+                    raise ValueError("No workspace found for org")
+                logger.debug(
+                    "KESSEL: checking %s for org %s on workspaces %s",
+                    relation, identity['org_id'], workspace_ids,
+                )
+                result = False
+                for wid in workspace_ids:
+                    ok, check_elapsed = kessel.client.check(
+                        kessel.Workspace(wid).to_ref(),
+                        relation,
+                        subject,
+                    )
+                    elapsed += check_elapsed
+                    if ok:
+                        result = True
+                        break
+            else:
+                # We actually translate this into the default workspace of that org.
+                workspace_id, w_elapsed = get_workspace_id(request)
+                elapsed += w_elapsed
+                if not workspace_id:
+                    # Log created by exception catch below
+                    raise ValueError("No workspace found for org")
+                logger.debug(
+                    "KESSEL: checking access for org %s workspace %s",
+                    identity['org_id'], workspace_id
+                )
+                # Kessel check requires a 'user_id' in the identity's user data.
+                # This is checked in InsightsRBACPermission, the caller.
+                result, check_elapsed = kessel.client.check(
+                    kessel.Workspace(workspace_id).to_ref(),
+                    relation,
+                    subject,
+                )
+                elapsed += check_elapsed
         elif scope == ResourceScope.WORKSPACE:
             logger.debug("KESSEL: checking which workspaces this user has access to")
             # Lookup all the workspaces in which the permission is granted.

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -15,6 +15,7 @@
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
 import responses
+from kessel.inventory.v1beta2 import check_request_pb2
 
 from django.http import HttpRequest
 from django.test import TestCase, override_settings
@@ -22,6 +23,7 @@ from django.urls import reverse
 
 from rest_framework.exceptions import AuthenticationFailed
 
+from api import kessel as kessel_mod
 from api.kessel import add_kessel_response
 from api.models import InventoryHost
 from api.permissions import (
@@ -759,6 +761,44 @@ class TestInsightsRBACPermissionKessel(TestCase):
         perm = RBACPermission('advisor:*:*')
         with self.assertRaises(ValueError):
             _ = has_kessel_permission(ResourceScope.ORG, perm, request)
+
+    @override_settings(RBAC_ENABLED=True, KESSEL_ENABLED=True, RBAC_URL=TEST_RBAC_URL)
+    @add_kessel_response(
+        permission_checks=[
+            (
+                check_request_pb2.CheckRequest(
+                    object=constants.kessel_std_org_obj,
+                    relation="advisor_recommendation_results_view",
+                    subject=constants.kessel_std_user_obj,
+                ),
+                kessel_mod.DENIED,
+            ),
+            (
+                check_request_pb2.CheckRequest(
+                    object=kessel_mod.Workspace(constants.host_group_1_id).to_ref().as_pb2(),
+                    relation="advisor_recommendation_results_view",
+                    subject=constants.kessel_std_user_obj,
+                ),
+                kessel_mod.ALLOWED,
+            ),
+        ],
+        resource_lookups=constants.kessel_user_in_workspace_host_group_1,
+    )
+    @responses.activate
+    def test_kessel_org_recommendation_results_read_tries_inventory_workspaces(self):
+        """
+        ORG-scoped recommendation-results:read must not use only the default
+        workspace; users may have Kessel access on other workspaces where they
+        have inventory_host_view.
+        """
+        responses.add(
+            responses.GET, TEST_RBAC_V2_WKSPC,
+            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+        )
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        perm = RBACPermission('advisor:recommendation-results:read')
+        result, _elapsed = has_kessel_permission(ResourceScope.ORG, perm, request)
+        self.assertTrue(result)
 
     @override_settings(RBAC_ENABLED=True, KESSEL_ENABLED=True, RBAC_URL=TEST_RBAC_URL)
     @add_kessel_response(


### PR DESCRIPTION
Based on [RBACv2 schema ](https://github.com/RedHatInsights/rbac-config/blob/master/configs/stage/schemas/src/advisor.ksl#L17-L19) we need to check `advisor_recommendation_results_view` permission in each workspace, not only in default one. Otherwise we can incorrectly get permission denied from backend.


## Summary by Sourcery

Update Kessel org-scope permission checks for advisor recommendation results to consider multiple workspaces inferred from inventory access instead of only the org default workspace.

Bug Fixes:
- Ensure ORG-scoped advisor recommendation-results:read permissions succeed when a user has Kessel access via non-default workspaces associated with their inventory_host_view access.

Tests:
- Add a Kessel auth test verifying ORG-scoped recommendation-results:read checks fall back to inventory workspaces when the default workspace is denied.

## Summary by Sourcery

Adjust Kessel org-scoped permission handling for advisor recommendation results to consider all relevant workspaces instead of only the default workspace.

Bug Fixes:
- Ensure org-scoped advisor recommendation-results:read checks succeed when the user has Kessel access via non-default workspaces inferred from inventory_host_view access.
- Avoid org-level permission failures when no access is granted on the default workspace but valid access exists on other workspaces.

Tests:
- Add a Kessel auth test verifying org-scoped recommendation-results:read checks fall back to inventory workspaces when the default workspace is denied.