### PR TITLE
fix(RHINENG-26636): Fix pathways has_incident/tags error

### DIFF
--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -893,6 +893,8 @@ class PathwayManager(models.Manager):
             return self.get_queryset().none().annotate(
                 impacted_systems_count=Value(0),
                 recommendation_level=Value(0),
+                has_incident=Value(False, models.BooleanField()),
+                reboot_required=Value(False, models.BooleanField()),
             )
 
         # get the total systems in an account

--- a/api/advisor/api/tests/test_pathway_views.py
+++ b/api/advisor/api/tests/test_pathway_views.py
@@ -813,3 +813,58 @@ class PathwayViewHostTagsTestCase(TestCase):
         systems_list = systems_page['data']
         self.assertEqual(len(systems_list), 1)  # One system
         self.assertEqual(systems_list[0]['display_name'], 'system02.example.biz')
+
+    def test_pathway_list_filters_with_no_results(self):
+        """
+        When tags filter out all hosts, pathway_agg_data is empty and
+        for_account() takes an early return path. Filtering on annotated
+        fields like has_incident and reboot_required must still work
+        without raising a FieldError.
+        """
+        # has_incident filter with tags that match no hosts
+        response = self.client.get(
+            reverse('pathway-list'),
+            data={'has_incident': 'true', 'tags': 'elephant/in=the_room'},
+            **self.header
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['data'], [])
+        self.assertEqual(response.json()['meta']['count'], 0)
+
+        response = self.client.get(
+            reverse('pathway-list'),
+            data={'has_incident': 'false', 'tags': 'elephant/in=the room'},
+            **self.header
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['data'], [])
+
+        # reboot_required filter with tags that match no hosts
+        response = self.client.get(
+            reverse('pathway-list'),
+            data={'reboot_required': 'true', 'tags': 'elephant/in=the/room'},
+            **self.header
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['data'], [])
+
+        response = self.client.get(
+            reverse('pathway-list'),
+            data={'reboot_required': 'false', 'tags': 'elephant/in=the=room'},
+            **self.header
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['data'], [])
+
+        # Both filters combined with no-match tags
+        response = self.client.get(
+            reverse('pathway-list'),
+            data={
+                'has_incident': 'true',
+                'reboot_required': 'true',
+                'tags': 'elephant/in=the.room',
+            },
+            **self.header
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['data'], [])


### PR DESCRIPTION
## Summary by Claude

When pathway_agg_data is empty (no matching reports - which happens when host tags filter out all systems), the early return only annotated impacted_systems_count and recommendation_level, but not has_incident or reboot_required. Then the list view at pathways.py:215 tries to .filter(has_incident=...) on a queryset missing that annotation, causing the FieldError.

## Summary by Sourcery

Ensure pathway list filtering works correctly when tag filters yield no matching hosts by returning an annotated empty queryset instead of erroring.

Bug Fixes:
- Prevent FieldError when filtering pathways by has_incident or reboot_required in combination with tags that exclude all hosts by annotating the early-return queryset with the expected boolean fields.

Tests:
- Add pathway list tests covering has_incident and reboot_required filters combined with tag filters that result in no matching hosts, asserting empty results and successful responses.