### PR TITLE
feat(RHINENG-25280): Display more fields in disabled-rules endpoint

### DIFF
--- a/api/advisor/api/serializers.py
+++ b/api/advisor/api/serializers.py
@@ -457,6 +457,7 @@ class DisabledRulesSerializer(serializers.Serializer):
     """
     rule_id = serializers.CharField(max_length=255, source='rule__rule_id')
     scope = serializers.CharField(max_length=10)
+    is_auto_ack = serializers.BooleanField()
 
 
 def validate_hosts_in_org(hosts, org_id, field_name='systems'):

--- a/api/advisor/api/tests/test_disabled_rules_views.py
+++ b/api/advisor/api/tests/test_disabled_rules_views.py
@@ -47,10 +47,13 @@ class DisabledRulesViewTestCase(TestCase):
         disabled_rules = disabled_page['data']
         self.assertIn('rule_id', disabled_rules[0])
         self.assertIn('scope', disabled_rules[0])
+        self.assertIn('is_auto_ack', disabled_rules[0])
         self.assertEqual(disabled_rules[0]['rule_id'], constants.acked_rule)
         self.assertEqual(disabled_rules[0]['scope'], 'account')
+        self.assertFalse(disabled_rules[0]['is_auto_ack'])
         self.assertEqual(disabled_rules[1]['rule_id'], constants.second_rule)
         self.assertEqual(disabled_rules[1]['scope'], 'system')
+        self.assertFalse(disabled_rules[1]['is_auto_ack'])
         self.assertEqual(len(disabled_rules), 2)
 
     def test_disabled_rules_detail(self):
@@ -63,8 +66,10 @@ class DisabledRulesViewTestCase(TestCase):
         disabled_rule = response.json()
         self.assertIn('rule_id', disabled_rule)
         self.assertIn('scope', disabled_rule)
+        self.assertIn('is_auto_ack', disabled_rule)
         self.assertEqual(disabled_rule['rule_id'], constants.acked_rule)
         self.assertEqual(disabled_rule['scope'], 'account')
+        self.assertFalse(disabled_rule['is_auto_ack'])
 
         # A rule that's not active should give a 404
         response = self.client.get(

--- a/api/advisor/api/views/disabled_rules.py
+++ b/api/advisor/api/views/disabled_rules.py
@@ -57,16 +57,16 @@ class DisabledRulesViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
             org_id=org_id, rule__active=True
         ).annotate(
             scope=Value('account'),
-            is_auto_ack=auto_ack_annotation,
+            is_auto_ack=auto_ack_annotation
         ).order_by('rule__rule_id').values(
-            'rule__rule_id', 'scope'
+            'rule__rule_id', 'scope', 'is_auto_ack'
         ).union(HostAck.objects.filter(
             org_id=org_id, rule__active=True
         ).annotate(
             scope=Value('system'),
-            is_auto_ack=auto_ack_annotation,
+            is_auto_ack=Value(False, output_field=BooleanField())
         ).distinct('rule__rule_id').order_by('rule__rule_id').values(
-            'rule__rule_id', 'scope'
+            'rule__rule_id', 'scope', 'is_auto_ack'
         )).order_by('rule__rule_id', 'scope')
 
     def retrieve(self, request, rule_id, format=None):

--- a/api/advisor/api/views/disabled_rules.py
+++ b/api/advisor/api/views/disabled_rules.py
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU General Public License along
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
-from django.db.models import Q, Value
+from django.conf import settings
+from django.db.models import BooleanField, Case, Q, Value, When
 from rest_framework import status, viewsets
 from rest_framework.response import Response
 
@@ -44,19 +45,26 @@ class DisabledRulesViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         org_id = request_to_org(self.request)
+        auto_ack_annotation = Case(
+            When(created_by=settings.AUTOACK['CREATED_BY'], then=Value(True)),
+            default=Value(False),
+            output_field=BooleanField(),
+        )
         # Internal ordering also makes sure that fields aren't implicitly
         # selected by default ordering, but then we want the whole queyset
         # to be explicitly sorted by rule_id.
         return Ack.objects.filter(
             org_id=org_id, rule__active=True
         ).annotate(
-            scope=Value('account')
+            scope=Value('account'),
+            is_auto_ack=auto_ack_annotation,
         ).order_by('rule__rule_id').values(
             'rule__rule_id', 'scope'
         ).union(HostAck.objects.filter(
             org_id=org_id, rule__active=True
         ).annotate(
-            scope=Value('system')
+            scope=Value('system'),
+            is_auto_ack=auto_ack_annotation,
         ).distinct('rule__rule_id').order_by('rule__rule_id').values(
             'rule__rule_id', 'scope'
         )).order_by('rule__rule_id', 'scope')
@@ -73,13 +81,15 @@ class DisabledRulesViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         org_id = request_to_org(request)
         filter_q = Q(org_id=org_id, rule__active=True, rule__rule_id=rule_id)
         try:
-            Ack.objects.get(filter_q)
+            ack = Ack.objects.get(filter_q)
             scope = 'account'
+            is_auto_ack = (ack.created_by == settings.AUTOACK['CREATED_BY'])
         except Ack.DoesNotExist:
             hostack = HostAck.objects.filter(filter_q)
             if not hostack.exists():
                 return Response(status=status.HTTP_404_NOT_FOUND)
             scope = 'system'
+            is_auto_ack = False
         return Response(DisabledRulesSerializer({
-            'rule__rule_id': rule_id, 'scope': scope
+            'rule__rule_id': rule_id, 'scope': scope, 'is_auto_ack': is_auto_ack
         }).data)


### PR DESCRIPTION
## Summary by Sourcery

Expose auto-acknowledgement metadata on disabled rules API responses.

New Features:
- Add is_auto_ack boolean field to the disabled-rules list and detail API responses to indicate whether a rule was auto-acknowledged.

Tests:
- Extend disabled-rules view tests to cover presence and values of the new is_auto_ack field in list and detail responses.