### PR TITLE
fix(RHINENG-25936): Make tag filtering more flexible

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -20,6 +20,7 @@ from functools import reduce
 from itertools import chain, product
 import re
 from typing import Optional
+import urllib.parse
 from uuid import UUID
 
 from django.apps import apps
@@ -516,7 +517,7 @@ host_id_query_param = OpenApiParameter(
 
 host_tags_query_param = OpenApiParameter(
     name='tags', type=OpenApiTypes.REGEX, location=OpenApiParameter.QUERY,
-    pattern=r'^[^/=]+/[^/=]+=[^/=]+$',
+    pattern=r'^[^/]+/[^=]+=.+$',
     description="Tags have a namespace, key and value in the form namespace/key=value",
     required=False, many=True, style='form',
 )
@@ -707,13 +708,13 @@ def filter_on_host_tags(request, field_name='host_id'):
         return Q()
 
     def unescape(token):
-        return token.replace('%2F', '/').replace('%3D', '=')
+        return urllib.parse.unquote(token)
 
     tag_query = Q()
     for tag in host_tags:
 
-        namespace, key_and_value = tag.split('/')
-        key, value = key_and_value.split('=')
+        namespace, key_and_value = tag.split('/', 1)
+        key, value = key_and_value.split('=', 1)
 
         namespace = unescape(namespace)
         key = unescape(key)

--- a/api/advisor/api/tests/test_parameter_parsing.py
+++ b/api/advisor/api/tests/test_parameter_parsing.py
@@ -15,6 +15,8 @@
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
 from datetime import datetime, timezone
+from unittest.mock import patch
+import urllib.parse
 from urllib.parse import quote
 
 from django.db.models import Q
@@ -210,36 +212,96 @@ class HostTagsParameterParsingTestCase(TestCase):
         self.assertIsInstance(q, Q)
         self.assertTrue(q)
 
-        # Caught by parameter regular expression
-        with self.assertRaisesRegex(
-            ValidationError, r"The value did not match the pattern"
-        ):
+        # Empty tag string doesn't match the regex pattern
+        with self.assertRaises(ValidationError):
             filter_on_host_tags(make_request_obj(
                 tags=''
             ))
 
     def test_invalid_tags(self):
+        # No namespace separator '/' - rejected by regex pattern
         with self.assertRaises(ValidationError):
             filter_on_host_tags(make_request_obj(
                 tags='key=value'
             ))
 
+        # No '/' or '=' - rejected by regex pattern
         with self.assertRaises(ValidationError):
             filter_on_host_tags(make_request_obj(
                 tags='key'
             ))
 
+        # No key=value separator '=' - rejected by regex pattern
         with self.assertRaises(ValidationError):
             filter_on_host_tags(make_request_obj(
-                tags='namespace/key'
+                tags='namespace/keyvalue'
+            ))
+
+        # No value - rejected by regex pattern
+        with self.assertRaises(ValidationError):
+            filter_on_host_tags(make_request_obj(
+                tags='n/k/e/y/'
+            ))
+
+        # No key - rejected by regex pattern
+        with self.assertRaises(ValidationError):
+            filter_on_host_tags(make_request_obj(
+                tags='namespace/=value'
             ))
 
     def test_multiple_tags_in_parameter(self):
         q = filter_on_host_tags(make_request_obj(
-            tags='namespace/key=value,Sat/env=prod'
+            tags='namespace/key=value,Sat/env=prod,n/k=v'
         ))
         self.assertIsInstance(q, Q)
         self.assertTrue(q)
+
+    def test_special_chars_in_parameter(self):
+        q = filter_on_host_tags(make_request_obj(
+            tags='some-namespace/some/tag=some/value,n/k/e/y/=/v/a/l/u/e/,namespace with spaces/key with spaces=value with spaces'
+        ))
+        self.assertIsInstance(q, Q)
+        self.assertTrue(q)
+
+    def test_unquoted_encoded_tags(self):
+        """Verify URL-encoded tags are correctly split and decoded.
+
+        The original URL-encoded query string is:
+        tags=insights-client%2Fcustom%252FLast%2520Reboot%3D2023-07-14%252011%253A26%253A07
+             %2Cinsights-client%2FPrivate+IPv4%3D192.168.1.100
+
+        After Django's first URL decode, the tag value becomes what we pass
+        to make_request_obj below. The filter should then split and unquote
+        to produce:
+        - insights-client/custom/Last Reboot=2023-07-14 11:26:07
+        - insights-client/Private IPv4=192.168.1.100
+        """
+        # Value after Django's initial URL decoding of the query string
+        tag_value = (
+            'insights-client/custom%2FLast%20Reboot=2023-07-14%2011%3A26%3A07,'
+            'insights-client/Private IPv4=192.168.1.100'
+        )
+        decoded_tags = []
+        _unquote = urllib.parse.unquote
+
+        def tracking_unquote(s):
+            result = _unquote(s)
+            decoded_tags.append(result)
+            return result
+
+        with patch('urllib.parse.unquote', side_effect=tracking_unquote):
+            q = filter_on_host_tags(make_request_obj(tags=tag_value))
+
+        self.assertIsInstance(q, Q)
+        self.assertTrue(q)
+
+        # unquote is called for namespace, key, value of each tag
+        self.assertEqual(decoded_tags, [
+            # Tag 1: insights-client/custom/Last Reboot=2023-07-14 11:26:07
+            'insights-client', 'custom/Last Reboot', '2023-07-14 11:26:07',
+            # Tag 2: insights-client/Private IPv4=192.168.1.100
+            'insights-client', 'Private IPv4', '192.168.1.100',
+        ])
 
     def test_quoted_parameters(self):
         def make_param_value(namespace, key, value):

--- a/service/README.md
+++ b/service/README.md
@@ -435,6 +435,14 @@ curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/s
 curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/57c4c38b-a8c6-4289-9897-223681fd804d/ | python -m json.tool
 ```
 
+**Match system(s) with specific tags:**
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/?tags=insights-client%2Fcustom%252FLast%2520Reboot%3D2023-07-14%252011%253A26%253A07%2Cinsights-client%2FPrivate+IPv4%3D192.168.1.100
+```
+Note: the tags query parameter is URL-encoded and will match systems tagged with either or both of these tags:
+- `insights-client/custom/Last Reboot=2023-07-14 11:26:07`
+- `insights-client/Private IPv4=192.168.1.100`
+
 **Get reports (rule hits) for a specific system:**
 ```bash
 curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/57c4c38b-a8c6-4289-9897-223681fd804d/reports/ | python -m json.tool

--- a/service/manual_test/fake_engine_result_rhel.json
+++ b/service/manual_test/fake_engine_result_rhel.json
@@ -23,7 +23,9 @@
       "system_profile": {"operating_system": {"name": "RHEL", "major": 8, "minor": 0}},
       "tags": [{"namespace": "foo", "key": "bar", "value": "buzz"},
                  {"namespace": "sample", "key": "tag", "value": "1"},
-                 {"namespace": "sample", "key": "tag", "value": "2"}],
+                 {"namespace": "sample", "key": "tag", "value": "2"},
+                 {"namespace": "insights-client", "key": "custom/Last Reboot", "value": "2023-07-14 11:26:07"},
+                 {"namespace": "insights-client", "key": "Private IPv4", "value": "192.168.1.100"}],
       "updated": null
     },
     "platform_metadata": {


### PR DESCRIPTION
## Summary by Sourcery

Relax tag filtering to support richer tag formats and document their usage.

Bug Fixes:
- Allow tag filters to include special characters, spaces, and additional separators within tag components while still validating basic structure.

Enhancements:
- Decode tag components using standard URL unquoting and split namespace/key/value more flexibly to handle complex tags.

Documentation:
- Add README example showing how to query systems by URL-encoded tags and what resulting tags will match.

Tests:
- Extend parameter parsing tests to cover empty and malformed tags, special characters and spaces, and URL-encoded multi-tag inputs.