### PR TITLE
Add CLAUDE.md and updates to READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+.idea/
+.coverage
+test_reports/
+junit-service.xml
+lint-results.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Insights Advisor Backend is a Django 5.2 / Python 3.12+ application for Red Hat's Hybrid Cloud Console. It consists of two main systems:
+- **API** (`api/`): Django REST Framework API serving recommendation data to users
+- **Service** (`service/`): Kafka consumer that receives rule processing results and records them in the database
+
+## Common Commands
+
+All commands run from the repository root. Use `pipenv shell` first or prefix with `pipenv run`.
+
+### Setup
+```bash
+pipenv install && pipenv install --dev
+export ADVISOR_DB_HOST=localhost
+podman-compose up -d advisor-db
+python api/advisor/manage.py migrate
+python api/advisor/manage.py mock_cyndi_table
+python api/advisor/manage.py loaddata rulesets rule_categories system_types upload_sources basic_test_data
+python api/advisor/manage.py freshen_hosts
+```
+
+### Running
+```bash
+pipenv run runapi                    # Start API server (Django runserver on :8000)
+pipenv run runservice                # Start Kafka service consumer
+pipenv run runtasks                  # Start Tasks service consumer
+```
+
+### Testing
+```bash
+pipenv run testapi                   # Run API tests (uses Django test runner with coverage)
+pipenv run testtasks                 # Run Tasks tests
+pipenv run testservice               # Run Service tests (pytest)
+pipenv run linter                    # Run flake8 on api/ and service/
+```
+
+### Running a single API test
+```bash
+python api/advisor/manage.py test api/advisor/api/tests/test_rule_views    # Single test module
+python api/advisor/manage.py test api/advisor/api/tests/test_rule_views.RuleViewSetTests.test_rule_list  # Single test
+```
+
+### Other useful pipenv scripts
+```bash
+pipenv run migratedb                 # Run migrations
+pipenv run makemigrations            # Create new migrations
+pipenv run mockcyndi                 # Create mock Cyndi table
+pipenv run loaddata                  # Load production fixtures
+pipenv run loadtestdata              # Load test fixtures
+pipenv run apicovhtml                # Generate HTML coverage report
+```
+
+## Architecture
+
+### Three APIs in one Django project
+
+The Django project (`api/advisor/project_settings/`) serves three APIs with separate URL prefixes:
+
+1. **Advisor API** (`api/advisor/api/`) — `/api/insights/v1/` — Main API for rules, systems, reports, acks
+2. **Tasks API** (`api/advisor/tasks/`) — `/api/tasks/v1/` — Playbook execution task management
+3. **Satellite Compatibility API** (`api/advisor/sat_compat/`) — `/r/insights/` — Legacy Satellite proxy compatibility
+
+### Key data models (`api/advisor/api/models.py`)
+
+- **Rule**, **RuleImpact**, **Resolution**, **Playbook** — Rule content imported from external repos via `import_content` command
+- **InventoryHost** — Syndicated from HBI (Host-Based Inventory) via Cyndi; read-only in production. Uses `for_account(request)` manager method to scope queries by org_id and staleness
+- **Host** — Advisor's own host tracking (Satellite IDs, etc.), used as FK for uploads/reports
+- **CurrentReport** — Active rule hits per host. Central to most queries
+- **Upload** — Groups reports from a single system check-in; tracks `checked_on` date
+- **Ack** / **HostAck** — User acknowledgments to suppress recommendations (global or per-host)
+- **Pathway** — Groups rules into remediation pathways
+
+### Query filtering pattern (`api/advisor/api/filters.py`)
+
+System-scoped filters follow a consistent pattern:
+1. Define an `OpenApiParameter` in `filters.py`
+2. Create a filter function returning a `Q()` object, accepting an optional `relation` parameter for use in both `InventoryHost` and `CurrentReport` queries
+3. Apply via `get_systems_queryset()` (for system queries) and `get_reports_subquery()` (for report-count queries)
+4. Advertise in `@extend_schema(parameters=[...])` on view methods
+
+Use `value_of_param(param, request)` for parameter extraction/validation and `filter_on_param(field, param, request)` for simple field filters. `filter_multi_param()` handles `filter[]` bracket syntax.
+
+### Authentication & permissions (`api/advisor/api/permissions.py`)
+
+- Requests carry a base64-encoded JSON identity in the `x-rh-identity` HTTP header (provided by 3Scale gateway)
+- `RHIdentityAuthentication` decodes and validates the identity; `org_id` scopes all data queries
+- `InsightsRBACPermission` checks permissions against RBAC service (or Kessel via gRPC when enabled)
+- RBAC/Kessel are disabled by default for local dev (`RBAC_ENABLED=false`, `KESSEL_ENABLED=false`)
+
+### Service (`service/service.py`)
+
+Kafka consumer processing `platform.engine.results` messages. Receives rule hit results, creates/updates/deletes `CurrentReport` records, manages `Upload` and `Host` records within atomic transactions.
+
+### Testing conventions
+
+- Tests use Django's `TestCase` with fixtures from `api/advisor/*/fixtures/`
+- Test constants are centralized in `api/advisor/api/tests/__init__.py` (`from api.tests import constants`) — use these instead of hardcoded strings
+- Call `update_stale_dates()` before tests involving systems to ensure hosts aren't filtered out by staleness
+- External API calls use the `responses` library (not `unittest.mock`)
+- Kafka mocking uses `DummyMessage`, `DummyConsumer`, `DummyProducer` from `api/advisor/kafka_utils.py`
+- Custom test runner (`CyndiTestRunner`) automatically creates mock Cyndi table before tests
+- API tests require the database: `podman-compose up -d advisor-db` with `ADVISOR_DB_HOST=localhost`
+
+### Content import
+
+Rule content is loaded via `python api/advisor/manage.py import_content -c <content_dir>`. Test content lives in `api/test_content/`.
+
+### Feature flags
+
+Unleash-based. For local dev, set `UNLEASH_FAKE_INITIALIZE=true` (default) or provide a bootstrap file via `UNLEASH_BOOTSTRAP_FILE`.

--- a/Containerfile.localdev
+++ b/Containerfile.localdev
@@ -1,0 +1,62 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ENV LC_ALL=C.utf8
+ENV LANG=C.utf8
+ENV HOME=/opt/app-root/src
+WORKDIR $HOME
+
+USER root
+ADD https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo group_insights-postgresql-16-epel-9.repo
+# Install & upgrade RHEL packages
+RUN (microdnf module enable -y postgresql:16 || \
+    cp group_insights-postgresql-16-epel-9.repo /etc/yum.repos.d/postgresql.repo \
+    ) && \
+    microdnf -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install \
+    python3.12 postgresql git-core && \
+    microdnf -y upgrade && \
+    microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
+
+# alias pip and python for compatibility
+RUN alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.12 1 && \
+    alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+# Needed because $HOME isn't owned by user 1001
+RUN chown 1001 $HOME && install -o 1001 -d $HOME/.cache
+
+# API, service and content import all need pip and pipenv installed
+COPY Pipfile Pipfile.lock ./
+# Install build tools for psycopg2, then remove them and dependencies after
+# in one step so the FS layer has minimal changes
+RUN microdnf -y install python3.12-pip python3.12-devel gcc libpq-devel && \
+    pip3 -q install pipenv && \
+    pipenv install && \
+    microdnf remove -y python3.12-devel gcc libpq-devel \
+    acl binutils binutils-gold cpp \
+    elfutils-debuginfod-client elfutils-default-yama-scope elfutils-libelf \
+    elfutils-libs libxcrypt-devel glibc-devel make libgomp libmpc \
+    libpkgconf pkgconf pkgconf-pkg-config \
+    glibc-headers kernel-headers && \
+    chown -R 1001 .cache .local
+# The unit tests need to install --dev packages, which needs to write to
+# .local, so we need to set the permissions so 1001 can do that here
+
+# Set Django 5.2+ minimum PostgreSQL version to 13
+RUN sed -i s/\(14,\)/\(13,\)/g $(pipenv --venv)/lib/python3.12/site-packages/django/db/backends/postgresql/features.py
+
+# Needed for Prometheus
+RUN install -o 1001 -d /metrics
+
+# Needed by Unleash cache - see UNLEASH_CACHE_DIR parameter in clowdapp.yml
+RUN install -o 1001 -m 775 -d /tmp/unleashcache/cache
+
+# Now transition to the container user
+USER 1001
+COPY ./api ./api
+COPY ./service ./service
+
+COPY container_init_localdev.sh cgroup-limits ./
+
+EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ managed inside Red Hat using [https://github.com/RedHatInsights/clowder](Clowder
 It's possible to run just the basic components Advisor needs using Podman, which
 is how we suggest you do this in development.
 
-The projects under [https://github.com/RedHatInsights/] are related to the
+The projects under [https://github.com/RedHatInsights/](https://github.com/RedHatInsights/) are related to the
 Insights project.
 
 # Installation
@@ -59,6 +59,11 @@ podman-compose up -d advisor-db
 pipenv shell
 python api/advisor/manage.py migrate
 python api/advisor/manage.py loaddata rulesets rule_categories system_types upload_sources basic_test_data
+```
+... or you can start the database, Kafka, Advisor service and API all together with podman-compose, like so:
+```
+export ADVISOR_DB_HOST=localhost
+podman-compose up -d advisor-db init-kafka kafka advisor-service advisor-api
 ```
 
 ## Feature Flags
@@ -413,6 +418,7 @@ Sending in fake engine results
 ```
 pipenv shell
 python service/manual_test/send_fake_engine_results.py
+python api/advisor/manage.py freshen_hosts
 ```
 
 ## Running the Service manually
@@ -422,7 +428,7 @@ but only for the dependencies. This method is meant for
 more rapid development.
 ```
 export ADVISOR_DB_HOST=localhost
-podman-compose up -d zookeeper kafka advisor-db
+podman-compose up -d advisor-db init-kafka
 ```
 Start Service manually
 ```
@@ -431,6 +437,7 @@ BOOTSTRAP_SERVERS=localhost:9092 python service/service.py
 Sending in engine results for processing.
 ```
 python service/manual_test/send_fake_engine_results.py
+python api/advisor/manage.py freshen_hosts
 ```
 
 ## Running the API with podman-compose
@@ -529,7 +536,7 @@ podman-compose up -d advisor-db
 ```
 To run Service Tests
 ```
-podman-compose up -d zookeeper kafka
+podman-compose up -d init-kafka
 pipenv run testservice
 ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -3,7 +3,7 @@
 This is an implementation of the Insights API in Django 5.2, which
 requires Python 3.12 or above.
 
-See the main [Read Me](../README.md) document for more information about
+See the main [README](../README.md) document for more information about
 Advisor's purpose and structure.
 
 # Advisor API overview
@@ -13,10 +13,10 @@ The Advisor API actually covers three APIs:
 - The main Advisor API, handling URLs starting with `/api/insights/v1/`, is
   in `api/advisor/api/`.
 - The Satellite Compatibility API, handling URLs starting with `/r/insights/`,
-  is in `api/advisor/sat_compat/`.  The [Readme](advisor/sat_compat/README.md)
+  is in `api/advisor/sat_compat/`.  The [README](advisor/sat_compat/README.md)
   there gives more information about what that is for.
 - The Tasks API, handling URLs starting with `/api/tasks/v1/`, is in
-  `api/advisor/tasks/`.  The [Readme](advisor/tasks/README.md) there gives
+  `api/advisor/tasks/`.  The [README](advisor/tasks/README.md) there gives
   more information about the Tasks app.
 
 ## Install instructions
@@ -30,14 +30,9 @@ The Advisor API actually covers three APIs:
     ```
     cd insights-advisor
     pip install pipenv
-    (optional) pipenv run pip install --upgrade pip
     pipenv install --dev
     pipenv shell
     ````
-
-    The `pipenv run pip install --upgrade pip` command is only necessary if you
-    encounter an error running `pipenv install` related to pip and
-    `no such option: --require-hashes`.
 
 - Running Advisor
 
@@ -49,9 +44,9 @@ The Advisor API actually covers three APIs:
 
 You can run Advisor as a series of podman containers controlled by
 podman-compose.  You will need to have podman and podman-compose installed on
-you development machine.
+your development machine.
 
-- To build the advisor-api container run `podman-compose build`
+- To build the advisor-api container run `podman-compose build advisor-api`
 
 - Start the containers with `podman-compose up`
 
@@ -404,12 +399,12 @@ For other queries, this would be done within the view, with code like this
 (taken from within `/api/advisor/api/views/rules.py`, edited for clarity):
 
 ```py
-    acct_rules = self.get_queryset()
-    if request.query_params:
-        acct_rules = acct_rules.filter(
-            filter_on_param('category_id', category_query_param, request),
-            filter_on_impacting(request),
-            ...
+acct_rules = self.get_queryset()
+if request.query_params:
+    acct_rules = acct_rules.filter(
+        filter_on_param('category_id', category_query_param, request),
+        filter_on_impacting(request),
+        ...
 ```
 
 Here we also see the use of `filter_on_param(query_key, parameter, request)`
@@ -422,32 +417,32 @@ of filters applied within `get_systems_queryset()` and `get_reports_subquery()`.
 For example, within `get_systems_queryset()`:
 
 ```py
-    return systems.filter(
-        filter_on_display_name(request),
-        filter_on_hits(request),
-        filter_on_incident(request),
-        filter_on_rhel_version(request),
-        filter_on_system_role(request),
-        filter_on_has_disabled_recommendation(request)
-    )
+return systems.filter(
+    filter_on_display_name(request),
+    filter_on_hits(request),
+    filter_on_incident(request),
+    filter_on_rhel_version(request),
+    filter_on_system_role(request),
+    filter_on_has_disabled_recommendation(request)
+)
 ```
 
 and within `get_reports_subquery()`:
 
 ```py
-    return CurrentReport.objects.filter(
-        Q(
-            host_tags_q, system_type_q, system_profile_filter,
-            category_filter,
-            cert_auth_q(request, relation='inventory'),
-            branch_id_filter,
-            filter_on_update_method(request, relation='inventory'),
-            get_host_group_filter(request, relation='inventory'),
-            filter_on_system_role(request, relation='inventory'),
-            stale_systems_filter,
-        ) if exclude_ineligible_hosts else Q(),
-        **outer_table_join
-    ).filter(
+return CurrentReport.objects.filter(
+    Q(
+        host_tags_q, system_type_q, system_profile_filter,
+        category_filter,
+        cert_auth_q(request, relation='inventory'),
+        branch_id_filter,
+        filter_on_update_method(request, relation='inventory'),
+        get_host_group_filter(request, relation='inventory'),
+        filter_on_system_role(request, relation='inventory'),
+        stale_systems_filter,
+    ) if exclude_ineligible_hosts else Q(),
+    **outer_table_join
+).filter(
 ```
 
 These additions mean that wherever a system is queried - and there are quite
@@ -467,20 +462,20 @@ So for example in the `SystemViewSet()` class in `api/advisor/api/views/systems.
 we should add it to this schema extension:
 
 ```py
-    @extend_schema(
-        parameters=[
-            sort_query_param, display_name_query_param, host_tags_query_param,
-            hits_query_param, filter_system_profile_sap_system_query_param,
-            filter_system_profile_sap_sids_contains_query_param,
-            incident_query_param, rhel_version_query_param, pathway_query_param,
-            host_group_name_query_param, update_method_query_param,
-            filter_system_profile_mssql_query_param,
-            filter_system_profile_ansible_query_param,
-            has_disabled_recommendation_query_param,
-            system_type_query_param, system_role_query_param,  # <-- here
-        ],
-    )
-    def list(self, request, format=None):
+@extend_schema(
+    parameters=[
+        sort_query_param, display_name_query_param, host_tags_query_param,
+        hits_query_param, filter_system_profile_sap_system_query_param,
+        filter_system_profile_sap_sids_contains_query_param,
+        incident_query_param, rhel_version_query_param, pathway_query_param,
+        host_group_name_query_param, update_method_query_param,
+        filter_system_profile_mssql_query_param,
+        filter_system_profile_ansible_query_param,
+        has_disabled_recommendation_query_param,
+        system_type_query_param, system_role_query_param,  # <-- here
+    ],
+)
+def list(self, request, format=None):
 ```
 
 However, in keeping with the 'Don't Repeat Yourself' philosophy, the

--- a/container_init_localdev.sh
+++ b/container_init_localdev.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+# -e: Exit immediately if any command or compound command exits
+# -u: Treat unset variables and parameters as failures.
+set -eu -o pipefail
+
+echo "Running database migrations ..."
+# podman-compose ensures the advisor-db service is running first
+pipenv run python api/advisor/manage.py migrate --noinput
+pipenv run python api/advisor/manage.py loaddata --verbosity=3 rulesets rule_categories system_types upload_sources
+
+echo "Loading production fixtures for tasks and pathways ..."
+pipenv run python api/advisor/manage.py loaddata --verbosity=3 production_tasks pathways_prod
+
+# Create fake inventory data for the dev environment, and load basic test data for the API, eg rules and hosts
+echo "Creating mocked inventory table and loading test data ..."
+pipenv run python api/advisor/manage.py mock_cyndi_table
+pipenv run python api/advisor/manage.py loaddata --verbosity=3 basic_test_data
+pipenv run python api/advisor/manage.py freshen_hosts
+
+# Import content from the dumped content directory if it exists
+dumped_content_dir='api/test_content/real_content'
+if [[ -d ${dumped_content_dir} && (
+    ( -f ${dumped_content_dir}/rule_content.yaml || -f ${dumped_content_dir}/rule_content.yaml.gz ) &&
+    ( -f ${dumped_content_dir}/playbook_content.yaml || -f ${dumped_content_dir}/playbook_content.yaml.gz ) &&
+    -f ${dumped_content_dir}/config.yaml
+) ]]; then
+    echo "Importing content from ${PWD}/${dumped_content_dir} ..."
+    pipenv run python api/advisor/manage.py import_content -c ${dumped_content_dir}/
+else
+    echo "No content to import from ${PWD}/${dumped_content_dir} - skipping content import"
+fi

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -62,10 +62,6 @@ services:
     depends_on:
       advisor-api:
         condition: service_started
-      nginx:
-        condition: service_started
-      zookeeper:
-        condition: service_started
       kafka:
         condition: service_started
       advisor-db:
@@ -76,11 +72,11 @@ services:
     environment:
       - BOOTSTRAP_SERVERS=kafka:29092
       - ADVISOR_DB_HOST=advisor-db
-    command: python service/service.py
+    command: pipenv run python service/service.py
   advisor-api:
     build:
       context: .
-      dockerfile: Containerfile
+      dockerfile: Containerfile.localdev
     ports:
       - "8000:8000"
     environment:
@@ -101,13 +97,11 @@ services:
       - USE_DJANGO_WEBSERVER=false
       - WEB_CONCURRENCY=2
     depends_on:
-      zookeeper:
-        condition: service_started
       kafka:
         condition: service_started
       advisor-db:
         condition: service_healthy
-    command: sh -c "./container_init.sh &&
+    command: sh -c "./container_init_localdev.sh &&
                     api/app.sh"
   unleash:
     image: quay.io/cloudservices/unleash-docker:5.6.9
@@ -130,7 +124,7 @@ services:
         condition: service_completed_successfully
 
   unleash-init-db:
-    image: quay.io/cloudservices/postgres:16
+    image: quay.io/cloudservices/postgresql-rds:13 
     command: psql -h advisor-db -U postgres -a -f .unleash/init-db.sql
     environment:
       PGPASSWORD: insights
@@ -139,3 +133,7 @@ services:
     depends_on:
       advisor-db:
         condition: service_healthy
+
+networks:
+  default:
+    name: advisor-net

--- a/service/README.md
+++ b/service/README.md
@@ -76,8 +76,7 @@ pipenv install --dev
 ```
 
 # Deploying
-This will start Zookeeper, Kafka, Postgresql and Nginx.
-Nginx is a stand-in and emulates s3.
+This will start Kafka and PostgreSQL.
 ```
 podman-compose up
 ```
@@ -90,11 +89,12 @@ manual_tests/send_fake_engine_results.
 
 # Running the Service
 
-Once you have deployed the environment and set up the database. You can run the
+Once you have deployed the environment and set up the database, you can run the
 service and begin engine results analysis.
-
 ```
 BOOTSTRAP_SERVERS=localhost:9092 pipenv run python service.py
+... or ...
+podman-compose up advisor-service
 ```
 
 ## Sending mock engine results
@@ -103,6 +103,7 @@ You can send in fake results for analysis using two methods.
 The first method is sending in fake engine results for direct consumption in this service.
 ```
 pipenv run python manual_test/send_fake_engine_results.py
+pipenv run python api/advisor/manage.py freshen_hosts
 ```
 
 The second method emulates an inventory message and will require a shared engine
@@ -110,7 +111,6 @@ instance running. This README does not intend to go through the steps to set up
 a shared engine instance. However, if you have one running you can use the
 following script which will send a message to the shared engine, then broadcast
 its results for consumption in this service.
-
 ```
 pipenv run python manual_test/send_fake_inventory_engine_message.py
 ```
@@ -120,13 +120,11 @@ pipenv run python manual_test/send_fake_inventory_engine_message.py
 To run tests, run the following commands:
 
 Start the DB:
-
 ```
 podman-compose up
 ```
 
 Then to run tests:
-
 ```
 pipenv run flake8 .
 pipenv run testservice
@@ -141,3 +139,337 @@ Coverage tests will then be located at `htmlcov/index.html` and must be greater 
 All outstanding issues or feature requests should be filed as Issues on this
 Github page. PRs should be submitted against the master branch for any new
 features or changes, and pass all testing above.
+
+# Detailed Service Architecture
+
+## Overview
+
+The Service (`service/service.py`) is a **multi-threaded Kafka consumer** that processes incoming system analysis results and inventory lifecycle events, persisting them to the database. It runs as a standalone process separate from the Django API.
+
+## Startup (`start()`, line 737)
+
+1. Initializes logging, Prometheus metrics, and a **BoundedExecutor** thread pool (default 30 threads)
+2. Subscribes to **three Kafka topics**:
+   - `platform.engine.results` — rule engine analysis results
+   - Inventory events topic — host delete notifications from HBI
+   - Rule hits topic — third-party rule hit submissions
+3. Enters a polling loop (`c.poll(1.0)`) that dispatches messages to handler functions via the thread pool
+4. Handles `SIGTERM` gracefully — finishes current work, flushes Kafka, then shuts down
+
+## Message Handlers
+
+### 1. `handle_engine_results()` — Primary workload
+
+Processes results from the Insights rules engine (insights-client uploads):
+
+- **Validates** the payload by checking required key paths (`results.reports`, `results.system`, `input.platform_metadata`, `input.host.id`, `input.platform_metadata.org_id`)
+- **Resolves the SystemType** (role + product_code) from the database
+- Extracts satellite metadata (managed status, satellite ID, branch ID)
+- Delegates to `create_db_reports()` for the actual database work
+
+### 2. `create_db_reports()` — Core database logic
+
+This is the most complex function, running inside a **database transaction with row-level locking**:
+
+1. **Host management**: Finds or creates a `Host` record for the inventory UUID. For brand-new accounts (no existing uploads), it auto-creates `Ack` records for rules tagged with `autoack`
+2. **Row locking**: Uses `select_for_update()` on the Host to prevent race conditions from concurrent uploads for the same system
+3. **Snapshots existing reports**: Fetches all current `CurrentReport` records for the host before modifications
+4. **Creates/updates Upload**: `update_or_create` on the `Upload` record for this host+org+source combination
+5. **Content filtering**: Optionally filters rule IDs for non-RHEL systems (e.g., only keeping "other_linux_system" rules) and RHEL6 systems (only upgrade rules)
+6. **Report reconciliation** — the key logic:
+   - Matches incoming rule IDs against rules in the database
+   - Preserves `impacted_date` for rules that already had reports (continuity tracking)
+   - Separates reports into **new** (bulk created) and **existing** (individually updated)
+   - **Deletes** any `CurrentReport` records whose rule IDs are no longer in the incoming results (rule is resolved)
+7. **Webhook/notification triggers** (`reports.py`): After the DB transaction, calls `trigger_report_hooks()` which:
+   - Compares new report list against previous DB reports
+   - Identifies **new recommendations** (rule hit appeared) and **resolved recommendations** (rule hit disappeared)
+   - Filters out acked/host-acked rules from notifications
+   - Produces messages to the **webhooks topic** and **remediations hook topic** via Kafka
+
+### 3. `handle_rule_hits()` — Third-party rule hits
+
+Similar to engine results but with a simpler payload format. Validates required keys (`org_id`, `source`, `host_product`, `host_role`, `inventory_id`, `hits`), resolves the system type, then delegates to the same `create_db_reports()` function.
+
+### 4. `handle_inventory_event()` — Host deletion
+
+Handles `delete` events from HBI. When a host is deleted from inventory:
+- Deletes the `Upload` records for that host (with DB retry logic, up to 3 attempts)
+- Deletes all `CurrentReport` records for that host
+- Deletes all `HostAck` records for that host
+- Each step retries independently on `OperationalError`/`InterfaceError`, closing stale DB connections between attempts
+
+## Supporting Infrastructure
+
+- **`payload_tracker.py`**: Produces status messages to a Kafka topic for payload lifecycle tracking (received → processing → success/error)
+- **`reports.py`**: Produces webhook and remediations events to Kafka when recommendations change
+- **`thread_storage.py`**: Thread-local storage for request context (request_id, inventory_id, org_id, timing metrics) used by logging and payload tracker
+- **`prometheus.py`**: Prometheus metrics — request counts, timing histograms, error counters, service status
+- **`settings.py`**: Configuration via environment variables with Clowder integration for OpenShift deployments
+
+## Error Handling
+
+- DB connection errors trigger `close_old_connections()` and retry
+- The entire report-creation flow is wrapped in `transaction.atomic()` — if anything fails, all DB changes roll back
+- Webhook/notification failures are caught and logged but **do not** fail the overall upload processing
+- Malformed JSON messages are logged and skipped
+
+# Local Testing with Kafka
+
+## Step 1: Start infrastructure and database
+
+```bash
+podman-compose up -d advisor-db init-kafka
+```
+This starts PostgreSQL and Kafka and creates the required topics (including `platform.engine.results`, `platform.inventory.events`, `platform.insights.rule-hits`).
+
+## Step 2: Set up the database and start the service
+
+```bash
+export ADVISOR_DB_HOST=localhost
+pipenv run migratedb
+pipenv run mockcyndi
+pipenv run loaddata
+pipenv run loadtestdata
+
+export BOOTSTRAP_SERVERS=localhost:9092
+export LOG_LEVEL=DEBUG
+pipenv run python service/service.py
+```
+... or ...
+```
+export ADVISOR_DB_HOST=localhost
+podman-compose up advisor-service
+```
+
+With `LOG_LEVEL=DEBUG` you'll see it log subscription to topics and every poll cycle.
+
+## Step 4: Send fake messages
+
+In a second terminal, use the pre-built scripts in `service/manual_test/`:
+
+**Send engine results** (simulates an insights-client upload):
+```bash
+pipenv run python service/manual_test/send_fake_engine_results.py
+pipenv run python api/advisor/manage.py freshen_hosts
+```
+This sends the payload from `fake_engine_result_rhel.json` — a host with 6 rule hits (org_id `9876543`, inventory ID `57c4c38b-...`). The service will log receiving it, resolving the system type, and creating/updating reports.
+
+**Send a host delete event**:
+```bash
+pipenv run python service/manual_test/send_fake_delete.py
+```
+This sends a delete event for inventory ID `00112233-4455-6677-8899-012345678901`. The service will log deleting uploads, reports, and host acks.
+
+**Other fake payloads** available:
+- `send_fake_engine_results.py` — supports `ENGINE_RESULTS_FILE` env var to pick a different JSON file:
+  - `fake_engine_result_rhel.json` (default)
+  - `fake_engine_result_non_rhel.json`
+  - `fake_engine_result_rhel6.json`
+  - `fake_engine_result_system01.json`
+- `send_fake_inventory_engine_message.py` — requires a running shared engine instance
+- `send_fake_dispatcher_run.py` — playbook dispatcher run simulation
+- `send_fake_task_upload.py` — tasks upload simulation
+
+To send more messages, edit the `range(1)` on line 44 of the send script to a higher number.
+
+## What you'll see in the service logs
+
+With `DEBUG` logging, the service will log:
+1. `"Received Platform Kafka message at ... from topic platform.engine.results"`
+2. `"Processing engine results for Inventory ID ... on account ... and org_id ..."`
+3. `"Created new upload for system UUID ..."` or `"Updated existing upload ..."`
+4. `"Creating current report object rule_id: ..."` for each rule hit
+5. `"Logged N reports for system UUID ..."` on success
+
+For errors (e.g. missing fixtures), you'll see `"Unable to get system type rhel / host from DB - load fixtures!"`.
+
+## Step 5: Verify data in the database
+
+After sending fake engine results, you can query the database to confirm the host, upload, and reports were created. The fake RHEL payload uses inventory_id `57c4c38b-a8c6-4289-9897-223681fd804d`, org_id `9876543`, and account `1234567`.
+
+### Django ORM
+
+```bash
+export ADVISOR_DB_HOST=localhost
+pipenv run python api/advisor/manage.py shell
+```
+
+Then in the shell:
+
+```python
+from api.models import Host, Upload, CurrentReport
+
+# See the host
+Host.objects.filter(inventory_id='57c4c38b-a8c6-4289-9897-223681fd804d').values()
+
+# See uploads for this host
+Upload.objects.filter(host_id='57c4c38b-a8c6-4289-9897-223681fd804d').values()
+
+# See current reports (rule hits) for this host
+CurrentReport.objects.filter(host_id='57c4c38b-a8c6-4289-9897-223681fd804d').values()
+
+# See reports with rule IDs (more readable)
+CurrentReport.objects.filter(
+    host_id='57c4c38b-a8c6-4289-9897-223681fd804d'
+).values('rule__rule_id', 'org_id', 'impacted_date', 'details')
+
+# Query by org_id instead
+Host.objects.filter(org_id='9876543').values()
+CurrentReport.objects.filter(org_id='9876543').values('host_id', 'rule__rule_id')
+```
+
+#### Pretty printing ORM output
+
+Use `pprint` for readable `.values()` output:
+```python
+from pprint import pprint
+pprint(list(Host.objects.filter(org_id='9876543').values()))
+```
+
+Print each object on its own line:
+```python
+for r in CurrentReport.objects.filter(host_id='57c4c38b-a8c6-4289-9897-223681fd804d').values('rule__rule_id', 'org_id'):
+    print(r)
+```
+
+Use `json` for JSON-style output (with `DjangoJSONEncoder` to handle datetime fields):
+```python
+import json
+from django.core.serializers.json import DjangoJSONEncoder
+qs = CurrentReport.objects.filter(host_id='57c4c38b-a8c6-4289-9897-223681fd804d').values('rule__rule_id', 'org_id', 'impacted_date')
+print(json.dumps(list(qs), indent=2, cls=DjangoJSONEncoder))
+
+# See the host with display_name from InventoryHost (via the inventory FK)
+from django.db.models import F
+qs = Host.objects.filter(inventory_id='00112233-4455-6677-8899-012345678901').annotate(display_name=F('inventory__display_name')).values()
+print(json.dumps(list(qs), indent=2, cls=DjangoJSONEncoder))
+```
+
+### Raw SQL
+
+```bash
+export ADVISOR_DB_HOST=localhost
+pipenv run python api/advisor/manage.py dbshell
+```
+
+Then in psql:
+
+```sql
+-- See the host (table: api_host, PK column: system_uuid)
+SELECT * FROM api_host
+WHERE system_uuid = '57c4c38b-a8c6-4289-9897-223681fd804d';
+
+-- See uploads for this host
+SELECT * FROM api_upload
+WHERE host_id = '57c4c38b-a8c6-4289-9897-223681fd804d';
+
+-- See current reports for this host
+SELECT * FROM api_currentreport
+WHERE system_uuid = '57c4c38b-a8c6-4289-9897-223681fd804d';
+
+-- See reports with rule IDs (joined)
+SELECT cr.system_uuid, r.rule_id, cr.org_id, cr.impacted_date
+FROM api_currentreport cr
+JOIN api_rule r ON cr.rule_id = r.id
+WHERE cr.system_uuid = '57c4c38b-a8c6-4289-9897-223681fd804d';
+
+-- Query by org_id
+SELECT * FROM api_host WHERE org_id = '9876543';
+SELECT h.system_uuid, r.rule_id FROM api_currentreport cr
+JOIN api_rule r ON cr.rule_id = r.id
+WHERE cr.org_id = '9876543';
+```
+
+Note: The `Host` model's PK field is called `inventory_id` in Django but maps to the DB column `system_uuid` (via `db_column='system_uuid'`). Similarly, `CurrentReport.host` maps to `system_uuid` in the DB.
+
+## Alternative: Run automated tests (no Kafka needed)
+
+If you just want to verify the service logic without running real Kafka:
+```bash
+export ADVISOR_DB_HOST=localhost
+pipenv run testservice
+```
+This uses pytest with mock Kafka consumers/producers (`DummyMessage`, `DummyConsumer`, etc.) and doesn't require a running Kafka broker.
+
+# Viewing Data via the API
+
+## Starting the API
+
+```bash
+export ADVISOR_DB_HOST=localhost
+pipenv run runapi
+... or ...
+pipenv run python api/advisor/manage.py runserver
+```
+
+This starts the Django dev server on `http://localhost:8000`. RBAC and Kessel are disabled by default for local dev.
+
+## Authentication
+
+All API requests require an `x-rh-identity` header containing a base64-encoded JSON identity. Generate one matching the fake engine results data (org_id `9876543`, account `1234567`):
+
+```bash
+export RH_IDENTITY=$(echo '{"identity": {"account_number": "1234567", "org_id": "9876543", "type": "User", "auth_type": "jwt", "user": {"username": "testing", "is_internal": true}}}' | base64 -w 0)
+```
+
+## API Endpoints
+
+The base path is `http://localhost:8000/api/insights/v1/`.
+
+**List all systems for your org:**
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/ | python -m json.tool
+```
+
+**Get a specific system by inventory ID:**
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/57c4c38b-a8c6-4289-9897-223681fd804d/ | python -m json.tool
+```
+
+**Get reports (rule hits) for a specific system:**
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/57c4c38b-a8c6-4289-9897-223681fd804d/reports/ | python -m json.tool
+```
+
+**List all rules:**
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/rule/ | python -m json.tool
+```
+
+**Get a specific rule and its systems:**
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/rule/test%7CActive_rule/ | python -m json.tool
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/rule/test%7CActive_rule/systems/ | python -m json.tool
+```
+
+**Other useful endpoints:**
+```bash
+# Acknowledgements
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/ack/ | python -m json.tool
+
+# Host acknowledgements
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/hostack/ | python -m json.tool
+
+# Stats overview
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/stats/ | python -m json.tool
+
+# Pathways
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/pathway/ | python -m json.tool
+
+# System types
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/systemtype/ | python -m json.tool
+```
+
+## Swagger UI
+
+Browse the API interactively at:
+```
+http://localhost:8000/api/insights/v1/openapi/swagger/
+```
+
+Use the Authorize button and paste the `$RH_IDENTITY` value into the `x-rh-identity` field.
+
+## API Root
+
+Visit `http://localhost:8000/api/insights/v1/` in a browser to see the full list of available endpoints (DRF's browsable API).

--- a/service/manual_test/fake_engine_result_rhel.json
+++ b/service/manual_test/fake_engine_result_rhel.json
@@ -20,7 +20,7 @@
       "stale_timestamp": "2020-02-12T12:30:21.831767+00:00",
       "stale_warning_timestamp": "2020-02-12T12:30:21.831767+00:00",
       "subscription_manager_id": "f0025e01-52ce-4681-ab88-f3ed0657fa95",
-      "system_profile": {},
+      "system_profile": {"operating_system": {"name": "RHEL", "major": 8, "minor": 0}},
       "tags": [{"namespace": "foo", "key": "bar", "value": "buzz"},
                  {"namespace": "sample", "key": "tag", "value": "1"},
                  {"namespace": "sample", "key": "tag", "value": "2"}],

--- a/service/manual_test/fake_engine_result_system01.json
+++ b/service/manual_test/fake_engine_result_system01.json
@@ -87,7 +87,7 @@
           }
         ],
         "release": "Red Hat Enterprise Linux Server 7.5 (Maipo)",
-        "rhel_version": "8.0",
+        "rhel_version": "7.5",
         "system_information": {
           "family": "Not Specified",
           "manufacturer": "Dell Inc.",

--- a/service/manual_test/insert_inventory_host.py
+++ b/service/manual_test/insert_inventory_host.py
@@ -1,0 +1,136 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Utility to insert a host dict into the local inventory.hosts_table.
+
+Usage from another script:
+    from insert_inventory_host import insert_host
+    insert_host(host_data_dict)
+
+Or standalone:
+    python insert_inventory_host.py fake_engine_result_rhel.json
+
+The host dict should match the shape found in engine result JSON files
+(i.e. input.host) or inventory messages (i.e. host).
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project_settings.settings")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'api', 'advisor'))
+django.setup()
+
+import psycopg2
+from psycopg2.extras import Json
+from django.conf import settings
+
+_db = settings.DATABASES['default']
+DB_HOST = _db['HOST']
+DB_PORT = _db['PORT'] or '5432'
+DB_NAME = _db['NAME']
+DB_USER = _db['USER']
+DB_PASSWORD = _db['PASSWORD']
+
+
+def insert_host(host_data):
+    """Insert or update a host in inventory.hosts_table.
+
+    Args:
+        host_data: dict with at least 'id', 'org_id', and 'display_name'.
+    """
+    now = datetime.now(timezone.utc)
+    try:
+        conn = psycopg2.connect(
+            host=DB_HOST, port=DB_PORT, dbname=DB_NAME,
+            user=DB_USER, password=DB_PASSWORD
+        )
+    except psycopg2.OperationalError as e:
+        print(f"Could not connect to database: {e}")
+        print(f"Cannot insert host {host_data['display_name']} into inventory.hosts_table and so the API can't display it.")
+        return
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO inventory.hosts_table (
+                    id, account, org_id, display_name, tags, groups,
+                    updated, created, last_check_in, stale_timestamp,
+                    system_profile, reporter, per_reporter_staleness,
+                    insights_id
+                ) VALUES (
+                    %(id)s, %(account)s, %(org_id)s, %(display_name)s,
+                    %(tags)s, %(groups)s, %(updated)s, %(created)s,
+                    %(last_check_in)s, %(stale_timestamp)s,
+                    %(system_profile)s, %(reporter)s,
+                    %(per_reporter_staleness)s, %(insights_id)s
+                )
+                ON CONFLICT (id) DO UPDATE SET
+                    display_name = EXCLUDED.display_name,
+                    tags = EXCLUDED.tags,
+                    updated = EXCLUDED.updated,
+                    stale_timestamp = EXCLUDED.stale_timestamp,
+                    system_profile = EXCLUDED.system_profile,
+                    reporter = EXCLUDED.reporter,
+                    per_reporter_staleness = EXCLUDED.per_reporter_staleness
+            """, {
+                'id': host_data['id'],
+                'account': host_data.get('account'),
+                'org_id': host_data['org_id'],
+                'display_name': host_data['display_name'],
+                'tags': Json(host_data.get('tags', [])),
+                'groups': Json(host_data.get('groups', [])),
+                'updated': host_data.get('updated') or now,
+                'created': host_data.get('created') or now,
+                'last_check_in': now,
+                'stale_timestamp': host_data.get('stale_timestamp') or now,
+                'system_profile': Json(host_data.get('system_profile', {})),
+                'reporter': host_data.get('reporter', 'puptoo'),
+                'per_reporter_staleness': Json(
+                    host_data.get('per_reporter_staleness', {})
+                ),
+                'insights_id': host_data.get('insights_id'),
+            })
+        conn.commit()
+        print(f"Host {host_data['id']} inserted into inventory.hosts_table")
+    finally:
+        conn.close()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python insert_inventory_host.py <engine_result.json>')
+        sys.exit(1)
+
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    filepath = os.path.join(this_dir, os.path.basename(sys.argv[1]))
+
+    with open(filepath) as f:
+        data = json.load(f)
+
+    # Support both engine result format (input.host) and inventory format (host)
+    if 'input' in data and 'host' in data['input']:
+        host = data['input']['host']
+    elif 'host' in data:
+        host = data['host']
+    else:
+        print('Could not find host data in JSON file')
+        sys.exit(1)
+
+    insert_host(host)

--- a/service/manual_test/send_fake_engine_results.py
+++ b/service/manual_test/send_fake_engine_results.py
@@ -18,6 +18,7 @@ import json
 import os
 
 from confluent_kafka import Producer
+from insert_inventory_host import insert_host
 
 BOOTSTRAP_SERVERS = os.environ.get('BOOTSTRAP_SERVERS', 'localhost:9092')
 ENGINE_RESULTS_TOPIC = os.environ.get('ENGINE_RESULTS_TOPIC', 'platform.engine.results')
@@ -30,6 +31,9 @@ p = Producer({'bootstrap.servers': BOOTSTRAP_SERVERS})
 
 with open(os.path.join(THIS_DIR, ENGINE_RESULTS_FILE)) as f:
     engine_results_message = json.load(f)
+
+# Insert the host into inventory.hosts_table so the API can find it
+insert_host(engine_results_message['input']['host'])
 
 
 def delivery_report(err, msg):


### PR DESCRIPTION
- piggybacking creating a separate local dev container setup
- adding .gitignore

## Summary by Sourcery

Add local development container setup and helper scripts, update documentation for running Advisor locally, and introduce a Claude configuration guide and inventory host test helper.

Enhancements:
- Add a helper script to insert test inventory hosts and integrate it into the fake engine results sender for better end-to-end local testing.
- Adjust podman-compose configuration and commands for advisor-service and advisor-api to better support local development workflows, including a dedicated local dev container init script and Dockerfile.
- Standardize README references and example code snippets for API filtering and view annotations.

Build:
- Introduce Containerfile.localdev and container_init_localdev.sh to build and initialize a local development Advisor API container with migrations, fixtures, and optional content import.
- Update podman-compose service dependencies, images, and networking to align with the new local dev setup and remove unused components like Zookeeper and Nginx.

Documentation:
- Update service, API, and top-level READMEs with clearer local dev, Kafka, and testing instructions, including freshening hosts and using init-kafka.
- Add CLAUDE.md describing project architecture, common commands, and conventions for working with the codebase.

Chores:
- Add a repository .gitignore file.