### PR TITLE
[RHINENG-25920] foreman-3.18: Use regex for matching RHEL versions

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -546,14 +546,8 @@ required_branch_id_param = OpenApiParameter(
 rhel_version_query_param = OpenApiParameter(
     name='rhel_version', location=OpenApiParameter.QUERY,
     description='Display only systems with these versions of RHEL',
-    required=False, many=True, type=OpenApiTypes.STR, style='form',
-    enum=(
-        '10.0', '10.1', '10.2',
-        '9.0', '9.1', '9.2', '9.3', '9.4', '9.5', '9.6', '9.7', '9.8',
-        '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6', '8.7', '8.8', '8.9', '8.10',
-        '7.0', '7.1', '7.2', '7.3', '7.4', '7.5', '7.6', '7.7', '7.8', '7.9', '7.10',
-        '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9', '6.10',
-    )
+    required=False, many=True, type=OpenApiTypes.REGEX, style='form',
+    pattern=r'^\d+\.\d+$'
 )
 
 

--- a/api/advisor/tasks/tests/test_task_views.py
+++ b/api/advisor/tasks/tests/test_task_views.py
@@ -373,10 +373,7 @@ class TaskViewTestCase(TestCase):
         )
         error = res.content.decode()
         self.assertEqual(res.status_code, 400, error)
-        self.assertIn(
-            "The value is required to be one of the following "
-            "values: ", error
-        )
+        self.assertIn("The value did not match the pattern", error)
 
         # Nonexistent task should just return a 404
         res = self.client.get(


### PR DESCRIPTION
Use regex for matching RHEL versions [RHINENG-23928](https://redhat.atlassian.net/browse/RHINENG-23928)

## Summary by Sourcery

Allow filtering systems by RHEL version using a regex-based query parameter instead of a fixed enum list.

Enhancements:
- Change the rhel_version OpenAPI query parameter to use a regex pattern for version matching rather than an enumerated list of allowed versions.

Tests:
- Expand rule systems detail tests to cover a broader set of RHEL versions, invalid rhel_version formats returning 400, and valid-but-nonexistent versions returning an empty result set.
- Update task systems requirements test to assert the new validation error message for invalid rhel_version values.

[RHINENG-23928]: https://redhat.atlassian.net/browse/RHINENG-23928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ