### PR TITLE
[RHINENG-25920] foreman-3.16: Use regex for matching RHEL versions 

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -534,14 +534,8 @@ required_branch_id_param = OpenApiParameter(
 rhel_version_query_param = OpenApiParameter(
     name='rhel_version', location=OpenApiParameter.QUERY,
     description='Display only systems with these versions of RHEL',
-    required=False, many=True, type=OpenApiTypes.STR, style='form',
-    enum=(
-        '10.0', '10.1', '10.2',
-        '9.0', '9.1', '9.2', '9.3', '9.4', '9.5', '9.6', '9.7', '9.8',
-        '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6', '8.7', '8.8', '8.9', '8.10',
-        '7.0', '7.1', '7.2', '7.3', '7.4', '7.5', '7.6', '7.7', '7.8', '7.9', '7.10',
-        '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7', '6.8', '6.9', '6.10',
-    )
+    required=False, many=True, type=OpenApiTypes.REGEX, style='form',
+    pattern=r'^\d+\.\d+$'
 )
 
 

--- a/api/advisor/api/tests/test_rule_views.py
+++ b/api/advisor/api/tests/test_rule_views.py
@@ -1485,8 +1485,8 @@ class RuleTestCase(TestCase):
         # only those that exist and have hits.
         response = self.client.get(
             reverse('rule-systems-detail', kwargs={'rule_id': constants.active_rule}),
-            data={'rhel_version': '7.1,7.2,7.3,7.4,7.5,7.6,7.7,7.8,7.9,7.10,8.10,9.8,10.0,10.2'},
-            **auth_header_for_testing()
+            data={'rhel_version': '7.0,7.1,7.2,7.3,7.4,7.5,7.6,7.7,7.8,7.9,7.10,8.0,8.10,9.0,9.10,10.0,10.10,11.0'},
+            **self.default_header
         )
         self.assertEqual(response.status_code, 200, response.content.decode())
         self.assertEqual(response.accepted_media_type, constants.json_mime)
@@ -1502,6 +1502,46 @@ class RuleTestCase(TestCase):
         self.assertEqual(hosts[3]['display_name'], constants.host_04_name)
         # Note that we're only seeing hits for the active rule, so system 5,
         # which is on RHEL 7.1, is not seen here.
+        self.assertEqual(len(hosts), 4)
+
+        # Test invalid rhel_version format - should return a 400
+        response = self.client.get(
+            reverse('rule-systems-detail', kwargs={'rule_id': constants.active_rule}),
+            data={'rhel_version': '7.5,foo.bar'},
+            **self.default_header
+        )
+        error = response.content.decode()
+        self.assertEqual(response.status_code, 400, error)
+        self.assertIn("The value did not match the pattern", error)
+
+        # Test rhel_version format that is valid but doesn't match any of our systems - should return an empty list, not an error
+        response = self.client.get(
+            reverse('rule-systems-detail', kwargs={'rule_id': constants.active_rule}),
+            data={'rhel_version': '200.0,0.002'},
+            **self.default_header
+        )
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        page = response.json()
+        hosts = page['data']
+        self.assertIsInstance(hosts, list)
+        self.assertEqual(len(hosts), 0)
+
+    def test_systems_detail_for_a_rule_system_type_filter(self):
+        # Test for 'conventional' systems, should exclude edge and bootc.
+        response = self.client.get(
+            reverse('rule-systems-detail', kwargs={'rule_id': constants.active_rule}),
+            data={'system_type': 'conventional'},
+            **self.default_header
+        )
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        page = response.json()
+        self.assertIn('data', page)
+        hosts = page['data']
+        self.assertIsInstance(hosts, list)
+        self.assertEqual(hosts[0]['system_uuid'], constants.host_06_uuid)
+        self.assertEqual(hosts[1]['system_uuid'], constants.host_01_uuid)
+        self.assertEqual(hosts[2]['system_uuid'], constants.host_03_uuid)
+        self.assertEqual(hosts[3]['system_uuid'], constants.host_04_uuid)
         self.assertEqual(len(hosts), 4)
 
     def test_systems_for_a_rule_acked(self):

--- a/api/advisor/tasks/tests/test_task_views.py
+++ b/api/advisor/tasks/tests/test_task_views.py
@@ -373,10 +373,7 @@ class TaskViewTestCase(TestCase):
         )
         error = res.content.decode()
         self.assertEqual(res.status_code, 400, error)
-        self.assertIn(
-            "The value is required to be one of the following "
-            "values: ", error
-        )
+        self.assertIn("The value did not match the pattern", error)
 
         # Nonexistent task should just return a 404
         res = self.client.get(


### PR DESCRIPTION
Use regex for matching RHEL versions [RHINENG-23928](https://redhat.atlassian.net/browse/RHINENG-23928)

[RHINENG-23928]: https://redhat.atlassian.net/browse/RHINENG-23928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Relax RHEL version filtering to use a regex pattern instead of a fixed enum and update tests accordingly.

Enhancements:
- Document the rhel_version query parameter as a regex-matched string pattern rather than a fixed set of allowed values.

Tests:
- Expand rule systems detail tests to cover a broader range of RHEL versions, invalid rhel_version formats returning 400, and valid-but-nonexistent versions returning an empty result set.
- Adjust task systems requirements tests to expect regex pattern validation error messages instead of enum-based validation messages.