### PR TITLE
fix(RHINENG-25936): Ensure QE host tag tests pass

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -22,6 +22,7 @@ import re
 from typing import Optional
 import urllib.parse
 from uuid import UUID
+from advisor_logging import logger
 
 from django.apps import apps
 from django.db.models import Exists, F, Q, OuterRef, Subquery
@@ -708,17 +709,18 @@ def filter_on_host_tags(request, field_name='host_id'):
         return Q()
 
     def unescape(token):
-        return urllib.parse.unquote(token)
+        return urllib.parse.unquote(token).replace('%2F', '/').replace('%3D', '=')
 
     tag_query = Q()
     for tag in host_tags:
-
+        logger.debug(f"Processing tag: {tag}")
         namespace, key_and_value = tag.split('/', 1)
         key, value = key_and_value.split('=', 1)
 
         namespace = unescape(namespace)
         key = unescape(key)
         value = unescape(value)
+        logger.debug(f"Processed tag: namespace={namespace}, key={key}, value={value}")
 
         tag_query &= Q(tags__contains=[{"namespace": namespace, "key": key, "value": value}])
 

--- a/api/advisor/api/tests/test_parameter_parsing.py
+++ b/api/advisor/api/tests/test_parameter_parsing.py
@@ -15,8 +15,6 @@
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
 from datetime import datetime, timezone
-from unittest.mock import patch
-import urllib.parse
 from urllib.parse import quote
 
 from django.db.models import Q
@@ -258,7 +256,7 @@ class HostTagsParameterParsingTestCase(TestCase):
 
     def test_special_chars_in_parameter(self):
         q = filter_on_host_tags(make_request_obj(
-            tags='some-namespace/some/tag=some/value,n/k/e/y/=/v/a/l/u/e/,namespace with spaces/key with spaces=value with spaces'
+            tags='some-namespace/some/tag=some/value,n/k/e/y/=/v=a&l$u&e/,namespace with spaces/key with spaces=value with spaces'
         ))
         self.assertIsInstance(q, Q)
         self.assertTrue(q)
@@ -269,39 +267,28 @@ class HostTagsParameterParsingTestCase(TestCase):
         The original URL-encoded query string is:
         tags=insights-client%2Fcustom%252FLast%2520Reboot%3D2023-07-14%252011%253A26%253A07
              %2Cinsights-client%2FPrivate+IPv4%3D192.168.1.100
+             %2Cinsights-client%2Fkey_12345678-1234-1234-1234-123456789012_%2524%25252F%2524%3D%2526abc%2526%25253Dkey_12345678-1234-1234-1234-123456789012
 
         After Django's first URL decode, the tag value becomes what we pass
         to make_request_obj below. The filter should then split and unquote
         to produce:
         - insights-client/custom/Last Reboot=2023-07-14 11:26:07
         - insights-client/Private IPv4=192.168.1.100
+        - insights-client/key_12345678-1234-1234-1234-123456789012_$/$=&abc&=key_12345678-1234-1234-1234-123456789012
         """
         # Value after Django's initial URL decoding of the query string
         tag_value = (
             'insights-client/custom%2FLast%20Reboot=2023-07-14%2011%3A26%3A07,'
-            'insights-client/Private IPv4=192.168.1.100'
+            'insights-client/Private IPv4=192.168.1.100,'
+            'insights-client/key_12345678-1234-1234-1234-123456789012_%24%252F%24=%26abc%26%253Dkey_12345678-1234-1234-1234-123456789012'
         )
-        decoded_tags = []
-        _unquote = urllib.parse.unquote
-
-        def tracking_unquote(s):
-            result = _unquote(s)
-            decoded_tags.append(result)
-            return result
-
-        with patch('urllib.parse.unquote', side_effect=tracking_unquote):
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
             q = filter_on_host_tags(make_request_obj(tags=tag_value))
-
-        self.assertIsInstance(q, Q)
-        self.assertTrue(q)
-
-        # unquote is called for namespace, key, value of each tag
-        self.assertEqual(decoded_tags, [
-            # Tag 1: insights-client/custom/Last Reboot=2023-07-14 11:26:07
-            'insights-client', 'custom/Last Reboot', '2023-07-14 11:26:07',
-            # Tag 2: insights-client/Private IPv4=192.168.1.100
-            'insights-client', 'Private IPv4', '192.168.1.100',
-        ])
+            self.assertIsInstance(q, Q)
+            self.assertTrue(q)
+            self.assertIn('DEBUG:advisor-log:Processed tag: namespace=insights-client, key=custom/Last Reboot, value=2023-07-14 11:26:07', logs.output)
+            self.assertIn('DEBUG:advisor-log:Processed tag: namespace=insights-client, key=Private IPv4, value=192.168.1.100', logs.output)
+            self.assertIn('DEBUG:advisor-log:Processed tag: namespace=insights-client, key=key_12345678-1234-1234-1234-123456789012_$/$, value=&abc&=key_12345678-1234-1234-1234-123456789012', logs.output)
 
     def test_quoted_parameters(self):
         def make_param_value(namespace, key, value):

--- a/service/README.md
+++ b/service/README.md
@@ -442,6 +442,11 @@ curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/s
 Note: the tags query parameter is URL-encoded and will match systems tagged with either or both of these tags:
 - `insights-client/custom/Last Reboot=2023-07-14 11:26:07`
 - `insights-client/Private IPv4=192.168.1.100`
+```bash
+curl -s -H "x-rh-identity: $RH_IDENTITY" http://localhost:8000/api/insights/v1/system/?tags=insights-client%2Fkey_12345678-1234-1234-1234-123456789012_%2524%25252F%2524%3D%2526abc%2526%25253Dkey_12345678-1234-1234-1234-123456789012
+```
+- `insights-client/key_12345678-1234-1234-1234-123456789012_$/$=&abc&=key_12345678-1234-1234-1234-123456789012`
+
 
 **Get reports (rule hits) for a specific system:**
 ```bash

--- a/service/manual_test/fake_engine_result_rhel.json
+++ b/service/manual_test/fake_engine_result_rhel.json
@@ -25,7 +25,9 @@
                  {"namespace": "sample", "key": "tag", "value": "1"},
                  {"namespace": "sample", "key": "tag", "value": "2"},
                  {"namespace": "insights-client", "key": "custom/Last Reboot", "value": "2023-07-14 11:26:07"},
-                 {"namespace": "insights-client", "key": "Private IPv4", "value": "192.168.1.100"}],
+                 {"namespace": "insights-client", "key": "Private IPv4", "value": "192.168.1.100"},
+                 {"namespace": "insights-client", "key": "key_12345678-1234-1234-1234-123456789012_$/$", "value": "&abc&=key_12345678-1234-1234-1234-123456789012"}
+      ],
       "updated": null
     },
     "platform_metadata": {


### PR DESCRIPTION
## Summary by Sourcery

Handle additional special characters in host tag filtering and align tests and documentation with the updated tag parsing behavior.

Bug Fixes:
- Fix host tag parsing to correctly handle encoded forward slashes and equals signs in tag namespaces, keys, and values.

Enhancements:
- Add debug logging around host tag processing to aid troubleshooting of tag parsing issues.

Documentation:
- Document complex host tag examples with special characters in the service README to illustrate correct URL encoding.

Tests:
- Update and extend parameter parsing tests to cover tags with special characters and to verify the new logging-based processing behavior.