### PR TITLE
fix: Set group.id on Kafka consumer for inventory replication service

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -321,6 +321,7 @@ class Command(BaseCommand):
         Run the handler loop continuously until interrupted by SIGTERM.
         """
         logger.info('Advisor Inventory replication service starting up')
+        settings.KAFKA_SETTINGS.update({'group.id': settings.GROUP_ID})
         receiver = KafkaDispatcher()
         receiver.register_handler(settings.INVENTORY_EVENTS_TOPIC, handle_inventory_event)
 


### PR DESCRIPTION
The advisor_inventory_service command was not setting a group.id on its Kafka consumer, inheriting tasks_callback via a side-effect import. This caused it to share a consumer group with the tasks service, leading to rebalance disruptions and missed messages in ephemeral environments.

## Summary by Sourcery

Bug Fixes:
- Ensure the advisor inventory service uses its own Kafka consumer group.id instead of implicitly sharing the tasks service consumer group, preventing rebalances and missed messages.