### PR TITLE
Use `_assigned` when checking recommendation-results in the default w…

### DIFF
--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -47,6 +47,8 @@ user_details_key = {
     'ServiceAccount': 'service_account'
 }
 
+use_assigned_permissions_for_resource = ['recommendation-results']
+
 
 def make_rbac_url(path, version: int = 1, rbac_base: str | None = None) -> str:
     """
@@ -559,11 +561,17 @@ def has_kessel_permission(
                 "KESSEL: checking access for org %s workspace %s",
                 identity['org_id'], workspace_id
             )
+            kessel_permission = permission.as_kessel_permission()
+            # We're using the default workspace permission for some host-centric resources (Do I have permissions to view recommendations?)
+            # Check `_assigned` permission when the `resource` is  `recommendation-results`
+            if permission.resource in use_assigned_permissions_for_resource:
+                kessel_permission += '_assigned'
+
             # Kessel check requires a 'user_id' in the identity's user data.
             # This is checked in InsightsRBACPermission, the caller.
             result, elapsed = kessel.client.check(
                 kessel.Workspace(workspace_id).to_ref(),
-                permission.as_kessel_permission(),
+                kessel_permission,
                 identity_to_subject(identity)
             )
         elif scope == ResourceScope.WORKSPACE:

--- a/api/advisor/api/tests/__init__.py
+++ b/api/advisor/api/tests/__init__.py
@@ -323,6 +323,11 @@ class constants(object):
         relation="advisor_recommendation_results_view",
         subject=kessel_std_user_obj,
     )
+    kessel_cpr_read_recom_read_assigned = check_request_pb2.CheckRequest(
+        object=kessel_std_org_obj,
+        relation="advisor_recommendation_results_view_assigned",
+        subject=kessel_std_user_obj,
+    )
     kessel_cpr_read_recom_svc_write = check_request_pb2.CheckRequest(
         object=kessel_std_org_obj,
         relation="advisor_recommendation_results_edit",
@@ -355,6 +360,8 @@ class constants(object):
         kessel_cpr_read_recom_write, kessel.DENIED
     ), (
         kessel_cpr_read_recom_read, kessel.ALLOWED
+    ), (
+        kessel_cpr_read_recom_read_assigned, kessel.ALLOWED
     )]
     kessel_allow_recom_read_svc_ro = [(
         kessel_cpr_read_recom_svc_read, kessel.ALLOWED

--- a/api/advisor/api/tests/__init__.py
+++ b/api/advisor/api/tests/__init__.py
@@ -363,6 +363,9 @@ class constants(object):
     ), (
         kessel_cpr_read_recom_read_assigned, kessel.ALLOWED
     )]
+    kessel_allow_read_assigned = [(
+        kessel_cpr_read_recom_read_assigned, kessel.ALLOWED
+    )]
     kessel_allow_recom_read_svc_ro = [(
         kessel_cpr_read_recom_svc_read, kessel.ALLOWED
     )]

--- a/api/advisor/api/tests/test_rbac.py
+++ b/api/advisor/api/tests/test_rbac.py
@@ -610,3 +610,19 @@ class KesselTestCase(TestCase):
             )
             self.assertTrue(kessel_response)
             self.assertGreater(time, 0.0)
+
+    @override_settings(RBAC_ENABLED=True, KESSEL_ENABLED=True, RBAC_URL=TEST_RBAC_URL)
+    def test_kessel_with_assigned_check(self):
+        with add_kessel_response(
+            permission_checks=constants.kessel_allow_read_assigned
+        ):
+            rq = request_object_for_testing(
+                auth_by=permissions.RHIdentityAuthentication
+            )
+            kessel_response, time = permissions.has_kessel_permission(
+                permissions.ResourceScope.ORG,
+                permissions.RBACPermission('advisor:recommendation-results:read'),
+                rq
+            )
+            self.assertTrue(kessel_response)
+            self.assertGreater(time, 0.0)


### PR DESCRIPTION
…orkspace

The permission in the schema is actually merging these questions:
- Do I have permissions to view recommendation-results?
- What workspaces do I have permissions to view the recommendation-results for?

By using the permission suffixed with `_assigned`, we are getting the first part, making it compatible with the way we're processing the requests.

## Summary by Sourcery

Adjust Kessel RBAC checks for recommendation results to rely on the `_assigned` permission variant for default workspace access.

Bug Fixes:
- Ensure Kessel permission checks for recommendation results use the `_assigned` relation so default workspace access is evaluated correctly.

Tests:
- Add Kessel RBAC test coverage for recommendation-results read access using the `_assigned` permission relation.