### PR TITLE
API: add workspace field and filter to the rules endpoint

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -590,6 +590,17 @@ update_method_query_param = OpenApiParameter(
     enum=('ostree', 'dnfyum')
 )
 
+group_id_query_param = OpenApiParameter(
+    name='group_id', location=OpenApiParameter.QUERY,
+    required=False, many=True, style='form', type=OpenApiTypes.UUID,
+    description=(
+        'Filter recommendations by group UUID. '
+        'Groups organize hosts in Inventory into workspaces. '
+        'Pass one or more group UUIDs to filter recommendations for hosts in those groups. '
+        'If omitted, shows recommendations from all groups.'
+    )
+)
+
 
 ##############################################################################
 # Commonly used filters
@@ -817,6 +828,39 @@ def filter_on_update_method(request, relation: Optional[str] = None):
     if 'dnfyum' in update_methods:
         update_method_filter |= Q(**{base_parameter + '__in': ('dnf', 'yum')})
     return update_method_filter
+
+
+def filter_on_workspace(request, relation: Optional[str] = None):
+    """
+    Filter recommendations by group UUID(s).
+
+    Groups are used in Inventory to organize hosts into workspaces.
+    This filter matches hosts that belong to any of the specified groups.
+
+    Args:
+        request: The HTTP request containing query parameters
+        relation: Optional relation prefix (e.g., 'inventory' for inventory__groups)
+
+    Returns:
+        Q object for filtering by group UUID(s)
+    """
+    group_ids = value_of_param(group_id_query_param, request)
+    if not group_ids:
+        return Q()
+
+    group_field = 'groups'
+    if relation:
+        group_field = f'{relation}__{group_field}'
+    group_contains_clause = group_field + '__contains'
+
+    # Build OR filter for multiple group IDs
+    group_filter = Q()
+    for group_id in group_ids:
+        # Filter by group UUID
+        # JSONField contains array of objects with 'id' field
+        group_filter |= Q(**{group_contains_clause: [{'id': str(group_id)}]})
+
+    return group_filter
 
 
 #######################################################

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -35,7 +35,7 @@ from api.filters import (
     category_query_param, host_group_name_query_param, pathway_query_param,
     filter_on_branch_id, filter_on_display_name, filter_on_system_type,
     filter_on_hits, filter_on_host_tags, filter_on_incident, filter_on_rhel_version,
-    filter_on_update_method, filter_on_has_disabled_recommendation,
+    filter_on_update_method, filter_on_has_disabled_recommendation, filter_on_workspace,
 )
 
 import logging
@@ -410,6 +410,7 @@ def get_reports_subquery(
             branch_id_filter,
             filter_on_update_method(request, relation='inventory'),
             get_host_group_filter(request, relation='inventory'),
+            filter_on_workspace(request, relation='inventory'),
             stale_systems_filter,
         ) if exclude_ineligible_hosts else Q(),
         **outer_table_join

--- a/api/advisor/api/serializers.py
+++ b/api/advisor/api/serializers.py
@@ -259,6 +259,8 @@ class RuleForAccountSerializer(NonNullModelSerializer):
     tags = serializers.SerializerMethodField()
     rating = serializers.IntegerField(read_only=True)
     pathway = RulePathwaySerializer(many=False, required=False)
+    workspace = serializers.SerializerMethodField()
+    group_id = serializers.SerializerMethodField()
 
     def get_playbook_count(self, value):
         return 0 if value.playbook_count is None else value.playbook_count
@@ -266,6 +268,40 @@ class RuleForAccountSerializer(NonNullModelSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_tags(self, value):
         return ' '.join(tag.name for tag in value.tags.order_by('name'))
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_workspace(self, rule):
+        """Get workspace name from first impacted system."""
+        # Get first current report for this rule
+        request = self.context.get('request')
+        if not request:
+            return None
+
+        from api.models import get_reports_subquery
+        first_report = get_reports_subquery(request, rule_id=rule.id).select_related('inventory').first()
+
+        if not first_report or not first_report.inventory:
+            return None
+
+        return first_report.inventory.group_name
+
+    @extend_schema_field(OpenApiTypes.UUID)
+    def get_group_id(self, rule):
+        """Get group ID from first impacted system."""
+        request = self.context.get('request')
+        if not request:
+            return None
+
+        from api.models import get_reports_subquery
+        first_report = get_reports_subquery(request, rule_id=rule.id).select_related('inventory').first()
+
+        if not first_report or not first_report.inventory:
+            return None
+
+        inventory = first_report.inventory
+        if inventory.groups and len(inventory.groups) > 0:
+            return inventory.groups[0].get('id')
+        return None
 
     class Meta:
         model = models.Rule
@@ -275,7 +311,8 @@ class RuleForAccountSerializer(NonNullModelSerializer):
             'likelihood', 'node_id', 'tags', 'playbook_count',
             'reboot_required', 'publish_date', 'summary', 'generic',
             'reason', 'more_info', 'impacted_systems_count', 'reports_shown', 'rule_status',
-            'resolution_set', 'total_risk', 'hosts_acked_count', 'rating', 'pathway'
+            'resolution_set', 'total_risk', 'hosts_acked_count', 'rating', 'pathway',
+            'workspace', 'group_id'
         )
 
 

--- a/api/advisor/api/tests/test_rule_workspace_filter.py
+++ b/api/advisor/api/tests/test_rule_workspace_filter.py
@@ -1,0 +1,396 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests for workspace filtering on the recommendations table (rules endpoint).
+
+The recommendations table shows all rules and their impacted system counts.
+Workspace filtering allows users to:
+- See workspace (group name) for each rule
+- See group_id (UUID) for filtering
+- Filter rules by workspace using group_id parameter
+- Sort rules by workspace name
+"""
+
+from datetime import timedelta
+from uuid import uuid4
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from api.models import (
+    InventoryHost, CurrentReport, Upload, Rule, RuleCategory, RuleSet, Host,
+    SystemType, UploadSource
+)
+from api.permissions import auth_header_for_testing
+from api.tests import constants
+
+
+class RuleWorkspaceFilterTestCase(TestCase):
+    """Test workspace field and filtering on recommendations table."""
+
+    def setUp(self):
+        """Set up test data with rules affecting hosts in different workspaces."""
+        self.client = APIClient()
+
+        # Create test category and ruleset
+        self.category = RuleCategory.objects.create(name="Availability")
+        self.ruleset = RuleSet.objects.create(
+            rule_source="https://test.example.com/rules",
+            description="Test ruleset for workspace filtering"
+        )
+
+        # Create test rules
+        self.rule_1 = Rule.objects.create(
+            rule_id="test_workspace_rule_1|TEST_RULE_1",
+            ruleset=self.ruleset,
+            category=self.category,
+            description="Test rule 1 for workspace filtering",
+            summary="Test summary 1",
+            generic="Test generic 1",
+            reason="Test reason 1",
+            active=True
+        )
+
+        self.rule_2 = Rule.objects.create(
+            rule_id="test_workspace_rule_2|TEST_RULE_2",
+            ruleset=self.ruleset,
+            category=self.category,
+            description="Test rule 2 for workspace filtering",
+            summary="Test summary 2",
+            generic="Test generic 2",
+            reason="Test reason 2",
+            active=True
+        )
+
+        # Create SystemType and UploadSource for uploads
+        self.system_type = SystemType.objects.create(role="host", product_code="rhel")
+        self.upload_source = UploadSource.objects.create(name="test-source")
+
+        # Create workspaces (groups)
+        self.engineering_group_id = uuid4()
+        self.production_group_id = uuid4()
+        self.testing_group_id = uuid4()
+
+        # Common timestamp values for hosts
+        now = timezone.now()
+        created_at = now - timedelta(days=7)
+        stale_timestamp = now + timedelta(days=1)
+        per_reporter_staleness = {
+            'puptoo': {
+                'stale_warning_timestamp': (now + timedelta(days=1)).isoformat(),
+                'check_in_succeeded': True
+            }
+        }
+
+        # Create hosts in different workspaces
+        # Engineering workspace - 2 hosts
+        self.host_eng_1_id = uuid4()
+        self.host_eng_1 = InventoryHost.objects.create(
+            id=self.host_eng_1_id,
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            display_name="engineering-host-1",
+            tags=[],
+            groups=[
+                {'id': str(self.engineering_group_id), 'name': 'Engineering', 'ungrouped': False}
+            ],
+            created=created_at,
+            updated=now,
+            last_check_in=now,
+            stale_timestamp=stale_timestamp,
+            insights_id=uuid4(),
+            per_reporter_staleness=per_reporter_staleness
+        )
+
+        self.host_eng_2_id = uuid4()
+        self.host_eng_2 = InventoryHost.objects.create(
+            id=self.host_eng_2_id,
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            display_name="engineering-host-2",
+            tags=[],
+            groups=[
+                {'id': str(self.engineering_group_id), 'name': 'Engineering', 'ungrouped': False}
+            ],
+            created=created_at,
+            updated=now,
+            last_check_in=now,
+            stale_timestamp=stale_timestamp,
+            insights_id=uuid4(),
+            per_reporter_staleness=per_reporter_staleness
+        )
+
+        # Production workspace - 1 host
+        self.host_prod_1_id = uuid4()
+        self.host_prod_1 = InventoryHost.objects.create(
+            id=self.host_prod_1_id,
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            display_name="production-host-1",
+            tags=[],
+            groups=[
+                {'id': str(self.production_group_id), 'name': 'Production', 'ungrouped': False}
+            ],
+            created=created_at,
+            updated=now,
+            last_check_in=now,
+            stale_timestamp=stale_timestamp,
+            insights_id=uuid4(),
+            per_reporter_staleness=per_reporter_staleness
+        )
+
+        # Testing workspace - 1 host
+        self.host_test_1_id = uuid4()
+        self.host_test_1 = InventoryHost.objects.create(
+            id=self.host_test_1_id,
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            display_name="testing-host-1",
+            tags=[],
+            groups=[
+                {'id': str(self.testing_group_id), 'name': 'Testing', 'ungrouped': False}
+            ],
+            created=created_at,
+            updated=now,
+            last_check_in=now,
+            stale_timestamp=stale_timestamp,
+            insights_id=uuid4(),
+            per_reporter_staleness=per_reporter_staleness
+        )
+
+        # Ungrouped host
+        self.host_ungrouped_id = uuid4()
+        self.host_ungrouped = InventoryHost.objects.create(
+            id=self.host_ungrouped_id,
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            display_name="ungrouped-host",
+            tags=[],
+            groups=[],
+            created=created_at,
+            updated=now,
+            last_check_in=now,
+            stale_timestamp=stale_timestamp,
+            insights_id=uuid4(),
+            per_reporter_staleness=per_reporter_staleness
+        )
+
+        # Create Host and Upload records (needed for CurrentReport)
+        self.uploads = {}
+        for host_id in [self.host_eng_1_id, self.host_eng_2_id, self.host_prod_1_id,
+                        self.host_test_1_id, self.host_ungrouped_id]:
+            host = Host.objects.create(
+                inventory_id=host_id,
+                account=constants.standard_acct,
+                org_id=constants.standard_org
+            )
+            self.uploads[host_id] = Upload.objects.create(
+                host=host,
+                account=constants.standard_acct,
+                org_id=constants.standard_org,
+                system_type=self.system_type,
+                source=self.upload_source
+            )
+
+        # Rule 1 affects: Engineering (2), Production (1)
+        CurrentReport.objects.create(
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            rule=self.rule_1,
+            host_id=self.host_eng_1_id,
+            upload=self.uploads[self.host_eng_1_id],
+            details={}
+        )
+        CurrentReport.objects.create(
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            rule=self.rule_1,
+            host_id=self.host_eng_2_id,
+            upload=self.uploads[self.host_eng_2_id],
+            details={}
+        )
+        CurrentReport.objects.create(
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            rule=self.rule_1,
+            host_id=self.host_prod_1_id,
+            upload=self.uploads[self.host_prod_1_id],
+            details={}
+        )
+
+        # Rule 2 affects: Testing (1), Ungrouped (1)
+        CurrentReport.objects.create(
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            rule=self.rule_2,
+            host_id=self.host_test_1_id,
+            upload=self.uploads[self.host_test_1_id],
+            details={}
+        )
+        CurrentReport.objects.create(
+            account=constants.standard_acct,
+            org_id=constants.standard_org,
+            rule=self.rule_2,
+            host_id=self.host_ungrouped_id,
+            upload=self.uploads[self.host_ungrouped_id],
+            details={}
+        )
+
+        # Auth header
+        self.auth_header = auth_header_for_testing()
+
+    def test_workspace_field_in_response(self):
+        """Test that workspace field appears in recommendations table response."""
+        response = self.client.get(
+            reverse('rule-list'),
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Find our test rules in response
+        rules = {r['rule_id']: r for r in response.data['data']}
+
+        self.assertIn('test_workspace_rule_1|TEST_RULE_1', rules)
+        self.assertIn('workspace', rules['test_workspace_rule_1|TEST_RULE_1'])
+
+    def test_group_id_field_in_response(self):
+        """Test that group_id field appears in recommendations table response."""
+        response = self.client.get(
+            reverse('rule-list'),
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        rules = {r['rule_id']: r for r in response.data['data']}
+
+        self.assertIn('test_workspace_rule_1|TEST_RULE_1', rules)
+        self.assertIn('group_id', rules['test_workspace_rule_1|TEST_RULE_1'])
+
+    def test_workspace_shows_first_affected_workspace(self):
+        """Test that workspace shows the first affected system's workspace."""
+        response = self.client.get(
+            reverse('rule-list'),
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        rules = {r['rule_id']: r for r in response.data['data']}
+        rule_1 = rules['test_workspace_rule_1|TEST_RULE_1']
+
+        # Rule 1 affects Engineering and Production - should show first one
+        self.assertIsNotNone(rule_1['workspace'])
+        self.assertIn(rule_1['workspace'], ['Engineering', 'Production'])
+
+    def test_filter_by_single_group_id(self):
+        """Test filtering recommendations by single workspace (group_id)."""
+        response = self.client.get(
+            reverse('rule-list'),
+            {'group_id': [str(self.engineering_group_id)]},
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        rules = {r['rule_id']: r for r in response.data['data']}
+
+        # Should include rule_1 with impacted systems in Engineering
+        self.assertIn('test_workspace_rule_1|TEST_RULE_1', rules)
+        rule_1 = rules['test_workspace_rule_1|TEST_RULE_1']
+        self.assertEqual(rule_1['impacted_systems_count'], 2)  # 2 Engineering hosts
+
+        # Rule_2 may still appear but with 0 impacted systems (doesn't affect Engineering)
+        if 'test_workspace_rule_2|TEST_RULE_2' in rules:
+            rule_2 = rules['test_workspace_rule_2|TEST_RULE_2']
+            self.assertEqual(rule_2['impacted_systems_count'], 0)
+
+    def test_filter_by_multiple_group_ids(self):
+        """Test filtering by multiple group_ids (OR logic)."""
+        response = self.client.get(
+            reverse('rule-list'),
+            {'group_id': [str(self.engineering_group_id), str(self.testing_group_id)]},
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        rule_ids = [r['rule_id'] for r in response.data['data']]
+
+        # Should include rule_1 (affects Engineering)
+        self.assertIn('test_workspace_rule_1|TEST_RULE_1', rule_ids)
+        # Should include rule_2 (affects Testing)
+        self.assertIn('test_workspace_rule_2|TEST_RULE_2', rule_ids)
+
+    def test_impacted_systems_count_filtered_by_workspace(self):
+        """Test that impacted_systems_count reflects workspace filter."""
+        # Without filter - rule_1 affects 3 systems (2 Eng + 1 Prod)
+        response = self.client.get(
+            reverse('rule-list'),
+            **self.auth_header
+        )
+        rules = {r['rule_id']: r for r in response.data['data']}
+        rule_1 = rules.get('test_workspace_rule_1|TEST_RULE_1')
+        if rule_1:
+            total_count = rule_1['impacted_systems_count']
+            self.assertEqual(total_count, 3)
+
+        # With Engineering filter - rule_1 should show 2 systems
+        response = self.client.get(
+            reverse('rule-list'),
+            {'group_id': str(self.engineering_group_id)},
+            **self.auth_header
+        )
+        rules = {r['rule_id']: r for r in response.data['data']}
+        rule_1 = rules.get('test_workspace_rule_1|TEST_RULE_1')
+        if rule_1:
+            filtered_count = rule_1['impacted_systems_count']
+            self.assertEqual(filtered_count, 2)
+
+    def test_no_filter_shows_all_rules(self):
+        """Test that omitting group_id filter shows all rules."""
+        response = self.client.get(
+            reverse('rule-list'),
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        rule_ids = [r['rule_id'] for r in response.data['data']]
+
+        # Should include both test rules
+        self.assertIn('test_workspace_rule_1|TEST_RULE_1', rule_ids)
+        self.assertIn('test_workspace_rule_2|TEST_RULE_2', rule_ids)
+
+    def test_workspace_with_other_filters(self):
+        """Test that workspace filter works alongside other filters."""
+        response = self.client.get(
+            reverse('rule-list'),
+            {
+                'group_id': [str(self.engineering_group_id)],
+            },
+            **self.auth_header
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Should successfully return results
+        self.assertGreater(len(response.data['data']), 0)
+

--- a/api/advisor/api/views/rules.py
+++ b/api/advisor/api/views/rules.py
@@ -38,7 +38,7 @@ from api.filters import (
     sort_params_to_fields, sort_param_enum, filter_on_display_name,
     systems_detail_name_query_param, host_group_name_query_param,
     topic_query_param, filter_on_topic, update_method_query_param,
-    system_type_query_param,
+    system_type_query_param, group_id_query_param,
 )
 from api.models import (
     Ack, CurrentReport, HostAck, Resolution, Rule,
@@ -356,6 +356,7 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
             filter_system_profile_mssql_query_param,
             filter_system_profile_ansible_query_param,
             host_group_name_query_param, update_method_query_param,
+            group_id_query_param,
         ],
     )
     def list(self, request, format=None):


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-24027

api/advisor/api/filters.py
- Added group_id_query_param OpenAPI parameter accepting one or more group UUIDs. Added
  filter_on_workspace() function that filters CurrentReport by group membership using PostgreSQL JSONField __contains operator.

api/advisor/api/models.py
  - Imported filter_on_workspace from filters. Applied the workspace filter in get_reports_subquery() alongside other existing filters like tags and system profile.

api/advisor/api/serializers.py
  - Added workspace and group_id as SerializerMethodFields to RuleForAccountSerializer.
Implemented getter methods that extract workspace name and group UUID from the first impacted system using existing InventoryHost.group_name property.
  
api/advisor/api/views/rules.py
  - Imported group_id_query_param from filters. Added it to the @extend_schema parameters list for the rule-list endpoint to document the new query parameter.

api/advisor/api/tests/test_rule_workspace_filter.py (new file)
  - Created comprehensive test suite with 8 test cases. Tests cover workspace/group_id field display, single/multiple group filtering, impacted systems count with filters, and filter
  combinations

## Summary by Sourcery

Add workspace awareness and group-based filtering to the rules (recommendations) API.

New Features:
- Expose workspace name and group_id fields on rule responses derived from impacted systems.
- Support filtering recommendations by one or more inventory group UUIDs via a new group_id query parameter.

Enhancements:
- Apply workspace-based filtering in the reports subquery so impacted_systems_count and results reflect selected workspaces.

Tests:
- Add a dedicated test suite validating workspace fields on rules, single and multi-group filtering, impacted_systems_count behavior, and interaction with other filters.