### PR TITLE
Fix CVE-2025-66418, CVE-2025-66471, CVE-2026-21441: bump urllib3 to 2.6.3

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1080,11 +1080,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
-                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.5.0"
+            "version": "==2.6.3"
         },
         "watchtower": {
             "hashes": [


### PR DESCRIPTION
## Summary
- Bumps urllib3 from 2.5.0 to 2.6.3 in `Pipfile.lock` default dependencies
- Resolves three CVEs
     - **CVE-2025-66418** (SAT-41218): Unbounded decompression chain leads to resource exhaustion
     - **CVE-2025-66471** (SAT-41412): Streaming API improperly handles highly compressed data
     - **CVE-2026-21441** (SAT-41474): Decompression-bomb safeguard bypass when following HTTP redirects

## Summary by Sourcery

Bump urllib3 dependency to address security vulnerabilities in the backend service.

Bug Fixes:
- Resolve multiple urllib3-related CVEs by upgrading the library to version 2.6.3 in the locked dependencies.

Build:
- Update Pipfile.lock to pin urllib3 to version 2.6.3 in default dependencies.