### PR TITLE
Use info level logging for kessel again, temporarily

### DIFF
--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -221,7 +221,7 @@ def set_rbac_success(request: Request, message: str) -> None:
     permissions check.
     """
     setattr(request, 'rbac_message', message)
-    logger.debug(message)
+    logger.info(message)
 
 
 def make_rbac_request(rbac_url: str, request: Request) -> tuple[Response | None, float]:
@@ -427,14 +427,14 @@ def has_rbac_permission(request: Request, permission: str = 'advisor:*:*') -> tu
             # Always OK on exact match
             if rbac_permission == request_permission:
                 # Log and return exact match
-                logger.debug(f"RBAC permission '{rbac_permission}' exactly matched sought permission")
+                logger.info(f"RBAC permission '{rbac_permission}' exactly matched sought permission")
                 setattr(request._request, 'rbac_matched_permission', rbac_permission)
                 setattr(request._request, 'rbac_match_type', 'exact')
                 return (True, elapsed)
 
             if request_permission in rbac_permission:
                 # Log and return inexact match
-                logger.debug(f"RBAC permission {rbac_permission} pattern matched sought permission {request_permission}")
+                logger.info(f"RBAC permission {rbac_permission} pattern matched sought permission {request_permission}")
                 setattr(request._request, 'rbac_matched_permission', rbac_permission)
                 setattr(request._request, 'rbac_match_type', 'contains')
                 return (True, elapsed)
@@ -548,14 +548,15 @@ def has_kessel_permission(
     logger.debug("KESSEL debug: identity = %s", repr(identity))
     logger.debug("KESSEL debug: permission = %s", repr(permission))
     try:
-        logger.debug("Checking %s has %s in %s...", identity, permission, scope)
+        logger.info("KESSEL: Checking identity %s has permission %s in scope %s...",
+                    repr(identity), repr(permission), scope)
         if scope == ResourceScope.ORG:
             # We actually translate this into the default workspace of that org.
             workspace_id, elapsed = get_workspace_id(request)
             if not workspace_id:
                 # Log created by exception catch below
                 raise ValueError("No workspace found for org")
-            logger.debug(
+            logger.info(
                 "KESSEL: checking access for org %s workspace %s",
                 identity['org_id'], workspace_id
             )
@@ -567,7 +568,7 @@ def has_kessel_permission(
                 identity_to_subject(identity)
             )
         elif scope == ResourceScope.WORKSPACE:
-            logger.debug("KESSEL: checking which workspaces this user has access to")
+            logger.info("KESSEL: checking which workspaces this user has access to")
             # Lookup all the workspaces in which the permission is granted.
             result, elapsed = kessel.client.host_groups_for(
                 identity_to_subject(identity)
@@ -578,7 +579,7 @@ def has_kessel_permission(
             if host_id is None:
                 raise ValueError("Host scope requested but host_id not provided")
 
-            logger.debug("KESSEL: checking access to host %s", host_id)
+            logger.info("KESSEL: checking access to host %s", host_id)
             result, elapsed = kessel.client.check(
                 kessel.Host(str(host_id)).to_ref(),
                 permission.as_kessel_permission(),
@@ -922,7 +923,6 @@ class InsightsRBACPermission(BasePermission):
     app = 'advisor'
 
     def has_permission(self, request: Request, view) -> bool:
-        logger.debug("Started InsightsRBACPermission.has_permission")
         # Returns true or false
 
         # Allow views to specify a specific resource name via its

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -788,15 +788,11 @@ class TestInsightsRBACPermissionKessel(TestCase):
             # successful message in rbac_message and logs
             self.assertEqual(
                 logs.output[0],
-                'DEBUG:advisor-log:Started InsightsRBACPermission.has_permission'
+                'INFO:advisor-log:InsightsRBACPermission has_permission() check starting'
             )
             self.assertEqual(
                 logs.output[1],
-                'DEBUG:advisor-log:InsightsRBACPermission has_permission() check starting'
-            )
-            self.assertEqual(
-                logs.output[2],
-                'DEBUG:advisor-log:KESSEL: ResourceScope is HOST - defer to has_object_permission'
+                'INFO:advisor-log:KESSEL: ResourceScope is HOST - defer to has_object_permission'
             )
             self.assertEqual(
                 request.rbac_message,
@@ -823,10 +819,14 @@ class TestInsightsRBACPermissionKessel(TestCase):
             "Permission scope is 'Host' but object has no 'id' attribute"
         )
         # Finally we actually get to do a has_kessel_permission check
-        with add_kessel_response(
-            permission_checks=constants.kessel_allow_host_01_read
-        ):
-            self.assertTrue(irbp.has_object_permission(request, view, host))
+        with self.assertLogs(logger='advisor-log') as logs:
+            with add_kessel_response(
+                permission_checks=constants.kessel_allow_host_01_read
+            ):
+                self.assertTrue(irbp.has_object_permission(request, view, host))
+                self.assertTrue(logs.output[0].startswith('INFO:advisor-log:KESSEL: Checking identity'))
+                self.assertTrue(logs.output[1].startswith('INFO:advisor-log:KESSEL: checking access to host'))
+                self.assertTrue(logs.output[3].startswith('INFO:advisor-log:KESSEL: returned True'))
 
 
 class TestTurnpikeAuthentication(TestCase):


### PR DESCRIPTION
We are still fine-tuning and testing kessel in Advisor, so having more logs again would probably be helpful in the meantime.

## Summary by Sourcery

Increase Kessel- and RBAC-related logging visibility and align tests with the new log messages.

Enhancements:
- Raise RBAC and Kessel permission check logging from debug to info to make permission evaluation more visible in production logs.

Tests:
- Update Kessel ResourceScope host permission tests to assert the new INFO-level log messages and additional Kessel logging emitted during host permission checks.