### PR TITLE
Sync foreman 3.18 with main

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ pytest-server-fixtures = {extras = ["http"],version = "*"}
 pytest-django = "*"
 unittest-xml-reporting = "*"
 django-stubs = "*"
+mypy = "*"
 
 [packages]
 app-common-python = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6aaee585dd65eb7b4377b0df7b9aae829574ae66d60fbf895f12a25a7c979b3c"
+            "sha256": "09d54e69bec766e673cb5e146d7784e8834e2a7d6fcd17e6382c1eabef5df5cc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "apscheduler": {
             "hashes": [
-                "sha256:0db77af6400c84d1747fe98a04b8b58f0080c77d11d338c4f507a9752880f221",
-                "sha256:6162cb5683cb09923654fa9bdd3130c4be4bfda6ad8990971c9597ecd52965d2"
+                "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41",
+                "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.11.1"
+            "version": "==3.11.2"
         },
         "asgiref": {
             "hashes": [
@@ -50,20 +50,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:8ed6ad670a5a2d7f66c1b0d3362791b48392c7a08f78479f5d8ab319a4d9118f",
-                "sha256:c47a2f40df933e3861fc66fd8d6b87ee36d4361663a7e7ba39a87f5a78b2eae1"
+                "sha256:4251bbac90e4a190680439973d9e9ed851e50292c10cd063c8bf0c365410ffe1",
+                "sha256:edbfbfbadd419e65888166dd044786d4b731cf60abeb2301b73e775e154d7c5e"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.24"
+            "version": "==1.42.35"
         },
         "botocore": {
             "hashes": [
-                "sha256:8fca9781d7c84f7ad070fceffaff7179c4aa7a5ffb27b43df9d1d957801e0a8d",
-                "sha256:be8d1bea64fb91eea08254a1e5fea057e4428d08e61f4e11083a02cafc1f8cc6"
+                "sha256:40a6e0f16afe9e5d42e956f0b6d909869793fadb21780e409063601fc3d094b8",
+                "sha256:b89f527987691abbd1374c4116cc2711471ce48e6da502db17e92b17b2af8d47"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.24"
+            "version": "==1.42.35"
         },
         "certifi": {
             "hashes": [
@@ -72,6 +72,96 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2026.1.4"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb",
+                "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b",
+                "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f",
+                "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9",
+                "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44",
+                "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2",
+                "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c",
+                "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75",
+                "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65",
+                "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e",
+                "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a",
+                "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e",
+                "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25",
+                "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a",
+                "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe",
+                "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b",
+                "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91",
+                "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592",
+                "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187",
+                "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c",
+                "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1",
+                "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94",
+                "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba",
+                "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb",
+                "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165",
+                "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+                "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca",
+                "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c",
+                "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6",
+                "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c",
+                "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0",
+                "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743",
+                "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63",
+                "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5",
+                "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5",
+                "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4",
+                "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d",
+                "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b",
+                "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93",
+                "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205",
+                "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27",
+                "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512",
+                "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d",
+                "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c",
+                "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037",
+                "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26",
+                "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322",
+                "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb",
+                "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c",
+                "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8",
+                "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4",
+                "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414",
+                "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9",
+                "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664",
+                "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9",
+                "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775",
+                "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739",
+                "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc",
+                "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062",
+                "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe",
+                "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9",
+                "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92",
+                "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5",
+                "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13",
+                "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d",
+                "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f",
+                "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495",
+                "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6",
+                "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c",
+                "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef",
+                "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5",
+                "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18",
+                "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad",
+                "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3",
+                "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7",
+                "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5",
+                "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534",
+                "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49",
+                "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2",
+                "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5",
+                "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453",
+                "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.0.0"
         },
         "charset-normalizer": {
             "hashes": [
@@ -234,6 +324,66 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.10.1"
         },
+        "cryptography": {
+            "hashes": [
+                "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217",
+                "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d",
+                "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc",
+                "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71",
+                "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971",
+                "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a",
+                "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926",
+                "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc",
+                "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d",
+                "sha256:191bb60a7be5e6f54e30ba16fdfae78ad3a342a0599eb4193ba88e3f3d6e185b",
+                "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20",
+                "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044",
+                "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3",
+                "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715",
+                "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4",
+                "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506",
+                "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f",
+                "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0",
+                "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683",
+                "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3",
+                "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21",
+                "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91",
+                "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c",
+                "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8",
+                "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df",
+                "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c",
+                "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb",
+                "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7",
+                "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04",
+                "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db",
+                "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459",
+                "sha256:7ce938a99998ed3c8aa7e7272dca1a610401ede816d36d0693907d863b10d9ea",
+                "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914",
+                "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717",
+                "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9",
+                "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac",
+                "sha256:a23582810fedb8c0bc47524558fb6c56aac3fc252cb306072fd2815da2a47c32",
+                "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec",
+                "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1",
+                "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb",
+                "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac",
+                "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665",
+                "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e",
+                "sha256:c70cc23f12726be8f8bc72e41d5065d77e4515efae3690326764ea1b07845cfb",
+                "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5",
+                "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936",
+                "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de",
+                "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372",
+                "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54",
+                "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422",
+                "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849",
+                "sha256:e7aec276d68421f9574040c26e2a7c3771060bc0cff408bae1dcb19d3ab1e63c",
+                "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963",
+                "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018"
+            ],
+            "markers": "python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'",
+            "version": "==46.0.3"
+        },
         "django": {
             "hashes": [
                 "sha256:74df100784c288c50a2b5cad59631d71214f40f72051d5af3fdf220c20bdbbbe",
@@ -313,11 +463,11 @@
         },
         "google.auth": {
             "hashes": [
-                "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da",
-                "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498"
+                "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f",
+                "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.47.0"
+            "version": "==2.48.0"
         },
         "grpcio": {
             "hashes": [
@@ -388,12 +538,12 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d",
-                "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"
+                "sha256:757f6b621fc4f7581a90600b2cd9df593461f06a41d7259cb9b94499dc4095a8",
+                "sha256:f006d110e5cb3102859b4f5cd48335dbd9cc28d0d27cd24ddbdafa6c60929408"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==23.0.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==24.1.1"
         },
         "idna": {
             "hashes": [
@@ -406,11 +556,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000",
-                "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"
+                "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb",
+                "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==8.7.0"
+            "version": "==8.7.1"
         },
         "inflection": {
             "hashes": [
@@ -422,11 +572,11 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
-                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+                "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d",
+                "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.0.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.1.0"
         },
         "jsonschema": {
             "hashes": [
@@ -521,12 +671,12 @@
         },
         "markdown": {
             "hashes": [
-                "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e",
-                "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c"
+                "sha256:1c19c10bd5c14ac948c53d0d762a04e2fa35a6d58a6b7b1e6bfcbe6fefc0001a",
+                "sha256:867d788939fe33e4b736426f5b9f651ad0c0ae0ecf89df0ca5d1176c70812fe3"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==3.10"
+            "version": "==3.10.1"
         },
         "mmh3": {
             "hashes": [
@@ -683,11 +833,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
-                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
+                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==25.0"
+            "version": "==26.0"
         },
         "pathable": {
             "hashes": [
@@ -707,28 +857,28 @@
         },
         "prometheus-client": {
             "hashes": [
-                "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce",
-                "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99"
+                "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055",
+                "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==0.23.1"
+            "version": "==0.24.1"
         },
         "protobuf": {
             "hashes": [
-                "sha256:1f8017c48c07ec5859106533b682260ba3d7c5567b1ca1f24297ce03384d1b4f",
-                "sha256:2981c58f582f44b6b13173e12bb8656711189c2a70250845f264b877f00b1913",
-                "sha256:56dc370c91fbb8ac85bc13582c9e373569668a290aa2e66a590c2a0d35ddb9e4",
-                "sha256:7109dcc38a680d033ffb8bf896727423528db9163be1b6a02d6a49606dcadbfe",
-                "sha256:7636aad9bb01768870266de5dc009de2d1b936771b38a793f73cbbf279c91c5c",
-                "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d",
-                "sha256:8cd7640aee0b7828b6d03ae518b5b4806fdfc1afe8de82f79c3454f8aef29872",
-                "sha256:b5d3b5625192214066d99b2b605f5783483575656784de223f00a8d00754fc0e",
-                "sha256:d9b19771ca75935b3a4422957bc518b0cecb978b31d1dd12037b088f6bcc0e43",
-                "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4"
+                "sha256:0f12ddbf96912690c3582f9dffb55530ef32015ad8e678cd494312bd78314c4f",
+                "sha256:1fe3730068fcf2e595816a6c34fe66eeedd37d51d0400b72fabc848811fdc1bc",
+                "sha256:2fe67f6c014c84f655ee06f6f66213f9254b3a8b6bda6cda0ccd4232c73c06f0",
+                "sha256:3df850c2f8db9934de4cf8f9152f8dc2558f49f298f37f90c517e8e5c84c30e9",
+                "sha256:757c978f82e74d75cba88eddec479df9b99a42b31193313b75e492c06a51764e",
+                "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc",
+                "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d",
+                "sha256:955478a89559fa4568f5a81dce77260eabc5c686f9e8366219ebd30debf06aa6",
+                "sha256:c7c64f259c618f0bef7bee042075e390debbf9682334be2b67408ec7c1c09ee6",
+                "sha256:dc2e61bca3b10470c1912d166fe0af67bfc20eb55971dcef8dfa48ce14f0ed91"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==6.33.2"
+            "version": "==6.33.4"
         },
         "psycopg2": {
             "hashes": [
@@ -746,11 +896,11 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629",
-                "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"
+                "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf",
+                "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.6.1"
+            "version": "==0.6.2"
         },
         "pyasn1-modules": {
             "hashes": [
@@ -759,6 +909,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.4.2"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+                "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==3.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -1034,12 +1192,12 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922",
-                "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
+                "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70",
+                "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==80.9.0"
+            "version": "==80.10.2"
         },
         "six": {
             "hashes": [
@@ -1140,102 +1298,102 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:004cdcea3457c0ea3233622cd3464c1e32ebba9b41578421097402bee6461b63",
-                "sha256:0542ddf6107adbd2592f29da9f59f5d9cff7947b5bb4f734805085c327dcffaa",
-                "sha256:05fd3fb6edff0c98874d752013588836f458261e5eba587afe4c547bba544afd",
-                "sha256:074e6a5cd38e06671580b4d872c1a67955d4e69639e4b04e87fc03b494c1f060",
-                "sha256:07bc7745c945a6d95676953e86ba7cebb9f11de7773951c387f4c07dc76d03f5",
-                "sha256:08c0bcf932e47795c49f0406054824b9d45671362dfc4269e0bc6e4bff010704",
-                "sha256:097acc18bedf2c6e3144eaf09b5f6034926c3c9bb9e10574ffd0942717232507",
-                "sha256:0c986537abca9b064510f3fd104ba33e98d3036608c7f2f5537f869bc10e1ee5",
-                "sha256:0dba4da36730e384669e05b765a2c49f39514dd3012fcc0398dd66fba8d746d5",
-                "sha256:0e920567f8c3a3ce68ae5a42cf7c2dc4bb6cc389f18bff2235dd8c03fa405de5",
-                "sha256:0f59387f5e6edbbffec2281affb71cdc85e0776c1745150a3ab9b6c1d016106b",
-                "sha256:12d821de7408292530b0d241468b698bce18dd12ecaf45316149f53877885f8c",
-                "sha256:13b2066303a1c1833c654d2af0455bb009b6e1727b3883c9964bc5c2f643c1d0",
-                "sha256:1410bac9e98afd9623f53876fae7d8a5db9f5a0ac1c9e7c5188463cb4b3212e2",
-                "sha256:1451464fd855d9bd000c19b71bb7dafea9ab815741fb0bd9e813d9b671462d6f",
-                "sha256:149eccc85d48c8f06547534068c41d69a1a35322deaa4d69ba1561e2e9127e75",
-                "sha256:1e33d0bebf895c7a0905fcfaff2b07ab900885fc78bba2a12291a2cfbab014cc",
-                "sha256:200bb89fd2a8a07780eafcdff6463104dec459f3c838d980455cfa84f5e5e6e1",
-                "sha256:2376e8a9c889016f25472c452389e98bc6e54a19570b107e27cde9d47f387b64",
-                "sha256:28c5251b3ab1d23e66f1130ca0c419747edfbcb4690de19467cd616861507af7",
-                "sha256:2ec27a7a991d229213c8070d31e3ecf44d005d96a9edc30c78eaeafaa421c001",
-                "sha256:305716afb19133762e8cf62745c46c4853ad6f9eeba54a593e373289e24ea237",
-                "sha256:31663572f20bf3406d7ac00d6981c7bbbcec302539d26b5ac596ca499664de31",
-                "sha256:3224c7baf34e923ffc78cb45e793925539d640d42c96646db62dbd61bbcfa131",
-                "sha256:351511ae28e2509c8d8cae5311577ea7dd511ab8e746ffc8814a0896c3d33fbe",
-                "sha256:385977d94fc155f8731c895accdfcc3dd0d9dd9ef90d102969df95d3c637ab80",
-                "sha256:39764c6167c82d68a2d8c97c33dba45ec0ad9172570860e12191416f4f8e6e1b",
-                "sha256:3e33a968672be1394eded257ec10d4acbb9af2ae263ba05a99ff901bb863557e",
-                "sha256:4234914b8c67238a3c4af2bba648dc716aa029ca44d01f3d51536d44ac16854f",
-                "sha256:426559f105f644b69290ea414e154a0d320c3ad8a2bb75e62884731f69cf8e2c",
-                "sha256:465695268414e149bab754c54b0c45c8ceda73dd4a5c3ba255500da13984b16d",
-                "sha256:4bec8c7160688bd5a34e65c82984b25409563134d63285d8943d0599efbc448e",
-                "sha256:4c5627429f7fbff4f4131cfdd6abd530734ef7761116811a707b88b7e205afd7",
-                "sha256:4ca5f876bf41b24378ee67c41d688155f0e54cdc720de8ef9ad6544005899240",
-                "sha256:4d4ca49f5ba432b0755ebb0fc3a56be944a19a16bb33802264bbc7311622c0d1",
-                "sha256:4ebcddfcdfb4c614233cff6e9a3967a09484114a8b2e4f2c7a62dc83676ba13f",
-                "sha256:4f2bb4ee8dd40f9b2a80bb4adb2aecece9480ba1fa60d9382e8c8e0bd558e2eb",
-                "sha256:56f909a40d68947ef726ce6a34eb38f0ed241ffbe55c5007c64e616663bcbafc",
-                "sha256:5b771b59ac0dfb7f139f70c85b42717ef400a6790abb6475ebac1ecee8de782f",
-                "sha256:603c4414125fc9ae9000f17912dcfd3d3eb677d4e360b85206539240c96ea76e",
-                "sha256:60ca149a446da255d56c2a7a813b51a80d9497a62250532598d249b3cdb1a926",
-                "sha256:68c4eb92997dbaaf839ea13527be463178ac0ddd37a7ac636b8bc11a51af2428",
-                "sha256:6bb599052a974bb6cedfa114f9778fedfad66854107cf81397ec87cb9b8fbcf2",
-                "sha256:6f033dec603eea88204589175782290a038b436105a8f3637a81c4359df27832",
-                "sha256:72c8b494bd20ae1c58528b97c4a67d5cfeafcb3845c73542875ecd43924296de",
-                "sha256:77ffb3b7704eb7b9b3298a01fe4509cef70117a52d50bcba29cffc5f53dd326a",
-                "sha256:84b892e968164b7a0498ddc5746cdf4e985700b902128421bb5cec1080a6ee36",
-                "sha256:86d27d2dd7c7c5a44710565933c7dc9cd70e65ef97142e260d16d555667deef7",
-                "sha256:876a3ee7fd2613eb79602e4cdb39deb6b28c186e76124c3f29e580099ec21a87",
-                "sha256:8bba7e4743e37484ae17d5c3b8eb1ce78b564cb91b7ace2e2182b25f0f764cb5",
-                "sha256:8d16bbe566e16a71d123cd66382c1315fcd520c7573652a8074a8fe281b38c6a",
-                "sha256:8d264402fc179776d43e557e1ca4a7d953020d3ee95f7ec19cc2c9d769277f06",
-                "sha256:8f067ada2c333609b52835ca4d4868645d3b63ac04fb2b9a658c55bba7f667d3",
-                "sha256:8f4cbfff5cf01fa07464439a8510affc9df281535f41a1f5312fbd2b59b4ab5c",
-                "sha256:900580bc99c145e2561ea91a2d207e639171870d8a18756eb57db944a017d4bb",
-                "sha256:9061a3e3c92b27fd8036dafa26f25d95695b6aa2e4514ab16a254f297e664f83",
-                "sha256:90a96fcd824564eae6137ec2563bd061d49a32944858d4bdbae5c00fb10e76ac",
-                "sha256:9245bd392572b9f799261c4c9e7216bafc9405537d0f4ce3ad93afe081a12dc9",
-                "sha256:9799bd6a910961cb666196b8583ed0ee125fa225c6fdee2cbf00232b861f29d2",
-                "sha256:9a1d577c20b4334e5e814c3d5fe07fa4a8c3ae42a601945e8d7940bab811d0bd",
-                "sha256:a6b17c2b5e0b9bb7702449200f93e2d04cb04b1414c41424c08aa1e5d352da76",
-                "sha256:a730cd0824e8083989f304e97b3f884189efb48e2151e07f57e9e138ab104200",
-                "sha256:a8258f10059b5ac837232c589a350a2df4a96406d6d5f2a09ec587cbdd539655",
-                "sha256:ab6212e62ea0e1006531a2234e209607f360d98d18d532c2fa8e403c1afbdd71",
-                "sha256:abb903ffe46bd319d99979cdba350ae7016759bb69f47882242f7b93f3356055",
-                "sha256:abcea3b5f0dc44e1d01c27090bc32ce6ffb7aa665f884f1890710454113ea902",
-                "sha256:ac5d5329c9c942bbe6295f4251b135d860ed9f86acd912d418dce186de7c19ac",
-                "sha256:adb9b7b42c802bd8cb3927de8c1c26368ce50c8fdaa83a9d8551384d77537044",
-                "sha256:ae12fe90b00b71a71b69f513773310782ce01d5f58d2ceb2b7c595ab9d222094",
-                "sha256:b5cd111d3ab7390be0c07ad839235d5ad54d2ca497b5f5db86896098a77180a4",
-                "sha256:bb9d7efdb063903b3fdf77caec7b77c3066885068bdc0d44bc1b0c171033f944",
-                "sha256:c0a3b6e32457535df0d41d2d895da46434706dd85dbaf53fbc0d3bd7d914b362",
-                "sha256:c381a252317f63ca0179d2c7918e83b99a4ff3101e1b24849b999a00f9cd4f86",
-                "sha256:c713c1c528284d636cd37723b0b4c35c11190da6f932794e145fc40f8210a14a",
-                "sha256:c8be5bfcdc7832011b2652db29ed7672ce9d353dd19bce5272ca33dbcf60aaa8",
-                "sha256:c8f563b245b4ddb591e99f28e3cd140b85f114b38b7f95b2e42542f0603eb7d7",
-                "sha256:ca90ef33a152205fb6f2f0c1f3e55c50df4ef049bb0940ebba666edd4cdebc55",
-                "sha256:d60bf4d7f886989ddf80e121a7f4d140d9eac91f1d2385ce8eb6bda93d563297",
-                "sha256:d8750dd20362a1b80e3cf84f58013d4672f89663aee457ea59336df50fab6739",
-                "sha256:dd9ca2d44ed8018c90efb72f237a2a140325a4c3339971364d758e78b175f58e",
-                "sha256:e22539b676fafba17f0a90ac725f029a309eb6e483f364c86dcadee060429d46",
-                "sha256:e2a96fdc7643c9517a317553aca13b5cae9bad9a5f32f4654ce247ae4d321405",
-                "sha256:e5f4bfac975a2138215a38bda599ef00162e4143541cf7dd186da10a7f8e69f1",
-                "sha256:e8feeb5e8705835f0622af0fe7ff8d5cb388948454647086494d6c41ec142c2e",
-                "sha256:eb5069074db19a534de3859c43eec78e962d6d119f637c41c8e028c5ab3f59dd",
-                "sha256:f0b4101e2b3c6c352ff1f70b3a6fcc7c17c1ab1a91ccb7a33013cb0782af9820",
-                "sha256:f761dbcf45e9416ec4698e1a7649248005f0064ce3523a47402d1bff4af2779e",
-                "sha256:f9c96a29c6d65bd36a91f5634fef800212dff69dacdb44345c4c9783943ab0df",
-                "sha256:fb58da65e3339b3dbe266b607bb936efb983d86b00b03eb04c4ad5b442c58428",
-                "sha256:fbffc22d80d86fbe456af9abb17f7a7766e7b2101f7edaacc3535501691563f7",
-                "sha256:fdc5255eb4815babcdf236fa1a806ccb546724c8a9b129fd1ea4a5448a0bf07c",
-                "sha256:fe3425dc6021f906c6325d3c415e048e7cdb955505a94f1eb774dafc779ba203"
+                "sha256:044c6951ec37146b72a50cc81ef02217d27d4c3640efd2640311393cbbf143d3",
+                "sha256:060ebf6f2c51aff5ba38e1f43a2095e087389b1c69d559fde6049a4b0001320e",
+                "sha256:060ee84f6a769d40c492711911a76811b4befb6fba50abb450371abb720f5bd6",
+                "sha256:10758e0586c134a0bafa28f2d37dd2cdb5e4a90de25c0fc0c77dabbad46eca28",
+                "sha256:13fe81ead04e34e105bf1b3c9f9cdf32ce31736ee5d90a8d2de02b9d3e1bcb82",
+                "sha256:14ae4146465f8e6e6253eba0cccd57423e598a4cb925958b240c805300918343",
+                "sha256:14f500232e521201cf031549fb1ebdfc0a40f401cf519157f76c397e586c3beb",
+                "sha256:1574983178b35b9af4db4a9f7328a18a14a0a0ce76ffaa1c1bacb4cc82089a7c",
+                "sha256:196bfeabdccc5a020a57d5a368c681e3a6ceb0447d153aeccc1ab4d70a5032ba",
+                "sha256:21dd57941804ae2ac7e921771a5e21bbf9aabec317a041d164853ad0a96ce31e",
+                "sha256:264657171406c114787b441484de620e03d8f7202f113d62fcd3d9688baa3e6f",
+                "sha256:27ba1ed6f66b0e2d61bfa78874dffd4f8c3a12f8e2b5410e515ab345ba7bc9c3",
+                "sha256:292250282cf9bcf206b543d7608bda17ca6fc151f4cbae949fc7e115112fbd41",
+                "sha256:2a47a4223d3361b91176aedd9d4e05844ca67d7188456227b6bf5e436630c9a1",
+                "sha256:2a5b567f0b635b592c917f96b9a9cb3dbd4c320d03f4bf94e9084e494f2e8894",
+                "sha256:2ee0e58cca0c17dd9c6c1cdde02bb705c7b3fbfa5f3b0b5afeda20d4ebff8ef4",
+                "sha256:36393bd2841fa0b59498f75466ee9bdec4f770d3254f031f23e8fd8e140ffdd2",
+                "sha256:387a825f43d680e7310e6f325b2167dd093bc8ffd933b83e9aa0983cf6e0a2ef",
+                "sha256:3973f353b2d70bd9796cc12f532a05945232ccae966456c8ed7034cb96bbfd6f",
+                "sha256:3bca209d001fd03ea2d978f8a4985093240a355c93078aee3f799852c23f561a",
+                "sha256:406821f37f864f968e29ac14c3fccae0fec9fdeba48327f0341decf4daf92d7c",
+                "sha256:40ce1ea1e25125556d8e76bd0b61500839a07944cc287ac21d5626f3e620cad5",
+                "sha256:49d49e9a5e9f4dc3d3dac95278a020afa6d6bdd41f63608a76fa05a719d5b66f",
+                "sha256:4a3158dc2dcce5200d91ec28cd315c999eebff355437d2765840555d765a6e5f",
+                "sha256:4f7b71757a3ab19f7ba286e04c181004c1d61be921795ee8ba6970fd0ec91da5",
+                "sha256:59562de3f797979e1ff07c587e2ac36ba60ca59d16c211eceaa579c266c5022f",
+                "sha256:5b20211c47a8abf4abc3319d8ce2464864fa9f30c5fcaf958a3eed92f4f1fef8",
+                "sha256:5bd447332ec4f45838c1ad42268ce21ca87c40deb86eabd59888859b66be22a5",
+                "sha256:6326e18e9a553e674d948536a04a80d850a5eeefe2aae2e6d7cf05d54046c01b",
+                "sha256:6873f0271b4a15a33e7590f338d823f6f66f91ed147a03938d7ce26efd04eee6",
+                "sha256:68c86173562ed4413345410c9480a8d64864ac5e54a5cda236748031e094229f",
+                "sha256:69269ab58783e090bfbf5b916ab3d188126e22d6070bbfc93098fdd474ef937c",
+                "sha256:69e526e14f3f854eda573d3cf40cffd29a1a91c684743d904c33dbdcd0e0f3e7",
+                "sha256:6ae99e4560963ad8e163e819e5d77d413d331fd00566c1e0856aa252303552c1",
+                "sha256:6b8092aa38d72f091db61ef83cb66076f18f02da3e1a75039a4f218629600e04",
+                "sha256:6e5bbb5018bf76a56aabdb64246b5288d5ae1b7d0dd4d0534fe86df2c2992d1c",
+                "sha256:76e06ccacd1fb6ada5d076ed98a8c6f66e2e6acd3df02819e2ee29fd637b76ad",
+                "sha256:78f45d21dc4d5d6bd29323f0320089ef7eae16e4bef712dff79d184fa7330af3",
+                "sha256:79f6506a678a59d4ded048dc72f1859ebede8ec2b9a2d509ebe161f01c2879d3",
+                "sha256:7be4d613638d678b2b3773b8f687537b284d7074695a43fe2fbbfc0e31ceaed1",
+                "sha256:7c79ad5c28a16a1277e1187cf83ea8dafdcc689a784228a7d390f19776db7c31",
+                "sha256:7de326f80e3451bd5cc7239ab46c73ddb658fe0b7649476bc7413572d36cd548",
+                "sha256:7f9405ab4f81d490811b1d91c7a20361135a2df4c170e7f0b747a794da5b7f23",
+                "sha256:838943bea48be0e2768b0cf7819544cdedc1bbb2f28427eabb6eb8c9eb2285d3",
+                "sha256:88a800258d83acb803c38175b4495d293656d5fac48659c953c18e5f539a274b",
+                "sha256:89567798404af067604246e01a49ef907d112edf2b75ef814b1364d5ce267031",
+                "sha256:8a0b33e9fd838220b007ce8f299114d406c1e8edb21336af4c97a26ecfd185aa",
+                "sha256:8be48da4d47cc68754ce643ea50b3234557cbefe47c2f120495e7bd0a2756f2b",
+                "sha256:9074896edd705a05769e3de0eac0a8388484b503b68863dd06d5e473f874fd47",
+                "sha256:93b57142f9621b0d12349c43fc7741fe578e4bc914c1e5a54142856cfc0bf421",
+                "sha256:93d1d25ec2b27e90bcfef7012992d1f5121b51161b8bffcda756a816cf13c2c3",
+                "sha256:9779310cb5a9778a60c899f075a8514c89fa6d10131445c2207fc893e0b14557",
+                "sha256:97e596de8fa9bada4d88fde64a3f4d37f1b6131e4faa32bad7808abc79887ddc",
+                "sha256:9b2f4714bb7d99ba3790ee095b3b4ac94767e1347fe424278a0b10acb3ff04fe",
+                "sha256:9c9bdea644e94fd66d75a6f7e9a97bb822371e1fe7eadae2cacd50fcbc28e4dc",
+                "sha256:9cc7573518b7e2186bd229b1a0fe24a807273798832c27032c4510f47ffdb896",
+                "sha256:9f93959ee0c604bccd8e0697be21de0887b1f73efcc3aa73a3ec0fd13feace92",
+                "sha256:a360a8baeb038928ceb996f5623a4cd508728f8f13e08d4e96ce161702f3dd99",
+                "sha256:a43d34ce714f4ca674c0d90beb760eb05aad906f2c47580ccee9da8fe8bfb417",
+                "sha256:a55516c68ef3e08e134e818d5e308ffa6b1337cc8b092b69b24287bf07d38e31",
+                "sha256:a7fc042ba3c7ce25b8a9f097eb0f32a5ce1ccdb639d9eec114e26def98e1f8a4",
+                "sha256:abaea04f1e7e34841d4a7b343904a3f59481f62f9df39e2cd399d69a187a9660",
+                "sha256:ae47d8dcd3ded0155afbb59c62bd8ab07ea0fd4902e1c40567439e6db9dcaf2f",
+                "sha256:b01899e82a04085b6561eb233fd688474f57455e8ad35cd82286463ba06332b7",
+                "sha256:b3becbea7f3ce9a2d4d430f223ec15888e4deb31395840a79e916368d6004cce",
+                "sha256:b780090d15fd58f07cf2011943e25a5f0c1c894384b13a216b6c86c8a8a7c508",
+                "sha256:b7fc50d2afd2e6b4f6f2f403b70103d280a8e0cb35320cbbe6debcda02a1030b",
+                "sha256:bff1b04cb9d4900ce5c56c4942f047dc7efe57e2608cb7c3c8936e9970ccdbee",
+                "sha256:c1ea8ca9db5e7469cd364552985e15911548ea5b69c48a17291f0cac70484b2e",
+                "sha256:c6cadac7b8ace1ba9144feb1ae3cb787a6065ba6d23ffc59a934b16406c26573",
+                "sha256:c6f141b468740197d6bd38f2b26ade124363228cc3f9858bd9924ab059e00059",
+                "sha256:ca9566769b69a5e216a4e176d54b9df88f29d750c5b78dbb899e379b4e14b30c",
+                "sha256:d0ba505e021557f7f8173ee8cd6b926373d8653e5ff7581ae2efce1b11ef4c27",
+                "sha256:d6d16b0f71120e365741bca2cb473ca6fe38930bc5431c5e850ba949f708f892",
+                "sha256:d7f63ce526a96acd0e16c4af8b50b64334239550402fb1607ce6a584a6d62ce9",
+                "sha256:e080afb413be106c95c4ee96b4fffdc9e2fa56a8bbf90b5c0918e5c4449412f5",
+                "sha256:e4121a90823a063d717a96e0a0529c727fb31ea889369a0ee3ec00ed99bf6859",
+                "sha256:e64fa5a1e41ce5df6b547cbc3d3699381c9e2c2c369c67837e716ed0f549d48e",
+                "sha256:e79a8c7d461820257d9aa43716c4efc55366d7b292e46b5b37165be1d377405d",
+                "sha256:ed2bce0e7bfa53f7b0b01c722da289ef6ad4c18ebd52b1f93704c21f116360c8",
+                "sha256:ed75de7d1217cf3b99365d110975f83af0528c849ef5180a12fd91b5064df9d6",
+                "sha256:ee68e5a4e3e5443623406b905db447dceddffee0dceb39f4e0cd9ec2a35004b5",
+                "sha256:eeea10169fac01549a7921d27a3e517194ae254b542102267bef7a93ed38c40e",
+                "sha256:f06799ae1bdfff7ccb8665d75f8291c69110ba9585253de254688aa8a1ccc6c5",
+                "sha256:f0d7fea9d8e5d778cd5a9e8fc38308ad688f02040e883cdc13311ef2748cb40f",
+                "sha256:f106b2af193f965d0d3234f3f83fc35278c7fb935dfbde56ae2da3dd2c03b84d",
+                "sha256:f4af3b01763909f477ea17c962e2cca8f39b350a4e46e3a30838b2c12e31b81b",
+                "sha256:f61d349f5b7cd95c34017f1927ee379bfbe9884300d74e07cf630ccf7a610c1b",
+                "sha256:f674f59712d67e841525b99e5e2b595250e39b529c3bda14764e4f625a3fa01f",
+                "sha256:f819c727a6e6eeb8711e4ce63d78c620f69630a2e9d53bc95ca5379f57b6ba94",
+                "sha256:f9ab1d5b86f8fbc97a5b3cd6280a3fd85fef3b028689d8a2c00918f0d82c728c",
+                "sha256:fae91dfecd816444c74531a9c3d6ded17a504767e97aa674d44f638107265b99"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==7.11.3"
+            "version": "==7.13.2"
         },
         "decorator": {
             "hashes": [
@@ -1247,37 +1405,37 @@
         },
         "django-stubs": {
             "hashes": [
-                "sha256:2864e74b56ead866ff1365a051f24d852f6ed02238959664f558a6c9601c95bf",
-                "sha256:2a07e47a8a867836a763c6bba8bf3775847b4fd9555bfa940360e32d0ee384a1"
+                "sha256:2317a7130afdaa76f6ff7f623650d7f3bf1b6c86a60f95840e14e6ec6de1a7cd",
+                "sha256:c192257120b08785cfe6f2f1c91f1797aceae8e9daa689c336e52c91e8f6a493"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==5.2.7"
+            "version": "==5.2.9"
         },
         "django-stubs-ext": {
             "hashes": [
-                "sha256:0466a7132587d49c5bbe12082ac9824d117a0dedcad5d0ada75a6e0d3aca6f60",
-                "sha256:b690655bd4cb8a44ae57abb314e0995dc90414280db8f26fff0cb9fb367d1cac"
+                "sha256:230c51575551b0165be40177f0f6805f1e3ebf799b835c85f5d64c371ca6cf71",
+                "sha256:6db4054d1580657b979b7d391474719f1a978773e66c7070a5e246cd445a25a9"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==5.2.7"
+            "version": "==5.2.9"
         },
         "drf-spectacular-sidecar": {
             "hashes": [
-                "sha256:506a5a21ce1ad7211c28acb4e2112e213f6dc095a2052ee6ed6db1ffe8eb5a7b",
-                "sha256:f1de343184d1a938179ce363d318258fe1e5f02f2f774625272364835f1c42bd"
+                "sha256:6f7c173a8ddbbbdafc7a27e028614b65f07a89ca90f996a432d57460463b56be",
+                "sha256:af8df62f1b594ec280351336d837eaf2402ab25a6bc2a1fad7aee9935821070f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==2025.10.1"
+            "version": "==2026.1.1"
         },
         "execnet": {
             "hashes": [
-                "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc",
-                "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"
+                "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd",
+                "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.1"
+            "version": "==2.1.2"
         },
         "flake8": {
             "hashes": [
@@ -1309,7 +1467,7 @@
                 "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216",
                 "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.0.0"
         },
         "iniconfig": {
@@ -1319,6 +1477,88 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==2.3.0"
+        },
+        "librt": {
+            "hashes": [
+                "sha256:00105e7d541a8f2ee5be52caacea98a005e0478cfe78c8080fbb7b5d2b340c63",
+                "sha256:0241a6ed65e6666236ea78203a73d800dbed896cf12ae25d026d75dc1fcd1dac",
+                "sha256:03679b9856932b8c8f674e87aa3c55ea11c9274301f76ae8dc4d281bda55cf62",
+                "sha256:047164e5f68b7a8ebdf9fae91a3c2161d3192418aadd61ddd3a86a56cbe3dc85",
+                "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365",
+                "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862",
+                "sha256:20e3946863d872f7cabf7f77c6c9d370b8b3d74333d3a32471c50d3a86c0a232",
+                "sha256:2991b6c3775383752b3ca0204842743256f3ad3deeb1d0adc227d56b78a9a850",
+                "sha256:31724b93baa91512bd0a376e7cf0b59d8b631ee17923b1218a65456fa9bda2e7",
+                "sha256:3469e1af9f1380e093ae06bedcbdd11e407ac0b303a56bbe9afb1d6824d4982d",
+                "sha256:389bd25a0db916e1d6bcb014f11aa9676cedaa485e9ec3752dfe19f196fd377b",
+                "sha256:3968762fec1b2ad34ce57458b6de25dbb4142713e9ca6279a0d352fa4e9f452b",
+                "sha256:39a4c76fee41007070f872b648cc2f711f9abf9a13d0c7162478043377b52c8e",
+                "sha256:3d1322800771bee4a91f3b4bd4e49abc7d35e65166821086e5afd1e6c0d9be44",
+                "sha256:41d7bb1e07916aeb12ae4a44e3025db3691c4149ab788d0315781b4d29b86afb",
+                "sha256:43d4e71b50763fcdcf64725ac680d8cfa1706c928b844794a7aa0fa9ac8e5f09",
+                "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32",
+                "sha256:44e0c2cbc9bebd074cf2cdbe472ca185e824be4e74b1c63a8e934cea674bebf2",
+                "sha256:451e7ffcef8f785831fdb791bd69211f47e95dc4c6ddff68e589058806f044c6",
+                "sha256:46ef1f4b9b6cc364b11eea0ecc0897314447a66029ee1e55859acb3dd8757c93",
+                "sha256:4864045f49dc9c974dadb942ac56a74cd0479a2aafa51ce272c490a82322ea3c",
+                "sha256:4adc73614f0d3c97874f02f2c7fd2a27854e7e24ad532ea6b965459c5b757eca",
+                "sha256:4c3995abbbb60b3c129490fa985dfe6cac11d88fc3c36eeb4fb1449efbbb04fc",
+                "sha256:4d2f1e492cae964b3463a03dc77a7fe8742f7855d7258c7643f0ee32b6651dd3",
+                "sha256:535929b6eff670c593c34ff435d5440c3096f20fa72d63444608a5aef64dd581",
+                "sha256:5363427bc6a8c3b1719f8f3845ea53553d301382928a86e8fab7984426949bce",
+                "sha256:54feb7b4f2f6706bb82325e836a01be805770443e2400f706e824e91f6441dde",
+                "sha256:57175aa93f804d2c08d2edb7213e09276bd49097611aefc37e3fa38d1fb99ad0",
+                "sha256:5bcaaf624fd24e6a0cb14beac37677f90793a96864c67c064a91458611446e83",
+                "sha256:60c299e555f87e4c01b2eca085dfccda1dde87f5a604bb45c2906b8305819a93",
+                "sha256:631599598e2c76ded400c0a8722dec09217c89ff64dc54b060f598ed68e7d2a8",
+                "sha256:63937bd0f4d1cb56653dc7ae900d6c52c41f0015e25aaf9902481ee79943b33a",
+                "sha256:66daa6ac5de4288a5bbfbe55b4caa7bf0cd26b3269c7a476ffe8ce45f837f87d",
+                "sha256:6938cc2de153bc927ed8d71c7d2f2ae01b4e96359126c602721340eb7ce1a92d",
+                "sha256:6d772edc6a5f7835635c7562f6688e031f0b97e31d538412a852c49c9a6c92d5",
+                "sha256:6db5faf064b5bab9675c32a873436b31e01d66ca6984c6f7f92621656033a708",
+                "sha256:73fd300f501a052f2ba52ede721232212f3b06503fa12665408ecfc9d8fd149c",
+                "sha256:79feb4d00b2a4e0e05c9c56df707934f41fcb5fe53fd9efb7549068d0495b758",
+                "sha256:7aa7d5457b6c542ecaed79cec4ad98534373c9757383973e638ccced0f11f46d",
+                "sha256:7b0803e9008c62a7ef79058233db7ff6f37a9933b8f2573c05b07ddafa226611",
+                "sha256:7e03bea66af33c95ce3addf87a9bf1fcad8d33e757bc479957ddbc0e4f7207ac",
+                "sha256:864c4b7083eeee250ed55135d2127b260d7eb4b5e953a9e5df09c852e327961b",
+                "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06",
+                "sha256:87808a8d1e0bd62a01cafc41f0fd6818b5a5d0ca0d8a55326a81643cdda8f873",
+                "sha256:907ad09cfab21e3c86e8f1f87858f7049d1097f77196959c033612f532b4e592",
+                "sha256:95b67aa7eff150f075fda09d11f6bfb26edffd300f6ab1666759547581e8f666",
+                "sha256:978e8b5f13e52cf23a9e80f3286d7546baa70bc4ef35b51d97a709d0b28e537c",
+                "sha256:9b6943885b2d49c48d0cff23b16be830ba46b0152d98f62de49e735c6e655a63",
+                "sha256:9c1ba843ae20db09b9d5c80475376168feb2640ce91cd9906414f23cc267a1ff",
+                "sha256:a14229ac62adcf1b90a15992f1ab9c69ae8b99ffb23cb64a90878a6e8a2f5b81",
+                "sha256:a36515b1328dc5b3ffce79fe204985ca8572525452eacabee2166f44bb387b2c",
+                "sha256:ac9c8a458245c7de80bc1b9765b177055efff5803f08e548dd4bb9ab9a8d789b",
+                "sha256:ad64a14b1e56e702e19b24aae108f18ad1bf7777f3af5fcd39f87d0c5a814449",
+                "sha256:b09c52ed43a461994716082ee7d87618096851319bf695d57ec123f2ab708951",
+                "sha256:b45306a1fc5f53c9330fbee134d8b3227fe5da2ab09813b892790400aa49352d",
+                "sha256:b5b007bb22ea4b255d3ee39dfd06d12534de2fcc3438567d9f48cdaf67ae1ae3",
+                "sha256:b7e7f140c5169798f90b80d6e607ed2ba5059784968a004107c88ad61fb3641d",
+                "sha256:b9122094e3f24aa759c38f46bd8863433820654927370250f460ae75488b66ea",
+                "sha256:bb7a7807523a31f03061288cc4ffc065d684c39db7644c676b47d89553c0d714",
+                "sha256:be927c3c94c74b05128089a955fba86501c3b544d1d300282cc1b4bd370cb418",
+                "sha256:bfde8a130bd0f239e45503ab39fab239ace094d63ee1d6b67c25a63d741c0f71",
+                "sha256:c6f8947d3dfd7f91066c5b4385812c18be26c9d5a99ca56667547f2c39149d94",
+                "sha256:c7e8f88f79308d86d8f39c491773cbb533d6cb7fa6476f35d711076ee04fceb6",
+                "sha256:ca916919793a77e4a98d4a1701e345d337ce53be4a16620f063191f7322ac80f",
+                "sha256:cf243da9e42d914036fd362ac3fa77d80a41cadcd11ad789b1b5eec4daaf67ca",
+                "sha256:d6f254d096d84156a46a84861183c183d30734e52383602443292644d895047c",
+                "sha256:dbd79caaf77a3f590cbe32dc2447f718772d6eea59656a7dcb9311161b10fa75",
+                "sha256:ddb52499d0b3ed4aa88746aaf6f36a08314677d5c346234c3987ddc506404eac",
+                "sha256:e90a8e237753c83b8e484d478d9a996dc5e39fd5bd4c6ce32563bc8123f132be",
+                "sha256:e9c0afebbe6ce177ae8edba0c7c4d626f2a0fc12c33bb993d163817c41a7a05c",
+                "sha256:f11b300027ce19a34f6d24ebb0a25fd0e24a9d53353225a5c1e6cadbf2916b2e",
+                "sha256:f1ade7f31675db00b514b98f9ab9a7698c7282dad4be7492589109471852d398",
+                "sha256:f8f4a901a3fa28969d6e4519deceab56c55a09d691ea7b12ca830e2fa3461e34",
+                "sha256:fdec6e2368ae4f796fc72fad7fd4bd1753715187e6d870932b0904609e7c878e",
+                "sha256:ff3e9c11aa260c31493d4b3197d1e28dd07768594a4f92bec4506849d736248f",
+                "sha256:ff71447cb778a4f772ddc4ce360e6ba9c95527ed84a52096bd1bbf9fee2ec7c0"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==0.7.8"
         },
         "lxml": {
             "hashes": [
@@ -1483,6 +1723,59 @@
             "markers": "python_version >= '3.6'",
             "version": "==5.2.0"
         },
+        "mypy": {
+            "hashes": [
+                "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd",
+                "sha256:022ea7279374af1a5d78dfcab853fe6a536eebfda4b59deab53cd21f6cd9f00b",
+                "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1",
+                "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba",
+                "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b",
+                "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045",
+                "sha256:2899753e2f61e571b3971747e302d5f420c3fd09650e1951e99f823bc3089dac",
+                "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6",
+                "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a",
+                "sha256:409088884802d511ee52ca067707b90c883426bd95514e8cfda8281dc2effe24",
+                "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957",
+                "sha256:4b84a7a18f41e167f7995200a1d07a4a6810e89d29859df936f1c3923d263042",
+                "sha256:4f28f99c824ecebcdaa2e55d82953e38ff60ee5ec938476796636b86afa3956e",
+                "sha256:5f05aa3d375b385734388e844bc01733bd33c644ab48e9684faa54e5389775ec",
+                "sha256:7bcfc336a03a1aaa26dfce9fff3e287a3ba99872a157561cbfcebe67c13308e3",
+                "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718",
+                "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f",
+                "sha256:a009ffa5a621762d0c926a078c2d639104becab69e79538a494bcccb62cc0331",
+                "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1",
+                "sha256:ab43590f9cd5108f41aacf9fca31841142c786827a74ab7cc8a2eacb634e09a1",
+                "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13",
+                "sha256:b13cfdd6c87fc3efb69ea4ec18ef79c74c3f98b4e5498ca9b85ab3b2c2329a67",
+                "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2",
+                "sha256:b7951a701c07ea584c4fe327834b92a30825514c868b1f69c30445093fdd9d5a",
+                "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b",
+                "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8",
+                "sha256:c608937067d2fc5a4dd1a5ce92fd9e1398691b8c5d012d66e1ddd430e9244376",
+                "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef",
+                "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288",
+                "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75",
+                "sha256:de759aafbae8763283b2ee5869c7255391fbc4de3ff171f8f030b5ec48381b74",
+                "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250",
+                "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab",
+                "sha256:ee4c11e460685c3e0c64a4c5de82ae143622410950d6be863303a1c4ba0e36d6",
+                "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247",
+                "sha256:f7cee03c9a2e2ee26ec07479f38ea9c884e301d42c6d43a19d20fb014e3ba925",
+                "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e",
+                "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.19.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505",
+                "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.0"
+        },
         "path": {
             "hashes": [
                 "sha256:2dfcbfec8b4d960f3469c52acf133113c2a8bf12ac7b98d629fa91af87248d42",
@@ -1491,6 +1784,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==17.1.1"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
+                "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.0.4"
         },
         "pluggy": {
             "hashes": [
@@ -1502,28 +1803,30 @@
         },
         "psutil": {
             "hashes": [
-                "sha256:0005da714eee687b4b8decd3d6cc7c6db36215c9e74e5ad2264b90c3df7d92dc",
-                "sha256:1068c303be3a72f8e18e412c5b2a8f6d31750fb152f9cb106b54090296c9d251",
-                "sha256:18349c5c24b06ac5612c0428ec2a0331c26443d259e2a0144a9b24b4395b58fa",
-                "sha256:19644c85dcb987e35eeeaefdc3915d059dac7bd1167cdcdbf27e0ce2df0c08c0",
-                "sha256:2bdbcd0e58ca14996a42adf3621a6244f1bb2e2e528886959c72cf1e326677ab",
-                "sha256:31d77fcedb7529f27bb3a0472bea9334349f9a04160e8e6e5020f22c59893264",
-                "sha256:3792983e23b69843aea49c8f5b8f115572c5ab64c153bada5270086a2123c7e7",
-                "sha256:3bb428f9f05c1225a558f53e30ccbad9930b11c3fc206836242de1091d3e7dd3",
-                "sha256:56d974e02ca2c8eb4812c3f76c30e28836fffc311d55d979f1465c1feeb2b68b",
-                "sha256:6c86281738d77335af7aec228328e944b30930899ea760ecf33a4dba66be5e74",
-                "sha256:8f33a3702e167783a9213db10ad29650ebf383946e91bc77f28a5eb083496bc9",
-                "sha256:95ef04cf2e5ba0ab9eaafc4a11eaae91b44f4ef5541acd2ee91d9108d00d59a7",
-                "sha256:ad81425efc5e75da3f39b3e636293360ad8d0b49bed7df824c79764fb4ba9b8b",
-                "sha256:b403da1df4d6d43973dc004d19cee3b848e998ae3154cc8097d139b77156c353",
-                "sha256:bc31fa00f1fbc3c3802141eede66f3a2d51d89716a194bf2cd6fc68310a19880",
-                "sha256:bd0d69cee829226a761e92f28140bec9a5ee9d5b4fb4b0cc589068dbfff559b1",
-                "sha256:c525ffa774fe4496282fb0b1187725793de3e7c6b29e41562733cae9ada151ee",
-                "sha256:f39c2c19fe824b47484b96f9692932248a54c43799a84282cfe58d05a6449efd",
-                "sha256:fac9cd332c67f4422504297889da5ab7e05fd11e3c4392140f7370f4208ded1f"
+                "sha256:05cc68dbb8c174828624062e73078e7e35406f4ca2d0866c272c2410d8ef06d1",
+                "sha256:08a2f175e48a898c8eb8eace45ce01777f4785bc744c90aa2cc7f2fa5462a266",
+                "sha256:0d67c1822c355aa6f7314d92018fb4268a76668a536f133599b91edd48759442",
+                "sha256:2ceae842a78d1603753561132d5ad1b2f8a7979cb0c283f5b52fb4e6e14b1a79",
+                "sha256:35630d5af80d5d0d49cfc4d64c1c13838baf6717a13effb35869a5919b854cdf",
+                "sha256:3fce5f92c22b00cdefd1645aa58ab4877a01679e901555067b1bd77039aa589f",
+                "sha256:494c513ccc53225ae23eec7fe6e1482f1b8a44674241b54561f755a898650679",
+                "sha256:5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8",
+                "sha256:81442dac7abfc2f4f4385ea9e12ddf5a796721c0f6133260687fec5c3780fa49",
+                "sha256:923f8653416604e356073e6e0bccbe7c09990acef442def2f5640dd0faa9689f",
+                "sha256:93f3f7b0bb07711b49626e7940d6fe52aa9940ad86e8f7e74842e73189712129",
+                "sha256:99a4cd17a5fdd1f3d014396502daa70b5ec21bf4ffe38393e152f8e449757d67",
+                "sha256:ab2b98c9fc19f13f59628d94df5cc4cc4844bc572467d113a8b517d634e362c6",
+                "sha256:b1b0671619343aa71c20ff9767eced0483e4fc9e1f489d50923738caf6a03c17",
+                "sha256:b2e953fcfaedcfbc952b44744f22d16575d3aa78eb4f51ae74165b4e96e55f42",
+                "sha256:ba9f33bb525b14c3ea563b2fd521a84d2fa214ec59e3e6a2858f78d0844dd60d",
+                "sha256:cfbe6b40ca48019a51827f20d830887b3107a74a79b01ceb8cc8de4ccb17b672",
+                "sha256:d34d2ca888208eea2b5c68186841336a7f5e0b990edec929be909353a202768a",
+                "sha256:ea46c0d060491051d39f0d2cff4f98d5c72b288289f57a21556cc7d504db37fc",
+                "sha256:f7583aec590485b43ca601dd9cea0dcd65bd7bb21d30ef4ddbf4ea6b5ed1bdd3",
+                "sha256:f78baafb38436d5a128f837fab2d92c276dfb48af01a240b861ae02b2413ada8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==7.1.3"
+            "version": "==7.2.1"
         },
         "py": {
             "hashes": [
@@ -1559,12 +1862,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:8f44522eafe4137b0f35c9ce3072931a788a21ee40a2ed279e817d3cc16ed21e",
-                "sha256:e5ccdf10b0bac554970ee88fc1a4ad0ee5d221f8ef22321f9b7e4584e19d7f96"
+                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
+                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==9.0.0"
+            "version": "==9.0.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -1629,20 +1932,28 @@
         },
         "termcolor": {
             "hashes": [
-                "sha256:610e6456feec42c4bcd28934a8c87a06c3fa28b01561d46aa09a9881b8622c58",
-                "sha256:a10343879eba4da819353c55cb8049b0933890c2ebf9ad5d3ecd2bb32ea96ea6"
+                "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5",
+                "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==3.2.0"
+            "version": "==3.3.0"
+        },
+        "types-pyyaml": {
+            "hashes": [
+                "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3",
+                "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==6.0.12.20250915"
         },
         "unittest-xml-reporting": {
             "hashes": [
-                "sha256:edd8d3170b40c3a81b8cf910f46c6a304ae2847ec01036d02e9c0f9b85762d28",
-                "sha256:f3d7402e5b3ac72a5ee3149278339db1a8f932ee405f48bcb9c681372f2717d5"
+                "sha256:bfa1ed65e9e6f33c161d04470d89050458cfb65a5a5d0358834ef7ce037d9136",
+                "sha256:e3e24bac8ea27c454d8be1d718851b2c5c8f712d75281920b6af81bdfef2f9bc"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==3.2.0"
+            "markers": "python_version >= '3.10'",
+            "version": "==4.0.0"
         }
     }
 }

--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -564,6 +564,7 @@ rule_id_query_param = OpenApiParameter(
 )
 
 
+# Note that this has nothing to do with the SystemType model....
 system_type_query_param = OpenApiParameter(
     name='system_type', location=OpenApiParameter.QUERY,
     description="Display only systems with this type ('all' = both types)",
@@ -742,20 +743,22 @@ def filter_on_host_tags(request, field_name='host_id'):
     )})
 
 
-def filter_on_system_type(request):
+def filter_on_system_type(request, relation: Optional[str] = None):
     """
     Filter on the host_type field (currently within system_profile).
     """
     system_type = value_of_param(system_type_query_param, request)
-    # relation='' ?
+    base_parameter = 'system_profile__'
+    if relation:
+        base_parameter = f"{relation}__{base_parameter}"
     if system_type is None or system_type == 'all':
         return Q()
     elif system_type == 'edge':
-        return Q(system_profile__host_type='edge')
+        return Q(**{f"{base_parameter}host_type": 'edge'})
     elif system_type == 'bootc':
-        return Q(system_profile__bootc_status__isnull=False)
+        return Q(**{f"{base_parameter}bootc_status__isnull": False})
     elif system_type == 'conventional':
-        return Q(system_profile__host_type__isnull=True)
+        return Q(**{f"{base_parameter}host_type__isnull": True})
 
 
 def filter_on_incident(request):

--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -1,0 +1,330 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+import prometheus
+import signal
+
+from project_settings import kafka_settings
+from django.core.management.base import BaseCommand
+
+from advisor_logging import logger
+from feature_flags import (
+    feature_flag_is_enabled, FLAG_INVENTORY_EVENT_REPLICATION
+)
+from api.models import InventoryHost, Host  # pyright: ignore[reportImplicitRelativeImport]
+
+from kafka_utils import JsonValue, KafkaDispatcher  # , send_kafka_message
+
+
+#############################################################################
+def handle_inventory_event(topic: str, message: dict[str, JsonValue]) -> None:
+    """
+    Handle inventory events.
+
+    The inventory event messages are documented at:
+    https://inscope.corp.redhat.com/docs/default/component/host-based-inventory/#created-event
+    """
+    if 'type' not in message:
+        logger.error("Message received on topic %s with no 'type' field", topic)
+        return
+
+    if not feature_flag_is_enabled(FLAG_INVENTORY_EVENT_REPLICATION):
+        sys_uuid: str = message.get('host', {}).get('id', 'unknown UUID')
+        logger.info(
+            "Received Inventory %s event for %s - feature flag not enabled, ignoring",
+            message['type'], sys_uuid
+        )
+        return
+
+    match message['type']:
+        case 'delete':
+            handle_deleted_event(message)
+        case 'created' | 'updated':
+            handle_created_event(message)
+        case msg_type:
+            logger.error("Inventory event: Unknown message type: %s", msg_type)
+
+
+#############################################################################
+def log_missing_key(request_id: str, event_type: str, key_name: str):
+    logger.error(
+        "Request %s: Inventory %s event did not contain required key '%s'",
+        request_id, event_type, key_name
+    )
+    prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
+
+
+#############################################################################
+SYSTEM_PROFILE_KEYS = (
+    'ansible', 'bootc_status', 'host_type', 'mssql', 'operating_system',
+    'owner_id', 'rhc_client_id', 'sap', 'sap_system', 'sap_sids',
+    # need to phase out sap_system and sap_sids in favour of sap structure.
+    'system_update_method',
+)
+
+
+def extract_system_profile(source: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    """
+    Grab just the keys we need from the given system profile.
+    """
+    return {
+        key: source[key]
+        for key in SYSTEM_PROFILE_KEYS
+        if key in source
+    }
+
+
+#############################################################################
+def handle_created_event(message: dict[str, JsonValue]):
+    """
+    Handle a 'created' or 'updated' event message.
+
+    We break this down into two parts:
+        1. Create or update the basic information of the host.
+        2. Update the host's system_profile and other complex fields.
+
+    This just breaks down the amount of data being updated in each transaction.
+
+    Message is of the form:
+        {
+           "type": "created",  # or 'updated' - already checked.
+           "timestamp": "<timestamp>",
+           "platform_metadata": "<metadata_json_doc>",
+           "metadata": {
+               "request_id": "<request_id>",
+           },
+           "host": {
+              "id": "<id>",
+              "account": "<account_number>",
+              "org_id": "<org_id>",
+              "display_name": "<display_name>",
+              "ansible_host": "<ansible_host>",
+              "fqdn": "<fqdn>",
+              "insights_id": "<insights_id>",
+              "subscription_manager_id": "<subscription_manager_id>",
+              "satellite_id": "<satellite_id>",
+              "bios_uuid": "<bios_uuid>",
+              "ip_addresses": [<ip_addresses>],
+              "mac_addresses": [<mac_addresses>],
+              "facts": [<facts>],
+              "provider_id": "<provider_id>",
+              "provider_type": "<provider_type>",
+              "created": "<created_date>",
+              "updated": "<updated_date>",
+              "last_check_in": "<last_check_in_date>",
+              "stale_timestamp": "<stale_timestamp>",
+              "stale_warning_timestamp": "<stale_warning_timestamp>",
+              "culled_timestamp": "<culled_timestamp>",
+              "reporter": "<reporter>",
+              "tags": [<tags>],
+              "system_profile": {<system_profile>},
+              "per_reporter_staleness": {<per_reporter_staleness>},
+              "groups": [{
+                "id": <group_id>,
+                "name": <group_name>
+              }],
+              "openshift_cluster_id": "<openshift_cluster_id>",
+           }
+        }
+
+    """
+    # We know this exists because handle_inventory_message used it
+    event_type: str = str(message['type'])
+    logger.info(f"Handling '{event_type}' event")
+
+    # Maybe this is a weird way of handling checking the keys, but ... it
+    # saves writing what amounts to an exception handler.
+    request_id = 'Unknown'
+    # Only use 'get' specifically on optional fields, everything else should
+    # be required.
+    try:
+        metadata: dict[str, str] = message['metadata']
+        request_id = metadata['request_id']
+        host: dict[str, str] = message['host']
+        host_id = host['id']
+        display_name = host['display_name']
+        account = host.get('account')  # optional
+        org_id = host['org_id']
+        tags = host['tags']
+        groups = host['groups']
+        created = host['created']
+        updated = host['updated']
+        insights_id = host['insights_id']
+        satellite_id = host.get('satellite_id')  # optional
+        # No branch_id ?
+        # Sadly the staleness fields are still mandatory even though we
+        # should not use them.
+        stale_timestamp = host['stale_timestamp']
+        stale_warning_timestamp = host['stale_warning_timestamp']
+        culled_timestamp = host['culled_timestamp']
+        system_profile_field = host['system_profile']
+        per_reporter_staleness = host['per_reporter_staleness']
+    except KeyError as key_name:
+        # Might be missing metadata or request_id...
+        key_name = str(key_name).strip("'")  # Error is quoted in single quotes
+        if key_name == 'metadata':
+            request_id = 'metadata'
+        elif key_name == 'request_id':
+            request_id = 'unknown request_id'
+        # else the request_id variable exists from above
+        return log_missing_key(request_id, event_type, key_name)
+
+    # These are the particular fields that Advisor and Tasks uses
+    system_profile: dict[str, JsonValue] = extract_system_profile(system_profile_field)
+
+    # Create or update the inventory host.
+    # If we're creating the host, we need to supply a system_profile.
+    # However, if updating we don't really want to supply a large quantity
+    # of system_profile data that may not be changing.  When the system
+    # profile data moves into its own model, this may be easier and more
+    # efficient.
+    inv_host, created = InventoryHost.objects.update_or_create(
+        id=host_id,
+        defaults={
+            'display_name': display_name,
+            'account': account,
+            'org_id': org_id,
+            'tags': tags,
+            'groups': groups,
+            'created': created,
+            'updated': updated,
+            'insights_id': insights_id,
+            'stale_timestamp': stale_timestamp,
+            'stale_warning_timestamp': stale_warning_timestamp,
+            'culled_timestamp': culled_timestamp,
+            'per_reporter_staleness': per_reporter_staleness,
+            'system_profile': system_profile,
+        }
+    )
+    if created:
+        prometheus.INVENTORY_HOST_CREATED.inc()
+        action = 'Created'
+    else:
+        prometheus.INVENTORY_HOST_UPDATED.inc()
+        action = 'Updated'
+    logger.debug(
+        "%s Inventory host %s account %s org_id %s",
+        action, inv_host.id, account, org_id
+    )
+
+    # Also add the Host record
+    host_data = {
+        'account': account,
+        'org_id': org_id,
+        # branch_id not in Inventory create/update message?
+    }
+    if satellite_id:
+        host_data['satellite_id'] = satellite_id
+    host_obj, created = Host.objects.update_or_create(
+        inventory_id=inv_host.id,
+        defaults=host_data
+    )
+    action = 'Created' if created else 'Updated'
+    logger.debug(
+        "%s Host %s account %s org_id %s",
+        action, host_obj.inventory_id, account, org_id
+    )
+
+
+#############################################################################
+def handle_deleted_event(message: dict[str, JsonValue]):
+    """
+    Handle a 'deleted' event message.
+
+    Delete events are of the form:
+    {
+        "type": "delete",
+        "id": "<host id>",
+        "timestamp": "<delete timestamp>",
+        "account": "<account number>",
+        "org_id": "<org_id>",
+        "insights_id": "<insights id>",
+        "request_id": "<request id>",
+        "subscription_manager_id": "<subscription_manager_id>",
+        "initiated_by_frontend": "<initiated_by_frontend>",
+        "platform_metadata": "<metadata_json_doc>",
+        "metadata": {
+            "request_id": "<request_id>",
+        },
+    }
+
+    """
+    logger.info("Handling 'deleted' event")
+
+    try:
+        request_id = message['request_id']
+        inventory_id = message['id']
+        account = message.get('account')  # optional
+        org_id = message['org_id']
+    except KeyError as missing_key:
+        key_name = str(missing_key).strip("'")
+        if key_name == 'request_id':
+            request_id = 'unknown request_id'
+        else:
+            request_id = message['request_id']
+        return log_missing_key(request_id, 'delete', key_name)
+
+    payload_info = {
+        'request_id': request_id,
+        'inventory_id': inventory_id,
+        'account': account,
+        'org_id': org_id,
+        'source': 'inventory'
+    }
+    logger.info(
+        "Received DELETE event from Inventory for host %s.",
+        inventory_id, extra=payload_info
+    )
+
+    # Delete Host object and related records - CurrentReport, HostAck,
+    # SatMaintenanceAction, and Upload
+    deleted_records = Host.objects.filter(
+        inventory_id=inventory_id, org_id=org_id
+    ).delete()
+    logger.info("Deleted %d records based on Host: %s.", *deleted_records)
+    # Delete InventoryHost record
+    deleted_records = InventoryHost.objects.filter(
+        id=inventory_id, org_id=org_id
+    ).delete()
+    logger.info("Deleted %d records based on InventoryHost: %s.", *deleted_records)
+    prometheus.INVENTORY_HOST_DELETED.inc()
+
+
+# Main command
+
+
+class Command(BaseCommand):
+    help = "Manage InventoryHost table replication from Inventory Event messages"
+
+    def handle(self, *args, **options):
+        """
+        Run the handler loop continuously until interrupted by SIGTERM.
+        """
+        logger.info('Advisor Inventory replication service starting up')
+
+        receiver = KafkaDispatcher()
+        receiver.register_handler(kafka_settings.INVENTORY_TOPIC, handle_inventory_event)
+
+        def terminate(signum: int, _):
+            logger.info("Signal %d received, triggering shutdown", signum)
+            receiver.quit = True
+
+        _ = signal.signal(signal.SIGTERM, terminate)
+        _ = signal.signal(signal.SIGINT, terminate)
+
+        # Loops until receiver.quit is set
+        receiver.receive()
+        logger.info('Advisor Inventory replication service shutting down')

--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -17,7 +17,8 @@
 import prometheus
 import signal
 
-from project_settings import kafka_settings
+# Import directly - causes an error if you get the name wrong.
+from project_settings.kafka_settings import INVENTORY_EVENTS_TOPIC
 from django.core.management.base import BaseCommand
 
 from advisor_logging import logger
@@ -314,9 +315,8 @@ class Command(BaseCommand):
         Run the handler loop continuously until interrupted by SIGTERM.
         """
         logger.info('Advisor Inventory replication service starting up')
-
         receiver = KafkaDispatcher()
-        receiver.register_handler(kafka_settings.INVENTORY_TOPIC, handle_inventory_event)
+        receiver.register_handler(INVENTORY_EVENTS_TOPIC, handle_inventory_event)
 
         def terminate(signum: int, _):
             logger.info("Signal %d received, triggering shutdown", signum)

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -363,7 +363,7 @@ def get_reports_subquery(
     if not org_id:
         return CurrentReport.objects.none()
     host_tags_q = filter_on_host_tags(request)
-    system_type_q = filter_on_system_type(request)
+    system_type_q = filter_on_system_type(request, relation='inventory')
 
     system_profile_filter = filter_multi_param(
         request, 'system_profile', field_prefix='inventory'

--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -1316,7 +1316,7 @@ def request_to_org(request: Request) -> str:
 
 def auth_header_for_testing(
     org_id=None, account=None, supply_http_header=False, username='testing',
-    user_id='01234567-0123-0123-0123-0123456789ab', user_opts={},
+    user_id='16777216', user_opts={},
     system_opts=None, unencoded=False, raw=None, service_account=None
 ) -> dict[str, str]:
     """
@@ -1342,7 +1342,7 @@ def auth_header_for_testing(
             adds the HTTP_ prefix) as opposed to using Django's test client
             (which doesn't).
         username: the username to supply if required (default: 'testing')
-        user_id: the user id to supply if required (default: '123')
+        user_id: the user id to supply if required (default: '16777216')
         user_opts: a dictionary with any extra parameters for the user options
             section.
         system_opts: a dictionary with system options.
@@ -1423,14 +1423,8 @@ def auth_header_for_testing(
         if username is not None:
             user_section['username'] = username
         if user_id is not None:
-            # Don't actually store the user_id as a UUID, just validate that
-            # it is one.
-            try:
-                uuid.UUID(user_id)
-            except ValueError:
-                error_and_deny(
-                    "'user_id' argument to auth_header_for_testing must be a valid UUID"
-                )
+            # This is just a string in the schema, but most of the time it's
+            # given as a largish integer.  Don't do any validation here.
             user_section['user_id'] = user_id
         identity['user'] = user_section
         identity['type'] = 'User'

--- a/api/advisor/api/scripts/compile_advisor_content.py
+++ b/api/advisor/api/scripts/compile_advisor_content.py
@@ -1,0 +1,373 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+from os import path, walk
+import subprocess
+import yaml
+import zlib
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+##############################################################################
+# Read the Insights plugin content and playbook directories and produce the
+# 'dumped' files that Advisor needs to import the content.  This saves us
+# having to transmit the directories as zip files and unpack them and load
+# them in the Advisor container.  Everything has to be done without access to
+# the Advisor database, and preferably with only standard Python libraries.
+##############################################################################
+
+
+content_fields = {'generic', 'more_info', 'reason', 'resolution', 'summary'}
+
+
+##############################################################################
+# Dump file reading and writing
+##############################################################################
+
+RULE_CONTENT_YAML_FILE = 'rule_content.yaml'
+PLAYBOOK_CONTENT_YAML_FILE = 'playbook_content.yaml'
+
+
+def dump_yaml(content, yaml_filename):
+    """
+    Dump data to a YAML file, compressing it if it ends with the .gz extension.
+    """
+    with open(yaml_filename, 'wb') as fh:
+        dump_data = yaml.dump(content).encode('utf-8')
+        if yaml_filename.endswith('.gz'):
+            # Write with max compression and gzip header
+            dump_data = zlib.compress(dump_data, level=9, wbits=25)
+        fh.write(dump_data)
+
+
+##############################################################################
+# Content reading
+##############################################################################
+
+
+def get_field_content(plugin_path, field):
+    """
+    If the content MarkDown file for this field exists in this path, return
+    its content, otherwise return None.
+    """
+    markdown_file = path.join(plugin_path, f"{field}.md")
+    if not path.exists(markdown_file):
+        return None
+    with open(markdown_file, 'r') as fd:
+        return fd.read()
+
+
+def add_markdown_fields(base_data, base_path):
+    """
+    Add any found Markdown fields to the base data.  base_data is modified.
+    """
+    for field in content_fields:
+        content = get_field_content(base_path, field)
+        if content is not None:
+            base_data[field] = content
+
+
+def read_plugin_content(plugin_path):
+    """
+    Read the content in the plugin path and populate a dict with it.  This
+    includes both the plugin.yaml file and any metadata files
+    """
+    # We know there's a plugin.yaml file here because that's what tells us
+    # this is a plugin directory and to read the plugin content.
+    with open(path.join(plugin_path, 'plugin.yaml'), 'r') as fd:
+        plugin_data = yaml.load(fd, yaml.Loader)
+    add_markdown_fields(plugin_data, plugin_path)
+    return plugin_data
+
+
+def read_rule_content(plugin_data, rule_path):
+    """
+    Read the content in the rule path and populate a dict with it.  This
+    includes both the plugin.yaml file and any metadata files
+    """
+    # We know there's a metadata.yaml file here because that's what tells us
+    # this is a rule directory and to read the rule content.
+    rule_content = dict(plugin_data)
+    metadata_filename = path.join(rule_path, 'metadata.yaml')
+    with open(metadata_filename, 'r') as fd:
+        metadata = yaml.load(fd, yaml.Loader)
+    # The actual rule metadata always supplies settings, right?
+    assert metadata, f"Metadata file at {metadata_filename} must have settings"
+    rule_content.update(metadata)
+    add_markdown_fields(rule_content, rule_path)
+    return rule_content
+
+
+def rule_path_to_id(rule_path):
+    """
+    Transform the path into its plugin_name|ERROR_KEY format.
+    """
+    error_key = path.basename(rule_path)
+    plugin_path = path.dirname(rule_path)
+    plugin_name = path.basename(plugin_path)
+    rule_id = f"{plugin_name}|{error_key}"
+    return rule_id
+
+
+def generate_rule_content(content_dir):
+    """
+    Go through the content directory and construct it into rule data.
+    This looks for the `plugin.yaml` as the base directory of a plugin, and
+    then the directories underneath that for the rule data.
+
+    Originally I thought it would be worth using this code just for bulk
+    import, and then using other code for when we only wanted to pick up
+    just the updates since the last time a rule was changed in the database.
+    But it turns out this is fast enough, at least in testing so far, that
+    it's not worth yet trying to write code that reads the `git diff --since`
+    output and just parses those things.
+    """
+    all_rule_data = list()
+    this_plugin_dir = 'no directory'
+    # The tree structure of the rule content dir is something like this:
+    # api/test_content/content/
+    # ├── config.yaml
+    # └── fixture_data
+    #     ├── README.md
+    #     └── test
+    #         ├── plugin.yaml
+    #         ├── Acked_rule
+    #         │   ├── generic.md
+    #         │   ├── metadata.yaml
+    #         │   ├── more_info.md
+    #         │   ├── reason.md
+    #         │   ├── resolution.md
+    #         │   └── summary.md
+    # We search for either the `plugin.yaml` or `metadata.yaml` files to
+    # then get the rule data.  The 'plugin' here is 'test' and the 'error_key'
+    # (though we don't refer to it) is 'Acked_rule'.  Because this is a
+    # depth-first search, the plugin_data will remain the same across all
+    # error keys, and will be read before the metadata.
+    plugin_data = dict()
+    for this_path, dirs, files in walk(content_dir):
+        if 'plugin.yaml' in files:
+            this_plugin_dir = this_path
+            # This is the plugin part of the rule content, which loads the
+            # 'default' content for this rule.  This is then copied and
+            # overwritten by the rule content.
+            plugin_data = read_plugin_content(this_path)
+        # By tradition, rules have an upper-case error key.  Guess what the
+        # test data fixtures do not have?  So no 'path.basename(this_path).isupper()'
+        # test here.  And really we shouldn't assume that error keys will
+        # always be upper case - what distinguishes a rule content directory
+        # is that it's got a metadata.yaml file.
+        elif 'metadata.yaml' in files:
+            assert this_path.startswith(this_plugin_dir)
+            # There's a weird extra condition in the content server manager
+            # code that looks for paths with no yaml files, but we don't seem
+            # to see any of those in the content repository.
+            rule_id = rule_path_to_id(this_path)
+            rule_content = read_rule_content(plugin_data, this_path)
+            rule_content['rule_id'] = rule_id
+            all_rule_data.append(rule_content)
+
+    return all_rule_data
+
+
+##############################################################################
+# Playbook directory processing
+##############################################################################
+
+def get_playbook_name(playbook_data, playbook_filename):
+    """
+    Read the playbook and find its name, possibly having to grab it from the
+    first task.
+    """
+    first = playbook_data[0]
+    if not isinstance(first, dict):
+        logger.error("Playbook %s is malformed", playbook_filename)
+        return 'Unknown playbook'
+    if 'name' in first:
+        return first['name']
+    logger.warning("Playbook %s has no name - trying to find first task?", playbook_filename)
+    if not ('tasks' in first and isinstance(first['tasks'], list)):
+        logger.error("Playbook %s has no tasks", playbook_filename)
+        return 'Unknown playbook'
+    if not (first['tasks'] and 'name' in first['tasks'][0]):
+        logger.error("Playbook %s has no named first task", playbook_filename)
+        return 'Unknown playbook'
+    return first['tasks'][0]['name']
+
+
+def read_playbook(this_path, file):
+    """
+    Read the playbook, and grab a few things from it.  We don't want to store
+    the actual YAML, we store the raw file content, but OTOH we do need to
+    know the description.
+    """
+    playbook_filename = path.join(this_path, file)
+    with open(playbook_filename, 'r') as fh:
+        playbook_content = fh.read()
+    playbook_data = yaml.load(playbook_content, yaml.Loader)
+    assert len(playbook_data) > 0, f"Playbook {playbook_filename} empty?"
+    assert isinstance(playbook_data[0], dict), f"Playbook {playbook_filename} not a dict?"
+    name = get_playbook_name(playbook_data, playbook_filename)
+    return (playbook_content, name)
+
+
+def find_git_root(playbook_dir):
+    """
+    Find the root of the git repository.
+    """
+    command = ['git', '-C', playbook_dir, 'rev-parse', '--show-toplevel']
+    result = subprocess.run(command, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def find_git_hashes(playbook_dir):
+    """
+    Read the git log to determine the latest hash for each file.  More or less
+    drawn from the content server.
+    """
+    command = ['git', '-C', playbook_dir, 'log', '--stat', '--name-only', "--pretty=hash:%H"]
+    last_hash = None
+    hash_for_file = dict()
+    git_proc = subprocess.run(command, capture_output=True)
+    for line in git_proc.stdout.decode().splitlines():
+        # line = line.strip()  -- necessary?
+        if not line:
+            continue
+        if line.startswith('hash:'):
+            last_hash = line[5:]
+            continue
+        if not line.endswith('fixit.yml'):
+            continue
+        # Line here now is the file path and name, starting from the root of
+        # the repository, which might not be the 'playbook_dir' base.
+        if line not in hash_for_file:
+            hash_for_file[line] = last_hash
+
+    return hash_for_file
+
+
+def generate_playbook_content(playbook_dir):
+    """
+    Go through the playbook content directory and get a list of playbooks.
+
+    Advisor currently does not care what's in the Playbook model, it is never
+    served.  It only cares that they exist, and RHINENG-12950 will simplify
+    this down to a simple count in the Rule data.  So we do the minimum we
+    have to at this stage.
+    """
+    if not path.exists(path.join(playbook_dir, 'playbooks')):
+        logger.error(
+            f"Directory {playbook_dir} does not seem to have the playbooks directory"
+        )
+        return
+
+    # In generating content we should not refer to the database.  It's
+    # tempting to cheat here and include the resolution ID, but we can't
+    # store that in a dump...
+
+    playbook_for_rule = dict()
+
+    def fix_type(file):
+        if file.endswith('_fixit.yml'):
+            return file[:-len('_fixit.yml')]
+        else:
+            return 'fix'
+
+    hash_for_file = find_git_hashes(playbook_dir)
+    git_root = find_git_root(playbook_dir)
+    # Note that this also has to cope with being given test data that's not
+    # in a git repository.  It seems to work now.
+
+    for this_path, dirs, files in walk(path.join(playbook_dir, 'playbooks')):
+        # If we ever find a playbook repository that uses anything other than
+        # 'rhel_host' as its system type... then we need to change to something
+        # like...
+        # for dir_name in dirsp
+        #     if dir_name in system_type_set:
+        #         # remember this path and associate with this system type
+        # Rules are still only associated with one system type though so we
+        # rely on the system type definition in the rule.
+        if this_path.endswith('rhel_host'):
+            rule_id = rule_path_to_id(path.dirname(this_path))
+            # We're going to store some playbooks that might not appear in the
+            # database here...
+            for file in files:
+                if not file.endswith('fixit.yml'):
+                    continue
+                (playbook_content, description) = read_playbook(this_path, file)
+                # This key must match the construction of the `rule_id_type`
+                # annotation below, as the unique key we're comparing to.
+                fix = fix_type(file)
+                key = rule_id + fix
+
+                # Construct absolute path
+                playbook_abs_path = path.join(this_path, file)
+                # Convert to relative path from git root for hash lookup
+                playbook_rel_path = path.relpath(playbook_abs_path, git_root)
+
+                playbook_for_rule[key] = {
+                    'rule_id': rule_id,
+                    'type': fix,
+                    'play': playbook_content,
+                    'description': description,
+                    'path': playbook_abs_path,
+                    'version': hash_for_file.get(playbook_rel_path)
+                }
+
+    return playbook_for_rule
+
+
+##############################################################################
+# Main command
+##############################################################################
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)s: %(message)s',
+        stream=__import__('sys').stdout
+    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--content-repo-path', '-c', type=str, required=True,
+        help='The path to the Insights content repository',
+    )
+    parser.add_argument(
+        '--playbook-repo-path', '-p', type=str,
+        help='The path to the Insights playbook repository (or -c dir)',
+    )
+    parser.add_argument(
+        '--compress', '-z', default=False, action='store_true',
+        help="Compress dumped content"
+    )
+
+    args = parser.parse_args()
+    if not path.exists(args.content_repo_path):
+        logger.error(f"Cannot find path {args.content_repo_path}")
+    playbook_repo_path = args.playbook_repo_path
+    if not playbook_repo_path:
+        playbook_repo_path = args.content_repo_path
+
+    content = generate_rule_content(args.content_repo_path)
+    logger.info(f"{len(content)} rules loaded")
+    playbooks = generate_playbook_content(playbook_repo_path)
+    logger.info(f"{len(playbooks)} playbooks loaded")
+    gz_extension = '.gz' if args.compress else ''
+    dump_yaml(content, f'{RULE_CONTENT_YAML_FILE}{gz_extension}')
+    dump_yaml(playbooks, f'{PLAYBOOK_CONTENT_YAML_FILE}{gz_extension}')

--- a/api/advisor/api/tests/__init__.py
+++ b/api/advisor/api/tests/__init__.py
@@ -22,7 +22,7 @@ from django.utils import timezone
 
 from api import kessel
 from api.models import InventoryHost
-from api.permissions import identity_to_subject
+from api.permissions import identity_to_subject, auth_header_for_testing
 
 
 class constants(object):
@@ -45,9 +45,8 @@ class constants(object):
     alternate_org = '9988776'
     host_tag_org = '1000000'
     test_username = 'testing'
-    test_user_id = '01234567-0123-0123-0123-0123456789ab'
-    # SERVICEACCOUNT01
-    test_service_user_id = '53455256-4943-4541-4343-4f554e543031'
+    test_user_id = '16777216'
+    test_service_user_id = '33554432'
 
     service_account = {
         'client_id': '10203040-5060-7080-90a0-b0c0d0e0f000',
@@ -294,12 +293,12 @@ class constants(object):
 
     # Kessel RBAC permission constants
     kessel_std_org_obj = kessel.Workspace(kessel_std_workspace_id).to_ref().as_pb2()
-    kessel_std_user_identity_dict = {  # very minimal
-        'type': 'User', 'user': {'user_id': test_user_id}
-    }
-    kessel_std_service_identity_dict = {  # also very minimal
-        'type': 'ServiceAccount', 'service_account': {'user_id': test_service_user_id}
-    }
+    kessel_std_user_identity_dict = auth_header_for_testing(
+        user_id=test_user_id, unencoded=True
+    )['identity']
+    kessel_std_service_identity_dict = auth_header_for_testing(
+        service_account={'user_id': test_service_user_id}, unencoded=True
+    )['identity']
     kessel_std_user_obj = identity_to_subject(kessel_std_user_identity_dict).as_pb2()
     kessel_std_svc_user_obj = identity_to_subject(kessel_std_service_identity_dict).as_pb2()
     kessel_host_01_obj = kessel.Host(host_01_uuid).to_ref().as_pb2()

--- a/api/advisor/api/tests/test_advisor_inventory_service.py
+++ b/api/advisor/api/tests/test_advisor_inventory_service.py
@@ -1,0 +1,466 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+# import responses
+from copy import deepcopy
+from datetime import datetime, timedelta
+
+from django.test import TestCase  # , override_settings
+from django.utils import timezone
+
+from feature_flags import set_unleash_flag, FLAG_INVENTORY_EVENT_REPLICATION
+from kafka_utils import JsonValue
+# from project_settings import kafka_settings
+from api.management.commands.advisor_inventory_service import (
+    handle_inventory_event, handle_created_event, handle_deleted_event
+)
+from api.models import CurrentReport, Host, HostAck, InventoryHost, Upload
+from api.tests import constants
+
+#############################################################################
+# Message structures
+#############################################################################
+new_host_id: str = "00112233-4455-6677-8899-012345678920"
+new_host_name: str = "new_host_20.example.org"
+new_host_satid: str = "AABBCCDD-EEFF-FFEE-DDCC-AABBCCDDEE20"
+# Note that we want to make sure that we use current timestamps so this
+# data appears in current InventoryHost searches.
+now: datetime = timezone.now()
+plus7days: timedelta = timedelta(days=7)
+stale_time: str = (now + plus7days * 1).isoformat()
+stale_warn_time: str = (now + plus7days * 2).isoformat()
+cull_time: str = (now + plus7days * 3).isoformat()
+create_new_host_msg: dict[str, JsonValue] = {
+    # A minimal structure for a new host event.  We don't really need to test
+    # that fields we want to ignore are in fact ignored...
+    'type': 'created',
+    "timestamp": "<timestamp>",
+    "metadata": {
+        "request_id": "<request_id>",
+    },
+    "host": {
+        "id": new_host_id,
+        "account": constants.standard_acct,
+        "org_id": constants.standard_org,
+        "display_name": new_host_name,
+        "insights_id": "FFEEDDCC-BBAA-9988-7766-554433221120",
+        "satellite_id": new_host_satid,
+        "created": "2025-11-28T03:53:20Z",
+        "updated": "2025-11-28T03:53:20Z",
+        "tags": [],
+        "stale_timestamp": stale_time,
+        "stale_warning_timestamp": stale_warn_time,
+        "culled_timestamp": cull_time,
+        "system_profile": {
+            "ansible": "", "bootc_status": "", "host_type": "", "mssql": "",
+            "operating_system": "", "owner_id": "", "rhc_client_id": "",
+            "sap": "", "sap_system": "", "sap_sids": "",
+            "system_update_method": ""
+        },
+        "per_reporter_staleness": {"puptoo": {
+            "stale_timestamp": stale_time,
+            "stale_warning_timestamp": stale_warn_time,
+            "culled_timestamp": cull_time
+        }},
+        "groups": [],
+    }
+}
+update_host_msg: dict[str, JsonValue] = {
+    # A minimal structure for a new host event.  We don't really need to test
+    # that fields we want to ignore are in fact ignored...
+    'type': 'updated',
+    "timestamp": "<timestamp>",
+    "metadata": {
+        "request_id": "<request_id>",
+    },
+    "host": {
+        "id": constants.host_01_uuid,
+        "account": constants.standard_acct,
+        "org_id": constants.standard_org,
+        "display_name": constants.host_01_name,
+        "insights_id": constants.host_01_inid,
+        "satellite_id": '',
+        "created": "2025-12-01T03:09:27Z",
+        "updated": "2025-12-01T03:09:27Z",
+        "tags": [],
+        "stale_timestamp": stale_time,
+        "stale_warning_timestamp": stale_warn_time,
+        "culled_timestamp": cull_time,
+        "system_profile": {  # taken from the fixture, only certain values copied
+            "arch": "x86_64", "bios_vendor": "Dell Inc.", "bios_version": "2.8.0",
+            "bios_release_date": "13/06/2017", "cores_per_socket": 8,
+            "number_of_sockets": 2, "infrastructure_type": "physical",
+            "system_memory_bytes": 134927265792, "satellite_managed": True,
+            "insights_egg_version": "3.0.182-1", "sap_system": True,
+            "insights_client_version": "3.0.14", "sap_sids": ["E01", "E02"],
+            "os_release": "Red Hat Enterprise Linux Server",
+            "owner_id": "55df28a7-d7ef-48c5-bc57-8967025399b1",
+            "operating_system": {"name": "RHEL", "major": 7, "minor": 5},
+            "system_update_method": "dnf",
+            "workloads": {
+                "sap": {
+                    "sap_system": True, "version": "2.00.122.04.1478575636",
+                    "sids": ["E01", "E02"], "instance_number": "00"
+                }
+            }
+        },
+        "per_reporter_staleness": {"puptoo": {
+            "stale_timestamp": stale_time,
+            "stale_warning_timestamp": stale_warn_time,
+            "culled_timestamp": cull_time
+        }},
+        "groups": [],
+    }
+}
+delete_host_msg: dict[str, JsonValue] = {  # Pick a host with acks, hostacks, etc.
+    "type": "delete",
+    "id": constants.host_01_uuid,
+    "timestamp": "<delete timestamp>",
+    # Test handling of no account number
+    "org_id": constants.standard_org,
+    "insights_id": constants.host_01_inid,
+    "request_id": "<request id>",
+}
+
+
+#############################################################################
+# Test class
+#############################################################################
+
+
+class TestAdvisorInventoryServer(TestCase):
+    """
+    Test the Advisor Inventory Server functionality.
+
+    Because the command runs as a long-running service, we need to test its
+    parts by directly calling the functions that handle inventory events.
+    Until we find a way to simulate a Kafka queue that actually sends
+    messages to the consumer invoked in KafkaDispatcher, this will have to do.
+    """
+    fixtures = [
+        'rulesets', 'system_types', 'rule_categories', 'upload_sources',
+        'basic_test_data'
+    ]
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_message_dispatch(self):
+        """
+        Test that the handle_inventory_event function dispatches messages
+        correctly.
+        """
+        with self.assertLogs(logger='advisor-log') as logs:
+            # No 'type' field in message
+            handle_inventory_event('topic', {'key': 'value'})
+            self.assertEqual(len(logs.output), 1)
+            self.assertEqual(
+                "ERROR:advisor-log:Message received on topic topic with no 'type' field",
+                logs.output[0]
+            )
+            # Unknown message type
+            handle_inventory_event('topic', {'type': 'foo'})
+            self.assertEqual(
+                "ERROR:advisor-log:Inventory event: Unknown message type: foo",
+                logs.output[1]
+            )
+            self.assertEqual(len(logs.output), 2)
+        # Test the actual calls to create and delete in their own test methods.
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_created_message_success(self):
+        """
+        Test successful creation and updating of hosts.
+        """
+        # Start by processing the create message using handle_inventory_event
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+            handle_inventory_event('topic', create_new_host_msg)
+            # We aim to remove this debug log soon but in the meantime
+            log_lines: list[str] = list(filter(
+                lambda line: 'Using Cyndi replication view' not in line, logs.output
+            ))
+            self.assertEqual(
+                "INFO:advisor-log:Handling 'created' event",
+                log_lines[0]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Created Inventory host %s account %s org_id %s" % (
+                    new_host_id, constants.standard_acct, constants.standard_org
+                ),
+                log_lines[1]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Created Host %s account %s org_id %s" % (
+                    new_host_id, constants.standard_acct, constants.standard_org
+                ),
+                log_lines[2]
+            )
+            self.assertEqual(len(log_lines), 3)
+            # Check existence of InventoryHost record
+            self.assertEqual(
+                InventoryHost.objects.filter(id=new_host_id).count(),
+                1
+            )
+            new_ihost = InventoryHost.objects.get(id=new_host_id)
+            # Probably don't need to check the entire data set.
+            self.assertEqual(str(new_ihost.id), new_host_id)
+            self.assertEqual(new_ihost.account, constants.standard_acct)
+            self.assertEqual(new_ihost.org_id, constants.standard_org)
+            # Check existence of Host record
+            self.assertEqual(
+                Host.objects.filter(inventory_id=new_host_id).count(),
+                1
+            )
+            new_host = Host.objects.get(inventory_id=new_host_id)
+            self.assertEqual(str(new_host.satellite_id).upper(), new_host_satid)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_created_message_fail_missing_key(self):
+        """
+        Test all the missing keys being detected in the create message
+        """
+        modified_msg: dict[str, JsonValue]
+        for missing_field in (
+            'metadata', 'request_id', 'host', 'id', 'display_name', 'org_id',
+            'tags', 'groups', 'created', 'updated', 'insights_id',
+        ):
+            with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+                modified_msg = deepcopy(create_new_host_msg)
+                # Have to delete bits of the structure - not linear
+                match missing_field:
+                    case 'request_id':
+                        del modified_msg['metadata']['request_id']
+                    case 'host' | 'metadata':
+                        del modified_msg[missing_field]
+                    case host_field:  # everything else inside host
+                        del modified_msg['host'][host_field]
+                handle_created_event(modified_msg)
+                # We aim to remove this debug log soon but in the meantime
+                log_lines: list[str] = list(filter(
+                    lambda line: 'Using Cyndi replication view' not in line, logs.output
+                ))
+                self.assertEqual(
+                    "INFO:advisor-log:Handling 'created' event",
+                    log_lines[0]
+                )
+                if missing_field == 'metadata':
+                    this_req_id = 'metadata'
+                elif missing_field == 'request_id':
+                    this_req_id = 'unknown request_id'
+                else:
+                    this_req_id = modified_msg['metadata']['request_id']
+                self.assertEqual(
+                    "ERROR:advisor-log:Request %s: Inventory created event did not contain required key '%s'" % (
+                        this_req_id, missing_field
+                    ),
+                    log_lines[1],
+                    f"Field {missing_field} is required"
+                )
+                self.assertEqual(len(log_lines), 2)
+        # The optional fields should allow a success though.
+        # This also tests that receiving a 'create' event on a host that
+        # already exists is treated as an update.
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+            modified_msg = deepcopy(create_new_host_msg)
+            del modified_msg['host']['account']
+            handle_created_event(modified_msg)
+            log_lines: list[str] = list(filter(
+                lambda line: 'Using Cyndi replication view' not in line, logs.output
+            ))
+            self.assertEqual(
+                "INFO:advisor-log:Handling 'created' event",
+                log_lines[0]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Created Inventory host %s account %s org_id %s" % (
+                    new_host_id, None, constants.standard_org
+                ),
+                log_lines[1]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Created Host %s account %s org_id %s" % (
+                    new_host_id, None, constants.standard_org
+                ),
+                log_lines[2]
+            )
+            self.assertEqual(len(log_lines), 3)
+            # Check existence of InventoryHost record
+            self.assertEqual(
+                InventoryHost.objects.filter(id=new_host_id).count(),
+                1
+            )
+            self.assertEqual(
+                Host.objects.filter(inventory_id=new_host_id).count(),
+                1
+            )
+            host = Host.objects.get(inventory_id=new_host_id)
+            self.assertEqual(str(host.satellite_id), new_host_satid.lower())
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+            modified_msg = deepcopy(create_new_host_msg)
+            del modified_msg['host']['satellite_id']
+            handle_created_event(modified_msg)
+            log_lines: list[str] = list(filter(
+                lambda line: 'Using Cyndi replication view' not in line, logs.output
+            ))
+            self.assertEqual(
+                "INFO:advisor-log:Handling 'created' event",
+                log_lines[0]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Updated Inventory host %s account %s org_id %s" % (
+                    new_host_id, constants.standard_acct, constants.standard_org
+                ),
+                log_lines[1]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Updated Host %s account %s org_id %s" % (
+                    new_host_id, constants.standard_acct, constants.standard_org
+                ),
+                log_lines[2]
+            )
+            self.assertEqual(len(log_lines), 3)
+            # Check existence of InventoryHost record
+            self.assertEqual(
+                InventoryHost.objects.filter(id=new_host_id).count(),
+                1
+            )
+            self.assertEqual(
+                Host.objects.filter(inventory_id=new_host_id).count(),
+                1
+            )
+            host = Host.objects.get(inventory_id=new_host_id)
+            # Because the host is being updated, the Satellite ID has carried
+            # over from the previous update.
+            self.assertEqual(str(host.satellite_id), new_host_satid.lower())
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_updated_message_success(self):
+        """
+        Test successful updating of existing host.
+        """
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+            # Call via handle_inventory_event to exercise update handling
+            handle_inventory_event('topic', update_host_msg)
+            # Now check the logs
+            # We aim to remove this debug log soon but in the meantime
+            log_lines: list[str] = list(filter(
+                lambda line: 'Using Cyndi replication view' not in line, logs.output
+            ))
+            self.assertEqual(
+                "INFO:advisor-log:Handling 'updated' event",
+                log_lines[0]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Updated Inventory host %s account %s org_id %s" % (
+                    constants.host_01_uuid, constants.standard_acct, constants.standard_org
+                ),
+                log_lines[1]
+            )
+            self.assertEqual(
+                "DEBUG:advisor-log:Updated Host %s account %s org_id %s" % (
+                    constants.host_01_uuid, constants.standard_acct, constants.standard_org
+                ),
+                log_lines[2]
+            )
+            self.assertEqual(len(log_lines), 3)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_deleted_message_success(self):
+        """
+        Test successful deletion of existing host.
+        """
+        # Call handle_created_event directly
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+            handle_inventory_event('topic', delete_host_msg)
+            # Now check the logs
+            # We aim to remove this debug log soon but in the meantime
+            log_lines: list[str] = list(filter(
+                lambda line: 'Using Cyndi replication view' not in line, logs.output
+            ))
+            self.assertEqual(
+                "INFO:advisor-log:Handling 'deleted' event",
+                log_lines[0]
+            )
+            self.assertEqual(
+                "INFO:advisor-log:Received DELETE event from Inventory for host %s." % (
+                    constants.host_01_uuid
+                ),
+                log_lines[1]
+            )
+            self.assertEqual(
+                "INFO:advisor-log:Deleted %d records based on Host: %s." % (
+                    9, "{'api.CurrentReport': 4, 'api.HostAck': 1, 'api.Upload': 3, 'api.Host': 1}"
+                ),
+                log_lines[2]
+            )
+            self.assertEqual(
+                "INFO:advisor-log:Deleted %d records based on InventoryHost: %s." % (
+                    1, "{'api.InventoryHost': 1}"
+                ),
+                log_lines[3]
+            )
+            self.assertEqual(len(log_lines), 4)
+        # Now test that we actually deleted all those things:
+        self.assertEqual(
+            InventoryHost.objects.filter(id=constants.host_01_uuid).count(),
+            0
+        )
+        self.assertEqual(
+            Host.objects.filter(inventory_id=constants.host_01_uuid).count(),
+            0
+        )
+        self.assertEqual(
+            Upload.objects.filter(host_id=constants.host_01_uuid).count(),
+            0
+        )
+        self.assertEqual(
+            CurrentReport.objects.filter(host_id=constants.host_01_uuid).count(),
+            0
+        )
+        self.assertEqual(
+            HostAck.objects.filter(host_id=constants.host_01_uuid).count(),
+            0
+        )
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_deleted_message_fail_missing_key(self):
+        """
+        Test all the missing keys being detected in the delete message
+        """
+        # account is optional and missing account is tested above.
+        for missing_field in ('id', 'org_id', 'request_id'):
+            with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+                modified_msg: dict[str, JsonValue] = deepcopy(delete_host_msg)
+                del modified_msg[missing_field]
+                handle_deleted_event(modified_msg)
+                # We aim to remove this debug log soon but in the meantime
+                log_lines: list[str] = list(filter(
+                    lambda line: 'Using Cyndi replication view' not in line, logs.output
+                ))
+                self.assertEqual(
+                    "INFO:advisor-log:Handling 'deleted' event",
+                    log_lines[0]
+                )
+                if missing_field == 'request_id':
+                    this_req_id = 'unknown request_id'
+                else:
+                    this_req_id = modified_msg['request_id']
+                self.assertEqual(
+                    "ERROR:advisor-log:Request %s: Inventory delete event did not contain required key '%s'" % (
+                        this_req_id, missing_field
+                    ),
+                    log_lines[1],
+                    f"Field {missing_field} is required"
+                )
+                self.assertEqual(len(log_lines), 2)

--- a/api/advisor/api/tests/test_import_content_command.py
+++ b/api/advisor/api/tests/test_import_content_command.py
@@ -304,6 +304,8 @@ class ImportContentTestCase(TestCase):
             active_rule.playbooks()[0].description,
             'Fix for Active_rule on rhel/host'
         )
+        # Playbook version hash should be matched
+        self.assertIsNotNone(active_rule.playbooks()[0].version)
 
         # Then test the differences
         acked_rule = Rule.objects.get(rule_id=constants.acked_rule)
@@ -905,7 +907,7 @@ class CoverageTestCase(TestCase):
 
     def test_read_playbook_failures(self):
         playbook_file = join(PATH_TO_TEST_CONTENT_REPO, 'playbook.yaml')
-        from api.management.commands.import_content import read_playbook
+        from api.scripts.compile_advisor_content import read_playbook
         with FileDeleter(playbook_file):
             # First: no name but first task is named
             playbook_content = [{
@@ -960,7 +962,8 @@ class CoverageTestCase(TestCase):
             playbook_3 = playbooks[rule_fix]
             self.assertEqual(playbook_3['description'], 'step 3')
             self.assertEqual(playbook_3['play'], '- name: step 3\n')
-            self.assertEqual(playbook_3['path'], '/playbooks/rhel_host/fixit.yml')
+            # No git repository = full path including temp_dir.
+            self.assertEqual(playbook_3['path'], f'{temp_dir}/playbooks/rhel_host/fixit.yml')
             # rule_id contains the temp_dir name
             self.assertEqual(playbook_3['rule_id'], rule_id)
             self.assertEqual(playbook_3['type'], 'fix')

--- a/api/advisor/api/tests/test_kafka_utils.py
+++ b/api/advisor/api/tests/test_kafka_utils.py
@@ -1,0 +1,139 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+from django.test import TestCase  # , override_settings
+
+from kafka_utils import (
+    DummyMessage, DummyConsumer, JsonValue, KafkaDispatcher,
+    send_kafka_message,
+)
+
+
+class DummyHandler:
+    """
+    Record the messages sent to the handler by the dispatcher.
+    """
+    def __init__(self, name: str):
+        self.handled: dict[str, list[JsonValue]] = {}
+        self.__name__: str = name
+
+    def __call__(self, topic: str, message: JsonValue):
+        if topic not in self.handled:
+            self.handled[topic] = []
+        self.handled[topic].append(message)
+
+    def reset(self):
+        self.handled = {}
+
+
+class TestKafkaUtils(TestCase):
+    """
+    Test the Kafka Utils functionality, particularly around the KafkaDispatcher.
+    """
+
+    def test_message_failures(self):
+        """
+        Test that the server handles malformed and incorrect messages correctly.
+        """
+        consumer = DummyConsumer()
+        # A malformed message
+        malformed = DummyMessage(topic="malformed", value=b'JSON{no=work}')
+        consumer.add_message_obj(malformed)
+        # A message for a spurious topic
+        consumer.add_message(topic="spurious", value={"key": "value"})
+        # A message with a set error
+        error_msg = DummyMessage(topic="error", value=b'{"error": "error"}')
+        error_msg.set_error("Dramatic exit, scene left!")
+        # Just test that we can set a partition, it's ignored.
+        error_msg.set_partition(1)
+        consumer.add_message_obj(error_msg)
+
+        def error_prone_handler(topic: str, body: JsonValue):
+            raise ValueError(f"Error from {topic=} with {body=}")
+
+        consumer.add_message(topic='error', value={'data': 'something else'})
+
+        # Call the server with the consumer
+        dispatcher = KafkaDispatcher(consumer)
+        handler = DummyHandler('malform_handler')
+        with self.assertLogs(logger='advisor-log') as logs:
+            dispatcher.register_handler('malformed', handler)
+            # Duplicate handler check
+            dispatcher.register_handler('malformed', handler)
+            # Error thrown by handler
+            dispatcher.register_handler('error', error_prone_handler)
+            # quit out cleanly when we run out of messages
+            consumer.set_dispatcher_quit(dispatcher)
+            dispatcher.receive()
+            # No messages handled because it caught errors.
+            self.assertEqual(handler.handled, {})
+            # Logs should recognise failures:
+            self.assertIn(
+                'Topic malformed already has function malform_handler '
+                'registered when trying to register function malform_handler.  '
+                'Ignoring this new handler.',
+                logs.output[0]
+            )
+            self.assertIn(  # full log includes a traceback...
+                'Malformed JSON when handling malformed',
+                logs.output[1]
+            )
+            self.assertEqual(
+                "INFO:advisor-log:Received message for unregistered topic 'spurious'",
+                logs.output[2]
+            )
+            self.assertEqual(
+                "ERROR:advisor-log:Dramatic exit, scene left!",
+                logs.output[3]
+            )
+            self.assertIn(  # full log includes a traceback...
+                "ValueError: Error from topic='error' with body={'data': 'something else'}",
+                logs.output[4]
+            )
+
+    def test_send_kafka_message(self):
+        import kafka_utils
+        current_producer = kafka_utils.producer
+
+        # Test logs if no producer
+        kafka_utils.producer = None
+        with self.assertLogs(logger='advisor-log') as logs:
+            send_kafka_message('test_topic', {'data': 'test_data'})
+            self.assertEqual(
+                logs.output[0], "ERROR:advisor-log:Kafka producer is not initialized"
+            )
+        kafka_utils.producer = current_producer
+        current_producer.reset_calls()
+
+        # Now test that we actually did something with our producer
+        with self.assertLogs(logger='advisor-log') as logs:
+            send_kafka_message('test_topic', {'data': 'test_data'})
+            self.assertEqual(current_producer.poll_calls, 1)
+            self.assertEqual(
+                current_producer.produce_calls[0]['topic'], 'test_topic'
+            )
+            self.assertEqual(
+                current_producer.produce_calls[0]['message'], b'{"data": "test_data"}'
+            )
+            self.assertEqual(
+                current_producer.produce_calls[0]['callback'], 'report_delivery_callback'
+            )
+            self.assertEqual(current_producer.flush_calls, 1)
+            # The report_delivery_callback function should have logged
+            # delivery of the message.
+            self.assertEqual(
+                logs.output[0], "INFO:advisor-log:Kafka message delivered to test_topic [0]"
+            )

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -549,10 +549,6 @@ class BadUsesOfAuthHeaderTestCase(TestCase):
         with self.assertRaises(AuthenticationFailed):
             _ = auth_header_for_testing(user_opts={'foo': 1}, system_opts={'bar': 2})
 
-    def test_user_id_not_uuid(self):
-        with self.assertRaises(AuthenticationFailed):
-            _ = auth_header_for_testing(user_id='not-a-uuid')
-
 
 class GetWorkspaceIdTestCase(TestCase):
     @responses.activate

--- a/api/advisor/api/views/rules.py
+++ b/api/advisor/api/views/rules.py
@@ -38,6 +38,7 @@ from api.filters import (
     sort_params_to_fields, sort_param_enum, filter_on_display_name,
     systems_detail_name_query_param, host_group_name_query_param,
     topic_query_param, filter_on_topic, update_method_query_param,
+    system_type_query_param,
 )
 from api.models import (
     Ack, CurrentReport, HostAck, Resolution, Rule,
@@ -579,6 +580,7 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
             filter_system_profile_sap_sids_contains_query_param,
             filter_system_profile_mssql_query_param,
             filter_system_profile_ansible_query_param,
+            system_type_query_param,
         ],
         responses={200: SystemsForRuleSerializer(many=False)},
     )
@@ -629,6 +631,7 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
             filter_system_profile_sap_sids_contains_query_param,
             filter_system_profile_mssql_query_param,
             filter_system_profile_ansible_query_param,
+            system_type_query_param,
         ],
         responses={200: SystemsDetailSerializer(many=True)},
         # should_page=True,  # How do we support this now?

--- a/api/advisor/kafka_utils.py
+++ b/api/advisor/kafka_utils.py
@@ -16,45 +16,375 @@
 
 import app_common_python
 from advisor_logging import logger
-from confluent_kafka import Producer
-from json import dumps as json_dumps
+# from collections.abc import Callable as AbcCallable
+from confluent_kafka import Consumer, KafkaError, Producer
+import json
+from typing import Callable, TypedDict
 
+import confluent_kafka
 from project_settings import kafka_settings as kafka_settings
+
+from django.core.signals import request_started, request_finished
 
 cfg = app_common_python.LoadedConfig
 
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+type HandlerFunc = Callable[[str, JsonValue], None]
 
-def topic(t):
-    return app_common_python.KafkaTopics[t].name
+
+class HandlerEntry(TypedDict):
+    handler: HandlerFunc
+    filters: dict[str, str]
 
 
-def write_cert(cert):
-    with open('/opt/certs/kafka-cacert', 'w') as f:
-        f.write(cert)
+type HandlerDataValue = HandlerEntry
 
+
+class ProducerEntry(TypedDict):
+    topic: str
+    message: bytes | None
+    callback: str | None
+
+
+type ProducerEntryValue = ProducerEntry
+
+
+duplicate_handler_warning_message = (
+    'Topic %s already has function %s registered when trying to ' +  # noqa: W504
+    'register function %s.  Ignoring this new handler.'
+)
+
+
+#############################################################################
+# Dummy classes for use during testing
+
+class DummyMessage():
+    """
+    A dummy Kafka message for use during testing.
+
+    Do not base this on confluent_kafka.Message because it seems to have a
+    weird initialisation process that we don't want to follow for tests.
+    """
+    def __init__(self, topic: str, value: bytes, headers: list[tuple[str, bytes]] | None = None):
+        self._topic: str = topic
+        self._value: bytes = value
+        self._headers: list[tuple[str, bytes]] | None = headers
+        self._partition: int = 0
+        self._error: str = ''
+
+    def topic(self) -> str:
+        return self._topic
+
+    def value(self) -> bytes:
+        return self._value
+
+    def headers(self) -> list[tuple[str, bytes]] | None:
+        return self._headers
+
+    def set_partition(self, partition: int):
+        self._partition = partition
+
+    def partition(self) -> int:
+        return self._partition
+
+    def set_error(self, error: str):
+        self._error = error
+
+    def error(self):
+        return self._error
+
+
+class DummyProducer:
+    """
+    A dummy Kafka producer for use during testing.
+    """
+    def __init__(self, *args, **kwargs):
+        self.poll_calls: int = 0
+        self.produce_calls: list[ProducerEntryValue] = []
+        self.flush_calls: int = 0
+
+    def poll(self, _time: int):
+        self.poll_calls += 1
+
+    def produce(self, topic: str, message: bytes, callback: Callable | None = None):
+        self.produce_calls.append({
+            'topic': topic,
+            'message': message,
+            'callback': callback.__name__ if callback else None,
+        })
+        if callback:
+            dummy_message = DummyMessage(topic, message, headers=None)
+            callback(err=None, msg=dummy_message)
+
+    def flush(self):
+        self.flush_calls += 1
+
+    def reset_calls(self):
+        self.poll_calls = 0
+        self.produce_calls = []
+        self.flush_calls = 0
+
+
+class DummyConsumer():
+    """
+    A dummy Kafka consumer for use during testing.
+
+    Usage:
+        consumer = DummyConsumer()
+        consumer.add_message('topic-name', {'key': 'value'})
+        consumer.add_message('topic-name', {'key': 'value2'}, headers=[('service', b'tasks')])
+
+        # Now when poll() is called, it will return these messages in order
+    """
+    def __init__(self, *args, **kwargs):
+        self.messages: list[DummyMessage | None] = []
+        self.message_index: int = 0
+        self.subscribed_topics: list[str] = []
+        self.closed: bool = False
+        self.dispatcher_to_quit: 'KafkaDispatcher' | None = None
+
+    def add_message(
+        self, topic: str, value: JsonValue, headers: list[tuple[str, bytes]] | None = None
+    ):
+        """
+        Add a message to the queue that will be returned by poll().
+        """
+        message_value = json.dumps(value).encode('utf-8')
+        self.messages.append(DummyMessage(topic, message_value, headers))
+
+    def add_message_obj(self, message: DummyMessage):
+        """
+        Add a message object to the queue that will be returned by poll().
+        """
+        self.messages.append(message)
+
+    def set_dispatcher_quit(self, dispatcher: 'KafkaDispatcher'):
+        """
+        When we reach the end of the message queue, set the 'quit' flag on
+        the dispatcher.  This is mainly for testing, to save having to have a
+        sentinel message.
+        """
+        self.dispatcher_to_quit = dispatcher
+
+    def subscribe(self, topics: list[str]):
+        """
+        Subscribe to topics.
+        """
+        self.subscribed_topics = topics
+        # Because the handler subscribes to the list of topics after the dummy
+        # consumer has added them as test data, should we check at this point
+        # that indeed those messages are all in the subscribed topics?  Maybe
+        # we want to see if the handler fails correctly?
+
+    def poll(self, timeout: int = 0) -> DummyMessage | None:
+        """
+        Return the next message in the queue, or None if no more messages.
+        """
+        if self.closed:
+            if self.dispatcher_to_quit:
+                self.dispatcher_to_quit.quit = True
+                return None
+            else:
+                raise KafkaError(KafkaError._PARTITION_EOF, "Consumer is closed")
+        if self.message_index < len(self.messages):
+            message = self.messages[self.message_index]
+            self.message_index += 1
+            return message
+        self.closed = True
+        # This would be a good point for the calling message handler to have
+        # set up a function which sets the KafkaHandler's `quit` property.
+        return None
+
+    def close(self):
+        """Close the consumer."""
+        self.closed = True
+
+
+#############################################################################
+# Setup
 
 producer = None
-if kafka_settings.WEBHOOKS_TOPIC:
-    logger.debug(f"Creating producer for topic: {kafka_settings.WEBHOOKS_TOPIC}")
+if not kafka_settings.KAFKA_SETTINGS:
+    # This means that we've been misconfigured
+    logger.error("Kafka producer settings required to send messages")
+elif not kafka_settings.KAFKA_SETTINGS.get('bootstrap.servers'):
+    # This means that we've been configured but from the Dev environment,
+    # which doesn't include a default bootstrap server.  So we use the dummy
+    # class above to just pretend to do stuff.
+    logger.warning("Using dummy Kakfa producer")
+    producer = DummyProducer()
+else:
     producer = Producer(kafka_settings.KAFKA_SETTINGS)
 
 
-def report_delivery_callback(err, msg):
-    """ Called once for each message produced to indicate delivery result.
-        Triggered by poll() or flush(). """
-    if err is not None:
-        logger.error('Webhook event message delivery failed: {}'.format(err))
-    else:
-        logger.info('Webhook event message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+#############################################################################
+# Message delivery callback
 
-
-def send_webhook_event(event_msg):
-    if kafka_settings.WEBHOOKS_TOPIC:
-        producer.poll(0)
-        logger.info("Producing webhook event msg: %s", event_msg)
-        send_msg = json_dumps(event_msg).encode('utf-8')
-        producer.produce(
-            kafka_settings.WEBHOOKS_TOPIC, send_msg,
-            callback=report_delivery_callback
+def report_delivery_callback(
+    err: Exception | None, msg: confluent_kafka.Message | DummyMessage
+):
+    """
+    Called once for each message produced to indicate delivery result.
+    Triggered by poll() or flush().
+    """
+    if err is None:
+        logger.info(
+            'Kafka message delivered to %s [%s]',
+            msg.topic(), msg.partition()
         )
-        producer.flush()
+    else:
+        logger.error('Kafka message delivery failed: {}'.format(err))
+
+
+def send_kafka_message(topic: str, message: JsonValue):
+    """
+    Simple helper to send a message on that topic.
+    """
+    if producer is None:
+        logger.error("Kafka producer is not initialized")
+        return
+    producer.poll(0)
+    encoded_message = json.dumps(message).encode('utf8')
+    producer.produce(topic, encoded_message, callback=report_delivery_callback)
+    producer.flush()
+
+
+def send_webhook_event(event_msg: JsonValue):
+    # For compatibility - replace with direct calls to send_kafka_message
+    send_kafka_message(kafka_settings.WEBHOOKS_TOPIC, event_msg)
+
+
+#############################################################################
+# Kafka message dispatch service class
+
+class KafkaDispatcher(object):
+    """
+    Dispatches messages from Kafka to handlers based on their topic.  This
+    handles the necessary boilerplate around receiving the message from Kafka,
+    checking that it's valid, decoding it from JSON into a structure, and
+    then processing that structure.
+
+    Usage:
+
+    >>> def topic_handler_fn(topic, body):
+    ...     print(f"Received {body['name']} message from {topic}")
+    ...
+    >>> dispatcher = KafkaDispatcher()
+    >>> dispatcher.register_handler("this topic", topic_handler_fn)
+    >>> dispatcher.receive()
+
+    A topic handler function can do anything, including setting the object's
+    `quit` property to True which will cause the receive loop to exit at the
+    next timeout of the wait for Kafka (defaults to 10 seconds).  Any return
+    value from the topic handler function is ignored.
+
+    Only one message handler can be registered to any topic.  If you need to
+    do two or more things with a message, then give this a single handler
+    function that then calls your other handlers.  This makes sure they're
+    called in the order _you_ want, rather than the arbitrary order we might
+    call them here.  Calling `register_handler` more than once will generate
+    a warning and ignore the new handler function given.
+    """
+    def __init__(self, consumer: Consumer | None = None):
+        self.registered_handlers: dict[str, HandlerEntry] = {}
+        self.quit: bool = False
+        self.loop_timeout: int = 1
+        # When being tested, supply a DummyConsumer object that has added
+        # messages via consumer.add_message().  Those messages will be processed
+        # in the order they were added.
+        if consumer is not None:
+            self.consumer = consumer
+        else:
+            self.consumer: Consumer = Consumer(kafka_settings.KAFKA_SETTINGS)
+
+    def register_handler(self, topic: str, handler_fn: HandlerFunc, **filters: dict[str, str]):
+        if topic in self.registered_handlers:
+            logger.warning(
+                duplicate_handler_warning_message,
+                topic, self.registered_handlers[topic]['handler'].__name__,
+                handler_fn.__name__,
+            )
+            return
+        self.registered_handlers[topic] = {
+            'handler': handler_fn,
+            'filters': filters
+        }
+
+    def _handle_message(self, message: confluent_kafka.Message | DummyMessage | None):
+        """
+        Receive a message, find the handler for this topic, and run the
+        message handler for this topic.
+        """
+        if message is None:
+            return
+        if message.error():
+            logger.error(message.error())
+            return
+
+        topic = message.topic()
+        if topic not in self.registered_handlers:
+            # Would this be too noisy?
+            logger.info("Received message for unregistered topic '%s'", topic)
+            return
+
+        # It is important we filter by headers so that we don't json.loads
+        # every upload that is sent to CRC.
+        # The headers come in as a list of tuples.  The filters is a dictionary.
+        # Example Filters: {'service': 'tasks'}
+        # Example Headers: [('service', b'tasks')]
+        headers: list[tuple[str, bytes]] | None = message.headers()
+        if headers is None:
+            headers = []
+        header_filters: dict[str, str] = self.registered_handlers[topic]['filters']
+
+        # It's a toss-up here whether converting this to a dictionary makes
+        # for faster comparisons, but it makes the code easier to read.
+        header_dict: dict[str, str] = {
+            key: value.decode('utf-8')
+            for key, value in headers
+            if value
+        }
+        filters_matched = all(
+            (key in header_dict and header_dict[key] == value)
+            for key, value in header_filters.items()
+        )
+
+        if not filters_matched:
+            return
+
+        # Decode JSON
+        try:
+            body = json.loads(message.value().decode('utf-8').strip('"'))
+        except Exception as e:
+            logger.exception(f"Malformed JSON when handling {topic}: {e}")
+            return
+        # Tell Django we're starting a 'request' (db connection restarts...)
+        request_started.send(sender=self.__class__)
+        # Call handler with JSON
+        try:
+            handler = self.registered_handlers[topic]['handler']
+            # assert isinstance(handler, AbcCallable)
+            handler(topic, body)
+        except Exception as e:
+            logger.exception(
+                "Error processing kafka message",
+                extra={
+                    'topic': topic,
+                    'payload': body,
+                    'error': str(e)
+                }
+            )
+        # and we're finishing the 'request'
+        request_finished.send(sender=self.__class__)
+
+    def receive(self):
+        """
+        Run the receive loop continuously until told to stop.
+        """
+        self.consumer.subscribe(list(self.registered_handlers.keys()))
+
+        while not self.quit:
+            # longer polling timeouts mean fewer iterations through this loop,
+            # but a longer time to respond to SIGTERM.  Here's the compromise:
+            self._handle_message(self.consumer.poll(self.loop_timeout))
+        self.consumer.close()

--- a/api/advisor/prometheus.py
+++ b/api/advisor/prometheus.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+from django.conf import settings
+from prometheus_client import start_http_server, Counter, Enum, Gauge, Histogram, Info
+
+# Prometheus configuration
+INSIGHTS_ADVISOR_UP = Gauge('insights_advisor_service_up', 'Insights Advisor Service Up')
+INSIGHTS_ADVISOR_STATUS = Enum(
+    'insights_advisor_service_status',
+    'Current Status of Advisor Service',
+    states=['initialized', 'starting', 'running', 'stopped']
+)
+INSIGHTS_ADVISOR_TOTAL_REQUESTS = Counter(
+    'insights_advisor_service_total_requests',
+    'Total Number of Received Requests'
+)
+INSIGHTS_ADVISOR_SUCCESSFUL_REQUESTS = Counter(
+    'insights_advisor_service_successful_requests',
+    'Total Number of Successful Requests'
+)
+INSIGHTS_ADVISOR_MISSING_CONTENT = Counter(
+    'insights_advisor_missing_content',
+    'Number of reports we tried processing but failed to find rule content for'
+)
+INSIGHTS_ADVISOR_DB_ERRORS = Counter(
+    'insights_advisor_db_errors',
+    'Total number of DB errors that have occurred'
+)
+INSIGHTS_ADVISOR_SERVICE_DB_ELAPSED = Histogram(
+    'insights_advisor_service_db_elapsed',
+    'Total time spent processing db calls for an archive'
+)
+THIRD_PARTY_RULE_HIT_REQUEST_RECEIVED = Counter(
+    'insights_advisor_service_third_party_rule_hit_request_received',
+    'A request that is received for a rule hit from a third party'
+)
+INSIGHTS_ADVISOR_SERVICE_HANDLE_ENGINE_RESULTS = Histogram(
+    'insights_advisor_service_handle_engine_results',
+    'Total time spent processing results received from the shared engine'
+)
+INSIGHTS_ADVISOR_SERVICE_RULE_HITS_ELAPSED = Histogram(
+    'insights_advisor_service_rule_hits_elapsed',
+    'Total time spent processing third party rule hits'
+)
+INSIGHTS_ADVISOR_SERVICE_WEBHOOK_EVENTS_ELAPSED = Histogram(
+    'insights_advisor_service_webhook_events_elapsed',
+    'Total time spent processing webhook events'
+)
+THIRD_PARTY_RULE_HIT_MISSING_KEYS = Counter(
+    'insights_advisor_service_rule_hits_missing_keys',
+    'Counter for how many rule hit requests are malformed, missing keys'
+)
+INVENTORY_EVENTS_TOPIC_RECEIVED = Counter(
+    'insights_advisor_service_inventory_event_received',
+    'A request that is received from the inventory service'
+)
+INSIGHTS_ADVISOR_SERVICE_INVENTORY_EVENTS_ELAPSED = Histogram(
+    'insights_advisor_service_inventory_events_elapsed',
+    'Total time spent processing an inventory event'
+)
+
+INVENTORY_EVENT_MISSING_KEYS = Counter(
+    'insights_advisor_service_inventory_event_missing_keys',
+    'Counter for how many inventory event requests are malformed, missing keys'
+)
+INVENTORY_EVENT_ERROR = Counter(
+    'insights_advisor_service_inventory_event_error',
+    'Counter for how many inventory events errored'
+)
+INVENTORY_HOST_CREATED = Counter(
+    'insights_advisor_service_inventory_host_created',
+    'Count how many inventory hosts were created'
+)
+INVENTORY_HOST_UPDATED = Counter(
+    'insights_advisor_service_inventory_host_updated',
+    'Count how many inventory hosts were updated'
+)
+INVENTORY_HOST_DELETED = Counter(
+    'insights_advisor_service_inventory_host_deleted',
+    'Count how many inventory hosts were deleted'
+)
+PAYLOAD_TRACKER_DELIVERY_ERRORS = Counter(
+    'insights_advisor_service_payload_tracker_delivery_errors',
+    'Counter for how many payload tracker messsages failed delivery'
+)
+ADVISOR_SERVICE_VERSION = Info(
+    'insights_advisor_service_version',
+    'Release and versioning information'
+)
+
+
+def start_prometheus():
+    start_http_server(settings.PROMETHEUS_PORT)

--- a/api/advisor/sat_compat/tests/test_systems_views.py
+++ b/api/advisor/sat_compat/tests/test_systems_views.py
@@ -966,7 +966,7 @@ class SystemViewTestCase(TestCase):
             status=200
         )
         responses.add(
-            responses.PATCH, INVENTORY_SERVER_URL + '/hosts/00112233-4455-6677-8899-0123456789FF',
+            responses.PATCH, INVENTORY_SERVER_URL + '/hosts/' + constants.missing_branch,
             status=404
         )
 
@@ -984,11 +984,11 @@ class SystemViewTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200, response.content.decode())
 
-        # Unknown client gets a 200
+        # Unknown client gets a 404
         response = self.client.put(
             reverse(
                 'sat-compat-v1-systems-detail',
-                kwargs={'uuid': '00112233-4455-6677-8899-0123456789FF'}
+                kwargs={'uuid': constants.missing_branch}
             ),
             data={
                 'display_name': 'foo.bar.baz',
@@ -996,7 +996,7 @@ class SystemViewTestCase(TestCase):
             content_type=constants.json_mime,
             **auth_header_for_testing(),
         )
-        self.assertEqual(response.status_code, 200, response.content.decode())
+        self.assertEqual(response.status_code, 404, response.content.decode())
 
         # Check form validation still 200s
         response = self.client.put(

--- a/api/advisor/sat_compat/views/systems.py
+++ b/api/advisor/sat_compat/views/systems.py
@@ -557,11 +557,13 @@ class V1SystemViewSet(viewsets.ReadOnlyModelViewSet):
         that the system being updated is actually the system which has that
         hostname. This is best-effort to support compatibility. The official
         way is to set the display_name in the upload or set it using
-        the inventory service. Always return a 200 no matter what.
+        the inventory service.  This returns a 404 if the system doesn't exist,
+        or a 200 whether or not the actual PATCH to inventory was successful.
         """
+        # Make sure the system exists in this org before we try to update it.
+        org_id = request_to_org(request)
+        system = get_system_or_404(self.get_queryset(), uuid, org_id)
         try:
-            org_id = request_to_org(request)
-            system = get_system_or_404(self.get_queryset(), uuid, org_id)
             # Validate form
             store_post_data(request, SatSystemEditSerializer)
             serdata = SatSystemEditSerializer(data=request.data)
@@ -580,7 +582,7 @@ class V1SystemViewSet(viewsets.ReadOnlyModelViewSet):
             else:
                 logger.info(f'Inventory returned ${response.status_code} on PATCH host')
         except (Exception,):
-            logger.exception('Failed to PATCH display_name')
+            logger.error('Failed to PATCH display_name')
 
         # System may not be created at this point.
         # The display_name will be set when the archive hits the inventory so always return 200.

--- a/api/advisor/tasks/management/commands/tasks_service.py
+++ b/api/advisor/tasks/management/commands/tasks_service.py
@@ -26,10 +26,11 @@ from django.core.cache import cache
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+from kafka_utils import KafkaDispatcher, send_kafka_message
 from advisor_logging import logger
 from api.permissions import auth_header_for_testing
 from api.utils import retry_request
-from tasks.kafka_utils import send_event_message, KafkaDispatcher, send_kakfa_message
+from tasks.kafka_utils import send_event_message
 from tasks.models import (
     ExecutedTask, ExecutedTaskStatusChoices, Host, Job, JobStatusChoices,
     SatelliteRhc, TaskTypeChoices,
@@ -322,7 +323,7 @@ def handle_script_job_updates(topic, message):
         "ingress_kafka_message": message
     })
     updated_on = message['timestamp']
-    send_kakfa_message(kafka_settings.PAYLOAD_TRACKER_TOPIC, {
+    send_kafka_message(kafka_settings.PAYLOAD_TRACKER_TOPIC, {
         'status': 'received',
         'service': 'tasks',
         'source': 'rhc-worker-script',


### PR DESCRIPTION
RHINENG-25823

## Summary by Sourcery

Introduce a shared Kafka utilities module with testing helpers and use it across services, add an Advisor inventory replication service driven by Kafka events, and enhance content compilation, auto-ack handling, filtering, feature-flag testing, and Prometheus metrics.

New Features:
- Add a shared KafkaDispatcher, dummy Kafka producer/consumer, and helper for sending JSON Kafka messages, and reuse them from tasks.
- Introduce an advisor_inventory_service management command to replicate InventoryHost data from inventory Kafka events into Advisor models.
- Add a standalone compile_advisor_content script to build rule and playbook content YAML (optionally compressed) from content repositories.
- Add a feature-flag testing helper to override Unleash flags in dev and tests.
- Expose Advisor service and inventory replication metrics via a dedicated Prometheus module and HTTP endpoint.

Bug Fixes:
- Prevent duplicate Kafka topic handlers and improve error handling and logging for malformed or errored Kafka messages.
- Ensure system-type filtering works correctly through related inventory models and extend rule system APIs to support system_type queries.
- Avoid creating duplicate auto-acks for rules that are already acknowledged and clean up auto-acks when tags change or content is reverted.
- Return 404 when attempting to rename a non-existent Satellite-compatible system instead of 200.
- Relax auth_header_for_testing user_id validation to accept non-UUID identifiers used in tests.

Enhancements:
- Refactor content import to delegate rule/playbook parsing to the new compile_advisor_content script, simplifying management command logic.
- Improve playbook version and path handling by deriving git hashes and using absolute paths when no git root is available.
- Tighten type hints and test utilities for modifying fixture files in import-content tests.
- Extend rule systems detail tests and views to cover conventional/edge/bootc system-type cases and ensure consistent filtering.
- Improve logging around Kafka message delivery, inventory events, and error conditions.

Build:
- Add mypy as a development dependency for improved static type checking.

Tests:
- Add comprehensive tests for the new advisor_inventory_service workflow, covering created/updated/deleted inventory events and side effects on Advisor models.
- Add unit tests for Kafka utilities, including dummy producer/consumer behavior, handler registration, and JSON decoding error paths.
- Extend import_content tests to cover playbook version hashing, path handling, and nuanced auto-ack scenarios.
- Update rule views and Satellite compatibility tests to validate new system_type filters and system rename semantics.
- Adjust auth and RBAC-related tests to use the shared auth_header_for_testing helper for identity construction.