### PR TITLE
Rhineng 25376 -- cherry pick "advisor-backend fix for MultipleObjectsReturned to active branches" into foreman 3.16

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -469,6 +469,15 @@ def create_db_reports(
                     report_hooks.trigger_report_hooks(
                         inventory_host, webhook_report_rule_objs, db_report_values
                     )
+                except db.InventoryHost.DoesNotExist:
+                    logger.warning(
+                        "InventoryHost not found for host", extra={
+                            'inventory_id': inventory_uuid, 'account': account, 'org_id': org_id
+                        }
+                    )
+                    # Otherwise, we don't need to report an error to payload
+                    # tracker here, as we have actually done everything else
+                    # that we needed to do for this upload.
                 except:
                     logger.exception("Error sending Report Hooks",
                                      extra={'inventory_id': inventory_uuid, 'account': account, 'org_id': org_id})

--- a/service/service.py
+++ b/service/service.py
@@ -464,7 +464,7 @@ def create_db_reports(
                 # Catch errors and do not fail entire upload on this
                 try:
                     inventory_host = db.InventoryHost.objects.get(
-                        inventory_id=host_obj.inventory_id, org_id=org_id
+                        id=host_obj.inventory_id, org_id=org_id
                     )
                     report_hooks.trigger_report_hooks(
                         inventory_host, webhook_report_rule_objs, db_report_values

--- a/service/service.py
+++ b/service/service.py
@@ -463,8 +463,11 @@ def create_db_reports(
                 # Fetch some of these fields from the InventoryHost object
                 # Catch errors and do not fail entire upload on this
                 try:
+                    inventory_host = db.InventoryHost.objects.get(
+                        inventory_id=host_obj.inventory_id, org_id=org_id
+                    )
                     report_hooks.trigger_report_hooks(
-                        host_obj.inventory, webhook_report_rule_objs, db_report_values
+                        inventory_host, webhook_report_rule_objs, db_report_values
                     )
                 except:
                     logger.exception("Error sending Report Hooks",

--- a/service/tests/sample_rule_hits.json
+++ b/service/tests/sample_rule_hits.json
@@ -4,7 +4,7 @@
  "host_role": "Cluster",
  "inventory_id": "2db7adeb-e3e8-4d40-bf68-bd00064e252b",
  "account": "123456",
- "org_id": "1234567",
+ "org_id": "9876543",
  "hits": [
    {
      "rule_id": "aiops_rule_1",


### PR DESCRIPTION
For [RHINENG-25376](https://redhat.atlassian.net/browse/RHINENG-25376). Cherry-pick the fix for RHINENG-24838.

## Summary by Sourcery

Handle missing InventoryHost records when triggering report hooks during host updates to avoid MultipleObjectsReturned errors and prevent upload failures.

Bug Fixes:
- Resolve MultipleObjectsReturned issues by explicitly fetching a single InventoryHost by id and org_id before invoking report hooks.
- Avoid upload failures by safely handling missing InventoryHost records and logging a warning instead of raising an error.

[RHINENG-25376]: https://redhat.atlassian.net/browse/RHINENG-25376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ