### PR TITLE
feat: Add AdvisorInventoryHost managed model with Kafka consumer

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -28,7 +28,7 @@ from advisor_logging import logger
 from feature_flags import (
     feature_flag_is_enabled, FLAG_INVENTORY_EVENT_REPLICATION
 )
-from api.models import InventoryHost, Host  # pyright: ignore[reportImplicitRelativeImport]
+from api.models import AdvisorInventoryHost, Host  # pyright: ignore[reportImplicitRelativeImport]
 
 from kafka_utils import JsonValue, KafkaDispatcher  # , send_kafka_message
 
@@ -72,26 +72,6 @@ def log_missing_key(request_id: str, event_type: str, key_name: str):
         request_id, event_type, key_name
     )
     prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
-
-
-#############################################################################
-SYSTEM_PROFILE_KEYS = (
-    'ansible', 'bootc_status', 'host_type', 'mssql', 'operating_system',
-    'owner_id', 'rhc_client_id', 'sap', 'sap_system', 'sap_sids',
-    # need to phase out sap_system and sap_sids in favour of sap structure.
-    'system_update_method',
-)
-
-
-def extract_system_profile(source: dict[str, JsonValue]) -> dict[str, JsonValue]:
-    """
-    Grab just the keys we need from the given system profile.
-    """
-    return {
-        key: source[key]
-        for key in SYSTEM_PROFILE_KEYS
-        if key in source
-    }
 
 
 #############################################################################
@@ -189,23 +169,34 @@ def handle_created_event(message: dict[str, JsonValue]):
         # else the request_id variable exists from above
         return log_missing_key(request_id, event_type, key_name)
 
-    # These are the particular fields that Advisor and Tasks uses
-    system_profile: dict[str, JsonValue] = extract_system_profile(system_profile_field)
+    if not insights_id:
+        logger.error(
+            "Request %s: Inventory %s event has null or empty insights_id for host %s",
+            request_id, event_type, host_id
+        )
+        prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
+        return
 
-    # Create or update the inventory host.
-    # If we're creating the host, we need to supply a system_profile.
-    # However, if updating we don't really want to supply a large quantity
-    # of system_profile data that may not be changing.  When the system
-    # profile data moves into its own model, this may be easier and more
-    # efficient.
-    inv_host, created = InventoryHost.objects.update_or_create(
-        id=host_id,
+    system_profile_raw: dict[str, JsonValue] = system_profile_field
+    os_info = system_profile_raw.get('operating_system', {})
+    bootc = system_profile_raw.get('bootc_status', {})
+    bootc_booted = bootc.get('booted', {}) if isinstance(bootc, dict) else {}
+
+    workloads = system_profile_raw.get('workloads', {})
+    workloads = workloads if isinstance(workloads, dict) else {}
+
+    workspace_id = groups[0].get('id') if groups else None
+    workspace_name = groups[0].get('name') if groups else None
+
+    inv_host, was_created = AdvisorInventoryHost.objects.update_or_create(
+        org_id=org_id,
+        inventory_id=host_id,
         defaults={
             'display_name': display_name,
             'account': account,
-            'org_id': org_id,
             'tags': tags,
-            'groups': groups,
+            'workspace_id': workspace_id,
+            'workspace_name': workspace_name,
             'created': created,
             'updated': updated,
             'last_check_in': last_check_in,
@@ -213,10 +204,19 @@ def handle_created_event(message: dict[str, JsonValue]):
             'stale_timestamp': stale_timestamp,
             'reporter': reporter,
             'per_reporter_staleness': per_reporter_staleness,
-            'system_profile': system_profile,
+            'os_name': os_info.get('name') if isinstance(os_info, dict) else None,
+            'os_major': os_info.get('major') if isinstance(os_info, dict) else None,
+            'os_minor': os_info.get('minor') if isinstance(os_info, dict) else None,
+            'host_type': system_profile_raw.get('host_type'),
+            'bootc_booted_image': bootc_booted.get('image') if isinstance(bootc_booted, dict) else None,
+            'bootc_booted_image_digest': bootc_booted.get('image_digest') if isinstance(bootc_booted, dict) else None,
+            'owner_id': system_profile_raw.get('owner_id') or None,
+            'rhc_client_id': system_profile_raw.get('rhc_client_id') or None,
+            'workloads': workloads,
+            'system_update_method': system_profile_raw.get('system_update_method'),
         }
     )
-    if created:
+    if was_created:
         prometheus.INVENTORY_HOST_CREATED.inc()
         action = 'Created'
     else:
@@ -224,7 +224,7 @@ def handle_created_event(message: dict[str, JsonValue]):
         action = 'Updated'
     logger.debug(
         "%s Inventory host %s account %s org_id %s",
-        action, inv_host.id, account, org_id
+        action, inv_host.inventory_id, account, org_id
     )
 
     # Also add the Host record
@@ -235,11 +235,11 @@ def handle_created_event(message: dict[str, JsonValue]):
     }
     if satellite_id:
         host_data['satellite_id'] = satellite_id
-    host_obj, created = Host.objects.update_or_create(
-        inventory_id=inv_host.id,
+    host_obj, was_created = Host.objects.update_or_create(
+        inventory_id=inv_host.inventory_id,
         defaults=host_data
     )
-    action = 'Created' if created else 'Updated'
+    action = 'Created' if was_created else 'Updated'
     logger.debug(
         "%s Host %s account %s org_id %s",
         action, host_obj.inventory_id, account, org_id
@@ -302,11 +302,11 @@ def handle_deleted_event(message: dict[str, JsonValue]):
         inventory_id=inventory_id, org_id=org_id
     ).delete()
     logger.info("Deleted %d records based on Host: %s.", *deleted_records)
-    # Delete InventoryHost record
-    deleted_records = InventoryHost.objects.filter(
-        id=inventory_id, org_id=org_id
+    # Delete AdvisorInventoryHost record
+    deleted_records = AdvisorInventoryHost.objects.filter(
+        inventory_id=inventory_id, org_id=org_id
     ).delete()
-    logger.info("Deleted %d records based on InventoryHost: %s.", *deleted_records)
+    logger.info("Deleted %d records based on AdvisorInventoryHost: %s.", *deleted_records)
     prometheus.INVENTORY_HOST_DELETED.inc()
 
 

--- a/api/advisor/api/migrations/0046_advisor_inventory_host.py
+++ b/api/advisor/api/migrations/0046_advisor_inventory_host.py
@@ -1,0 +1,144 @@
+import os
+import django_prometheus.models
+from django.db import migrations, models
+
+from api.scripts.partitioned_table_index_helper import (
+    create_partitioned_table_index,
+    drop_partitioned_table_index,
+)
+
+PARTITION_COUNT = int(os.getenv('PARTITION_COUNT', '16'))
+PARENT_TABLE = 'advisor_inventory_host'
+
+CREATE_PARENT_SQL = f"""
+    CREATE TABLE {PARENT_TABLE} (
+        inventory_id UUID NOT NULL,
+        account VARCHAR(10),
+        org_id VARCHAR(50) NOT NULL,
+        display_name VARCHAR(200) NOT NULL,
+        tags JSONB NOT NULL,
+        workspace_id UUID,
+        workspace_name VARCHAR(200),
+        updated TIMESTAMPTZ NOT NULL,
+        created TIMESTAMPTZ NOT NULL,
+        last_check_in TIMESTAMPTZ NOT NULL,
+        stale_timestamp TIMESTAMPTZ NOT NULL,
+        insights_id UUID NOT NULL,
+        reporter VARCHAR(200) NOT NULL DEFAULT 'puptoo',
+        per_reporter_staleness JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+        os_name VARCHAR(50),
+        os_major INTEGER,
+        os_minor INTEGER,
+        host_type VARCHAR(50),
+        bootc_booted_image VARCHAR(512),
+        bootc_booted_image_digest VARCHAR(256),
+        owner_id UUID,
+        rhc_client_id UUID,
+        workloads JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+        system_update_method VARCHAR(50),
+        PRIMARY KEY (org_id, inventory_id)
+    ) PARTITION BY HASH (org_id);
+"""
+
+partition_statements = []
+for i in range(PARTITION_COUNT):
+    partition_statements.append(
+        f'CREATE TABLE {PARENT_TABLE}_p{i} '
+        f'PARTITION OF {PARENT_TABLE} '
+        f'FOR VALUES WITH (MODULUS {PARTITION_COUNT}, REMAINDER {i});'
+    )
+PARTITION_SQL = '\n'.join(partition_statements)
+
+CREATE_TABLE_SQL = CREATE_PARENT_SQL + PARTITION_SQL
+
+# Mirrors inventory.hosts indexes (Cyndi mock + current HBI hosts indexes), adapted
+# for flattened advisor_inventory_host columns.
+PARTITIONED_INDEXES = [
+    ('idx_advisor_inventory_host_display_name', '(display_name)'),
+    ('idx_advisor_inventory_host_tags', 'USING GIN (tags jsonb_path_ops)'),
+    (
+        'idx_advisor_inventory_host_per_reporter_staleness',
+        'USING GIN (per_reporter_staleness jsonb_path_ops)',
+    ),
+    ('idx_advisor_inventory_host_insights_id', '(insights_id)'),
+    ('idx_advisor_inventory_host_host_type', '(host_type)'),
+]
+
+
+def create_advisor_inventory_host_indexes(apps, schema_editor):
+    for index_name, index_definition in PARTITIONED_INDEXES:
+        create_partitioned_table_index(
+            table_name=PARENT_TABLE,
+            index_name=index_name,
+            index_definition=index_definition,
+            num_partitions=PARTITION_COUNT,
+        )
+
+
+def drop_advisor_inventory_host_indexes(apps, schema_editor):
+    for index_name, _index_definition in reversed(PARTITIONED_INDEXES):
+        drop_partitioned_table_index(
+            table_name=PARENT_TABLE,
+            index_name=index_name,
+            num_partitions=PARTITION_COUNT,
+        )
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ('api', '0001_squashed_0045_remove_dailyhitgroup'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=CREATE_TABLE_SQL,
+                    reverse_sql=f'DROP TABLE IF EXISTS {PARENT_TABLE} CASCADE;',
+                ),
+                migrations.RunPython(
+                    create_advisor_inventory_host_indexes,
+                    drop_advisor_inventory_host_indexes,
+                ),
+            ],
+            state_operations=[
+                migrations.CreateModel(
+                    name='AdvisorInventoryHost',
+                    fields=[
+                        ('pk', models.CompositePrimaryKey('org_id', 'inventory_id', blank=True, editable=False, primary_key=True, serialize=False)),
+                        ('inventory_id', models.UUIDField()),
+                        ('account', models.CharField(blank=True, max_length=10, null=True)),
+                        ('org_id', models.CharField(max_length=50)),
+                        ('display_name', models.CharField(max_length=200)),
+                        ('tags', models.JSONField()),
+                        ('workspace_id', models.UUIDField(null=True)),
+                        ('workspace_name', models.CharField(blank=True, max_length=200, null=True)),
+                        ('updated', models.DateTimeField()),
+                        ('created', models.DateTimeField()),
+                        ('last_check_in', models.DateTimeField()),
+                        ('stale_timestamp', models.DateTimeField()),
+                        ('insights_id', models.UUIDField()),
+                        ('reporter', models.CharField(default='puptoo', max_length=200)),
+                        ('per_reporter_staleness', models.JSONField(default=dict)),
+                        ('os_name', models.CharField(blank=True, max_length=50, null=True)),
+                        ('os_major', models.IntegerField(null=True)),
+                        ('os_minor', models.IntegerField(null=True)),
+                        ('host_type', models.CharField(blank=True, max_length=50, null=True)),
+                        ('bootc_booted_image', models.CharField(blank=True, max_length=512, null=True)),
+                        ('bootc_booted_image_digest', models.CharField(blank=True, max_length=256, null=True)),
+                        ('owner_id', models.UUIDField(null=True)),
+                        ('rhc_client_id', models.UUIDField(null=True)),
+                        ('workloads', models.JSONField(default=dict)),
+                        ('system_update_method', models.CharField(blank=True, max_length=50, null=True)),
+                    ],
+                    options={
+                        'db_table': PARENT_TABLE,
+                    },
+                    bases=(django_prometheus.models.ExportModelOperationsMixin('advisorinventoryhost'), models.Model),
+                ),
+            ],
+        ),
+    ]

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -719,6 +719,41 @@ class InventoryHost(models.Model):
         db_table = '"inventory"."hosts"'
 
 
+class AdvisorInventoryHost(ExportModelOperationsMixin('advisorinventoryhost'), models.Model):
+    pk = models.CompositePrimaryKey("org_id", "inventory_id")
+    inventory_id = models.UUIDField()
+    account = models.CharField(max_length=10, blank=True, null=True)
+    org_id = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=200)
+    tags = models.JSONField()
+    workspace_id = models.UUIDField(null=True)
+    workspace_name = models.CharField(max_length=200, null=True, blank=True)
+    updated = models.DateTimeField()
+    created = models.DateTimeField()
+    last_check_in = models.DateTimeField()
+    stale_timestamp = models.DateTimeField()
+    insights_id = models.UUIDField()
+    reporter = models.CharField(max_length=200, default='puptoo')
+    per_reporter_staleness = models.JSONField(default=dict)
+
+    os_name = models.CharField(max_length=50, null=True, blank=True)
+    os_major = models.IntegerField(null=True)
+    os_minor = models.IntegerField(null=True)
+    host_type = models.CharField(max_length=50, null=True, blank=True)
+    bootc_booted_image = models.CharField(max_length=512, null=True, blank=True)
+    bootc_booted_image_digest = models.CharField(max_length=256, null=True, blank=True)
+    owner_id = models.UUIDField(null=True)
+    rhc_client_id = models.UUIDField(null=True)
+    workloads = models.JSONField(default=dict)
+    system_update_method = models.CharField(max_length=50, null=True, blank=True)
+
+    class Meta:
+        db_table = 'advisor_inventory_host'
+
+    def __str__(self):
+        return f"{self.display_name} ({self.inventory_id})"
+
+
 class Host(ExportModelOperationsMixin('host'), TimestampedModel):
     """
     The information about a host that Inventory doesn't store...

--- a/api/advisor/api/scripts/partitioned_table_index_helper.py
+++ b/api/advisor/api/scripts/partitioned_table_index_helper.py
@@ -1,0 +1,182 @@
+"""
+Helper functions for creating indexes on partitioned tables in Django migrations.
+
+In automated mode (local, CI, ephemeral), indexes are created on the parent table only.
+PostgreSQL creates matching indexes on all partitions automatically.
+
+In managed mode (stage, production), indexes are created on each partition with
+CREATE INDEX CONCURRENTLY first, then on the parent table.
+"""
+
+import logging
+import os
+
+from django.db import connection, connections
+
+logger = logging.getLogger(__name__)
+
+TABLE_NUM_PARTITIONS = int(os.getenv('ADVISOR_INVENTORY_HOST_NUM_PARTITIONS', '16'))
+MIGRATION_MODE = os.getenv('MIGRATION_MODE', 'automated')
+
+
+def validate_num_partitions(num_partitions: int) -> None:
+    if not 1 <= num_partitions <= 16:
+        raise ValueError(
+            f'Invalid number of partitions: {num_partitions}. Must be between 1 and 16.'
+        )
+
+
+def _qualified_name(schema: str, name: str) -> str:
+    return f'{schema}.{name}' if schema else name
+
+
+def _execute_sql(sql: str) -> None:
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+
+
+def create_partitioned_table_index(
+    table_name: str,
+    index_name: str,
+    index_definition: str,
+    num_partitions: int | None = None,
+    schema: str = '',
+    unique: bool = False,
+) -> None:
+    """
+    Create an index on a partitioned table and all its partitions.
+
+    Args:
+        table_name: Name of the parent table (without schema prefix)
+        index_name: Name for the index (partition indexes are prefixed per partition)
+        index_definition: Column definition for the index, e.g. "(org_id, last_check_in DESC)"
+            or "USING GIN (tags jsonb_path_ops)"
+        num_partitions: Number of hash partitions (0 .. num_partitions-1)
+        schema: Optional schema name (empty string for the default public schema)
+        unique: Create a UNIQUE index when True
+    """
+    if num_partitions is None:
+        num_partitions = TABLE_NUM_PARTITIONS
+
+    validate_num_partitions(num_partitions)
+
+    qualified_table = _qualified_name(schema, table_name)
+    migration_mode = MIGRATION_MODE
+    unique_clause = 'UNIQUE ' if unique else ''
+
+    logger.info(
+        "Creating index '%s' on partitioned table '%s' with %d partitions in '%s' mode",
+        index_name,
+        qualified_table,
+        num_partitions,
+        migration_mode,
+    )
+
+    if migration_mode == 'automated':
+        _execute_sql(
+            f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
+            f'ON {qualified_table} {index_definition};'
+        )
+        return
+
+    try:
+        logger.info(
+            'Creating indexes on %d partitions using CREATE INDEX CONCURRENTLY...',
+            num_partitions,
+        )
+
+        connection.commit()
+        db_connection = connections['default']
+        db_connection.set_autocommit(True)
+        try:
+            with db_connection.cursor() as cursor:
+                for i in range(num_partitions):
+                    partition_name = f'{table_name}_p{i}'
+                    partition_index_name = f'{table_name}_p{i}_{index_name}'
+                    qualified_partition = _qualified_name(schema, partition_name)
+                    cursor.execute(
+                        f'CREATE {unique_clause}INDEX CONCURRENTLY IF NOT EXISTS {partition_index_name} '
+                        f'ON {qualified_partition} {index_definition};'
+                    )
+        finally:
+            db_connection.set_autocommit(False)
+
+        connection.begin()
+
+        _execute_sql("""
+            DO $$
+            DECLARE
+                idx_builds INT;
+            BEGIN
+                RAISE NOTICE 'Waiting for all concurrent index builds to complete...';
+                LOOP
+                    SELECT COUNT(*) INTO idx_builds
+                    FROM pg_stat_progress_create_index
+                    WHERE command = 'CREATE INDEX' AND phase != 'done';
+
+                    EXIT WHEN idx_builds = 0;
+
+                    RAISE NOTICE 'Still % ongoing index builds... sleeping 10s', idx_builds;
+                    PERFORM pg_sleep(10);
+                END LOOP;
+                RAISE NOTICE 'All concurrent index builds are complete.';
+            END;
+            $$;
+        """)
+
+        _execute_sql(
+            f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
+            f'ON {qualified_table} {index_definition};'
+        )
+    except Exception:
+        logger.exception(
+            "Error creating index '%s' on partitioned table '%s'",
+            index_name,
+            qualified_table,
+        )
+        raise
+
+
+def drop_partitioned_table_index(
+    table_name: str,
+    index_name: str,
+    num_partitions: int | None = None,
+    schema: str = '',
+    if_exists: bool = True,
+) -> None:
+    """
+    Drop an index from a partitioned table and any orphaned partition indexes.
+
+    Dropping the parent index cascades to attached partition indexes. Partition-level
+    indexes left over from a failed managed-mode creation are cleaned up explicitly.
+    """
+    if num_partitions is None:
+        num_partitions = TABLE_NUM_PARTITIONS
+
+    validate_num_partitions(num_partitions)
+
+    qualified_table = _qualified_name(schema, table_name)
+    if_exists_clause = 'IF EXISTS' if if_exists else ''
+
+    logger.info(
+        "Dropping index '%s' from partitioned table '%s' with %d partitions",
+        index_name,
+        qualified_table,
+        num_partitions,
+    )
+
+    try:
+        _execute_sql(f'DROP INDEX {if_exists_clause} {_qualified_name(schema, index_name)};')
+
+        for i in range(num_partitions):
+            partition_index_name = f'{table_name}_p{i}_{index_name}'
+            _execute_sql(
+                f'DROP INDEX {if_exists_clause} {_qualified_name(schema, partition_index_name)};'
+            )
+    except Exception:
+        logger.exception(
+            "Error dropping index '%s' from partitioned table '%s'",
+            index_name,
+            qualified_table,
+        )
+        raise

--- a/api/advisor/api/scripts/partitioned_table_index_helper.py
+++ b/api/advisor/api/scripts/partitioned_table_index_helper.py
@@ -10,14 +10,15 @@ CREATE INDEX CONCURRENTLY first, then on the parent table.
 
 import logging
 import os
+from typing import Literal
 
 from django.db import connection, connections
 
 logger = logging.getLogger(__name__)
 
 TABLE_NUM_PARTITIONS = int(os.getenv('ADVISOR_INVENTORY_HOST_NUM_PARTITIONS', '16'))
-MIGRATION_MODE = os.getenv('MIGRATION_MODE', 'automated')
 
+MigrationMode = Literal['automated', 'managed']
 
 def validate_num_partitions(num_partitions: int) -> None:
     if not 1 <= num_partitions <= 16:
@@ -34,76 +35,8 @@ def _execute_sql(sql: str) -> None:
     with connection.cursor() as cursor:
         cursor.execute(sql)
 
-
-def create_partitioned_table_index(
-    table_name: str,
-    index_name: str,
-    index_definition: str,
-    num_partitions: int | None = None,
-    schema: str = '',
-    unique: bool = False,
-) -> None:
-    """
-    Create an index on a partitioned table and all its partitions.
-
-    Args:
-        table_name: Name of the parent table (without schema prefix)
-        index_name: Name for the index (partition indexes are prefixed per partition)
-        index_definition: Column definition for the index, e.g. "(org_id, last_check_in DESC)"
-            or "USING GIN (tags jsonb_path_ops)"
-        num_partitions: Number of hash partitions (0 .. num_partitions-1)
-        schema: Optional schema name (empty string for the default public schema)
-        unique: Create a UNIQUE index when True
-    """
-    if num_partitions is None:
-        num_partitions = TABLE_NUM_PARTITIONS
-
-    validate_num_partitions(num_partitions)
-
-    qualified_table = _qualified_name(schema, table_name)
-    migration_mode = MIGRATION_MODE
-    unique_clause = 'UNIQUE ' if unique else ''
-
-    logger.info(
-        "Creating index '%s' on partitioned table '%s' with %d partitions in '%s' mode",
-        index_name,
-        qualified_table,
-        num_partitions,
-        migration_mode,
-    )
-
-    if migration_mode == 'automated':
-        _execute_sql(
-            f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
-            f'ON {qualified_table} {index_definition};'
-        )
-        return
-
-    try:
-        logger.info(
-            'Creating indexes on %d partitions using CREATE INDEX CONCURRENTLY...',
-            num_partitions,
-        )
-
-        connection.commit()
-        db_connection = connections['default']
-        db_connection.set_autocommit(True)
-        try:
-            with db_connection.cursor() as cursor:
-                for i in range(num_partitions):
-                    partition_name = f'{table_name}_p{i}'
-                    partition_index_name = f'{table_name}_p{i}_{index_name}'
-                    qualified_partition = _qualified_name(schema, partition_name)
-                    cursor.execute(
-                        f'CREATE {unique_clause}INDEX CONCURRENTLY IF NOT EXISTS {partition_index_name} '
-                        f'ON {qualified_partition} {index_definition};'
-                    )
-        finally:
-            db_connection.set_autocommit(False)
-
-        connection.begin()
-
-        _execute_sql("""
+def _wait_for_concurrent_indexes() -> None:
+    _execute_sql("""
             DO $$
             DECLARE
                 idx_builds INT;
@@ -124,10 +57,108 @@ def create_partitioned_table_index(
             $$;
         """)
 
-        _execute_sql(
-            f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
-            f'ON {qualified_table} {index_definition};'
+def _create_partitioned_table_index_automated(
+    qualified_table: str,
+    index_name: str,
+    index_definition: str,
+    unique_clause: str,
+) -> None:
+    _execute_sql(
+        f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
+        f'ON {qualified_table} {index_definition};'
+    )
+    return
+
+def _create_partitioned_table_index_managed(
+    table_name: str,
+    qualified_table: str,
+    index_name: str,
+    index_definition: str,
+    num_partitions: int,
+    schema: str,
+    unique_clause: str,
+) -> None:
+
+    db_connection = connections['default']
+    db_connection.ensure_connection()
+    db_connection.connection.commit()
+    db_connection.set_autocommit(True)
+    try:
+        with db_connection.cursor() as cursor:
+            for i in range(num_partitions):
+                partition_name = f'{table_name}_p{i}'
+                partition_index_name = f'{table_name}_p{i}_{index_name}'
+                qualified_partition = _qualified_name(schema, partition_name)
+                cursor.execute(
+                    f'CREATE {unique_clause}INDEX CONCURRENTLY IF NOT EXISTS {partition_index_name} '
+                    f'ON {qualified_partition} {index_definition};'
+                )
+    finally:
+        db_connection.set_autocommit(False)
+
+    _wait_for_concurrent_indexes()
+    _execute_sql(
+        f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
+        f'ON {qualified_table} {index_definition};'
+    )
+
+def create_partitioned_table_index(
+    table_name: str,
+    index_name: str,
+    index_definition: str,
+    num_partitions: int | None = None,
+    schema: str = '',
+    unique: bool = False,
+    migration_mode: MigrationMode = os.getenv('MIGRATION_MODE', 'automated'),
+) -> None:
+    """
+    Create an index on a partitioned table and all its partitions.
+
+    Args:
+        table_name: Name of the parent table (without schema prefix)
+        index_name: Name for the index (partition indexes are prefixed per partition)
+        index_definition: Column definition for the index, e.g. "(org_id, last_check_in DESC)"
+            or "USING GIN (tags jsonb_path_ops)"
+        num_partitions: Number of hash partitions (0 .. num_partitions-1)
+        schema: Optional schema name (empty string for the default public schema)
+        unique: Create a UNIQUE index when True
+    """
+    if num_partitions is None:
+        num_partitions = TABLE_NUM_PARTITIONS
+
+    validate_num_partitions(num_partitions)
+
+    qualified_table = _qualified_name(schema, table_name)
+    unique_clause = 'UNIQUE ' if unique else ''
+
+    logger.info(
+        "Creating index '%s' on partitioned table '%s' with %d partitions in '%s' mode",
+        index_name,
+        qualified_table,
+        num_partitions,
+        migration_mode,
+    )
+
+    if migration_mode == 'automated':
+        _create_partitioned_table_index_automated(
+            qualified_table=qualified_table,
+            index_name=index_name,
+            index_definition=index_definition,
+            unique_clause=unique_clause,
         )
+        return
+
+    try:
+        _create_partitioned_table_index_managed(
+            table_name=table_name,
+            qualified_table=qualified_table,
+            index_name=index_name,
+            index_definition=index_definition,
+            num_partitions=num_partitions,
+            schema=schema,
+            unique_clause=unique_clause,
+        )
+
     except Exception:
         logger.exception(
             "Error creating index '%s' on partitioned table '%s'",

--- a/api/advisor/api/tests/test_advisor_inventory_service.py
+++ b/api/advisor/api/tests/test_advisor_inventory_service.py
@@ -27,7 +27,7 @@ from kafka_utils import JsonValue
 from api.management.commands.advisor_inventory_service import (
     handle_inventory_event, handle_created_event, handle_deleted_event
 )
-from api.models import CurrentReport, Host, HostAck, InventoryHost, Upload
+from api.models import AdvisorInventoryHost, CurrentReport, Host, HostAck, InventoryHost, Upload
 from api.tests import constants
 
 #############################################################################
@@ -64,10 +64,32 @@ create_new_host_msg: dict[str, JsonValue] = {
         "tags": [],
         "stale_timestamp": stale_time,
         "system_profile": {
-            "ansible": "", "bootc_status": "", "host_type": "", "mssql": "",
-            "operating_system": "", "owner_id": "", "rhc_client_id": "",
-            "sap": "", "sap_system": "", "sap_sids": "",
-            "system_update_method": ""
+            "host_type": "edge",
+            "operating_system": {"name": "RHEL", "major": 9, "minor": 4},
+            "bootc_status": {
+                "booted": {
+                    "image": "quay.io/example/rhel:9.4",
+                    "image_digest": "sha256:abc123"
+                }
+            },
+            "owner_id": "55df28a7-d7ef-48c5-bc57-8967025399b1",
+            "rhc_client_id": "66ef39b8-e8f0-59d6-ca68-cee5983500c2",
+            "system_update_method": "dnf",
+            "workloads": {
+                "sap": {
+                    "sap_system": True,
+                    "sids": ["E01", "E02"],
+                    "instance_number": "00",
+                    "version": "2.00.122"
+                },
+                "ansible": {
+                    "controller_version": "4.6.0",
+                    "hub_version": "4.9.0"
+                },
+                "mssql": {
+                    "version": "16.0.1000"
+                }
+            }
         },
         "reporter": "puptoo",
         "per_reporter_staleness": {"puptoo": {
@@ -75,7 +97,7 @@ create_new_host_msg: dict[str, JsonValue] = {
             "stale_warning_timestamp": stale_warn_time,
             "culled_timestamp": cull_time
         }},
-        "groups": [],
+        "groups": [{"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "name": "test-workspace"}],
     }
 }
 update_host_msg: dict[str, JsonValue] = {
@@ -98,21 +120,16 @@ update_host_msg: dict[str, JsonValue] = {
         "last_check_in": "2025-12-01T03:09:27Z",
         "tags": [],
         "stale_timestamp": stale_time,
-        "system_profile": {  # taken from the fixture, only certain values copied
-            "arch": "x86_64", "bios_vendor": "Dell Inc.", "bios_version": "2.8.0",
-            "bios_release_date": "13/06/2017", "cores_per_socket": 8,
-            "number_of_sockets": 2, "infrastructure_type": "physical",
-            "system_memory_bytes": 134927265792, "satellite_managed": True,
-            "insights_egg_version": "3.0.182-1", "sap_system": True,
-            "insights_client_version": "3.0.14", "sap_sids": ["E01", "E02"],
-            "os_release": "Red Hat Enterprise Linux Server",
-            "owner_id": "55df28a7-d7ef-48c5-bc57-8967025399b1",
+        "system_profile": {
             "operating_system": {"name": "RHEL", "major": 7, "minor": 5},
+            "owner_id": "55df28a7-d7ef-48c5-bc57-8967025399b1",
             "system_update_method": "dnf",
             "workloads": {
                 "sap": {
-                    "sap_system": True, "version": "2.00.122.04.1478575636",
-                    "sids": ["E01", "E02"], "instance_number": "00"
+                    "sap_system": True,
+                    "sids": ["E01", "E02"],
+                    "instance_number": "00",
+                    "version": "2.00.122.04.1478575636"
                 }
             }
         },
@@ -154,6 +171,25 @@ class TestAdvisorInventoryServer(TestCase):
         'rulesets', 'system_types', 'rule_categories', 'upload_sources',
         'basic_test_data'
     ]
+
+    def setUp(self):
+        for inv_host in InventoryHost.objects.all():
+            AdvisorInventoryHost.objects.update_or_create(
+                inventory_id=inv_host.id,
+                org_id=inv_host.org_id,
+                defaults={
+                    'account': inv_host.account,
+                    'display_name': inv_host.display_name,
+                    'tags': inv_host.tags,
+                    'updated': inv_host.updated,
+                    'created': inv_host.created,
+                    'last_check_in': inv_host.last_check_in,
+                    'stale_timestamp': inv_host.stale_timestamp,
+                    'insights_id': inv_host.insights_id,
+                    'reporter': inv_host.reporter,
+                    'per_reporter_staleness': inv_host.per_reporter_staleness,
+                }
+            )
 
     @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
     def test_message_dispatch(self):
@@ -207,16 +243,41 @@ class TestAdvisorInventoryServer(TestCase):
                 log_lines[2]
             )
             self.assertEqual(len(log_lines), 3)
-            # Check existence of InventoryHost record
             self.assertEqual(
-                InventoryHost.objects.filter(id=new_host_id).count(),
+                AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).count(),
                 1
             )
-            new_ihost = InventoryHost.objects.get(id=new_host_id)
-            # Probably don't need to check the entire data set.
-            self.assertEqual(str(new_ihost.id), new_host_id)
+            new_ihost = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+            self.assertEqual(str(new_ihost.inventory_id), new_host_id)
             self.assertEqual(new_ihost.account, constants.standard_acct)
             self.assertEqual(new_ihost.org_id, constants.standard_org)
+            self.assertEqual(new_ihost.display_name, new_host_name)
+            self.assertEqual(str(new_ihost.workspace_id), "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+            self.assertEqual(new_ihost.workspace_name, "test-workspace")
+            self.assertEqual(new_ihost.os_name, "RHEL")
+            self.assertEqual(new_ihost.os_major, 9)
+            self.assertEqual(new_ihost.os_minor, 4)
+            self.assertEqual(new_ihost.host_type, "edge")
+            self.assertEqual(new_ihost.bootc_booted_image, "quay.io/example/rhel:9.4")
+            self.assertEqual(new_ihost.bootc_booted_image_digest, "sha256:abc123")
+            self.assertEqual(str(new_ihost.owner_id), "55df28a7-d7ef-48c5-bc57-8967025399b1")
+            self.assertEqual(str(new_ihost.rhc_client_id), "66ef39b8-e8f0-59d6-ca68-cee5983500c2")
+            self.assertEqual(new_ihost.workloads, {
+                "sap": {
+                    "sap_system": True,
+                    "sids": ["E01", "E02"],
+                    "instance_number": "00",
+                    "version": "2.00.122"
+                },
+                "ansible": {
+                    "controller_version": "4.6.0",
+                    "hub_version": "4.9.0"
+                },
+                "mssql": {
+                    "version": "16.0.1000"
+                }
+            })
+            self.assertEqual(new_ihost.system_update_method, "dnf")
             # Check existence of Host record
             self.assertEqual(
                 Host.objects.filter(inventory_id=new_host_id).count(),
@@ -295,9 +356,9 @@ class TestAdvisorInventoryServer(TestCase):
                 log_lines[2]
             )
             self.assertEqual(len(log_lines), 3)
-            # Check existence of InventoryHost record
+            # Check existence of AdvisorInventoryHost record
             self.assertEqual(
-                InventoryHost.objects.filter(id=new_host_id).count(),
+                AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).count(),
                 1
             )
             self.assertEqual(
@@ -330,9 +391,9 @@ class TestAdvisorInventoryServer(TestCase):
                 log_lines[2]
             )
             self.assertEqual(len(log_lines), 3)
-            # Check existence of InventoryHost record
+            # Check existence of AdvisorInventoryHost record
             self.assertEqual(
-                InventoryHost.objects.filter(id=new_host_id).count(),
+                AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).count(),
                 1
             )
             self.assertEqual(
@@ -375,6 +436,11 @@ class TestAdvisorInventoryServer(TestCase):
             )
             self.assertEqual(len(log_lines), 3)
 
+            inv_host = AdvisorInventoryHost.objects.get(inventory_id=constants.host_01_uuid)
+            self.assertEqual(inv_host.os_name, "RHEL")
+            self.assertEqual(inv_host.os_major, 7)
+            self.assertEqual(inv_host.os_minor, 5)
+
     @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
     def test_deleted_message_success(self):
         """
@@ -405,15 +471,15 @@ class TestAdvisorInventoryServer(TestCase):
                 log_lines[2]
             )
             self.assertEqual(
-                "INFO:advisor-log:Deleted %d records based on InventoryHost: %s." % (
-                    1, "{'api.InventoryHost': 1}"
+                "INFO:advisor-log:Deleted %d records based on AdvisorInventoryHost: %s." % (
+                    1, "{'api.AdvisorInventoryHost': 1}"
                 ),
                 log_lines[3]
             )
             self.assertEqual(len(log_lines), 4)
         # Now test that we actually deleted all those things:
         self.assertEqual(
-            InventoryHost.objects.filter(id=constants.host_01_uuid).count(),
+            AdvisorInventoryHost.objects.filter(inventory_id=constants.host_01_uuid).count(),
             0
         )
         self.assertEqual(
@@ -464,3 +530,27 @@ class TestAdvisorInventoryServer(TestCase):
                     f"Field {missing_field} is required"
                 )
                 self.assertEqual(len(log_lines), 2)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_created_nullable_fields(self):
+        """
+        Test that the handler works when optional system_profile fields are missing.
+        """
+        modified_msg = deepcopy(create_new_host_msg)
+        modified_msg['host']['system_profile'] = {}
+        modified_msg['host']['groups'] = []
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_created_event(modified_msg)
+        inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+        self.assertIsNone(inv_host.workspace_id)
+        self.assertIsNone(inv_host.workspace_name)
+        self.assertIsNone(inv_host.os_name)
+        self.assertIsNone(inv_host.os_major)
+        self.assertIsNone(inv_host.os_minor)
+        self.assertIsNone(inv_host.host_type)
+        self.assertIsNone(inv_host.bootc_booted_image)
+        self.assertIsNone(inv_host.bootc_booted_image_digest)
+        self.assertIsNone(inv_host.owner_id)
+        self.assertIsNone(inv_host.rhc_client_id)
+        self.assertEqual(inv_host.workloads, {})
+        self.assertIsNone(inv_host.system_update_method)

--- a/api/advisor/logging_conf.py
+++ b/api/advisor/logging_conf.py
@@ -94,6 +94,11 @@ LOGGING = {
             'level': LOG_LEVEL,
             'propagate': False,
         },
+        'api.scripts': {
+            'handlers': ['console'],
+            'level': LOG_LEVEL,
+            'propagate': False,
+        },
         'UnleashClient': {
             'handlers': ['console'],
             'level': 'WARNING',


### PR DESCRIPTION
## Summary
This PR resolves: https://redhat.atlassian.net/browse/RHINENG-23272

- New managed `AdvisorInventoryHost` model replacing Cyndi-replicated `InventoryHost`, with flattened system_profile columns and Kessel workspace fields
- Table uses composite PK `(org_id, inventory_id)` with `PARTITION BY HASH (org_id)` across 16 partitions
- Partitioned index helper script (`api/scripts/partitioned_table_index_helper.py`) for automated vs managed mode index creation on partitioned tables
- Kafka consumer updated to write to new model, extracting workspace from `groups` and workloads from `system_profile.workloads`
- Consumer validates `insights_id` is non-null before writing, rejecting events with missing or empty values
- PostgreSQL upgraded from 13 to 16 in podman-compose for Django 5.2 compatibility

## Summary by Sourcery

Introduce a new partitioned AdvisorInventoryHost model and wire the inventory Kafka consumer and tests to populate it with flattened system profile and workspace data while enforcing non-null insights_id and updating local PostgreSQL version.

New Features:
- Add AdvisorInventoryHost managed model with composite primary key and flattened host metadata fields, including workspace and system profile attributes.
- Add a reusable partitioned table index helper script and migration to create a hash-partitioned advisor_inventory_host table with corresponding indexes.

Bug Fixes:
- Reject inventory events with missing or empty insights_id to avoid persisting invalid host records.

Enhancements:
- Update the advisor inventory service handler to populate AdvisorInventoryHost instead of InventoryHost, extracting workspace, OS, bootc, owner, client, and workload information from incoming events.
- Extend logging configuration to cover script execution and align delete logging with AdvisorInventoryHost usage.

Build:
- Bump the PostgreSQL image in podman-compose from version 13 to 16 for local and CI environments.

Tests:
- Expand advisor inventory service tests to validate AdvisorInventoryHost creation, updates, deletions, field mappings, and behavior when optional system_profile data is absent.