### PR TITLE
[WIP] Eliminate v1 rbac calls when kessel enabled

### DIFF
--- a/api/advisor/api/kessel.py
+++ b/api/advisor/api/kessel.py
@@ -32,6 +32,7 @@ from kessel.inventory.v1beta2 import (
     reporter_reference_pb2,
     streamed_list_objects_request_pb2,
     streamed_list_objects_response_pb2,
+    streamed_list_subjects_request_pb2,
     subject_reference_pb2
 )
 
@@ -188,6 +189,52 @@ def _get_resource_page(
 
 
 #############################################################################
+# Streaming subject request/response handling (inverse of get_resources)
+#############################################################################
+
+principal_subject_type = representation_type_pb2.RepresentationType(
+    resource_type="principal",
+    reporter_type="rbac",
+)
+
+
+def get_subjects(
+    client_stub: inventory_service_pb2_grpc.KesselInventoryServiceStub,
+    subject_type: representation_type_pb2.RepresentationType,
+    relation: str,
+    resource: resource_reference_pb2.ResourceReference,
+    limit: int = 1000,
+    fetch_all=True
+) -> Generator[
+    subject_reference_pb2.SubjectReference, None, None
+]:
+    """
+    Get all subjects that have the given relation to the given resource.
+    Inverse of get_resources: given a resource, find the subjects.
+    """
+    continuation_token = None
+    while True:
+        request = streamed_list_subjects_request_pb2.StreamedListSubjectsRequest(
+            resource=resource,
+            relation=relation,
+            subject_type=subject_type,
+            pagination=request_pagination_pb2.RequestPagination(
+                limit=limit,
+                continuation_token=continuation_token
+            )
+        )
+        last_data = None
+        for data in client_stub.StreamedListSubjects(request):
+            yield data.subject
+            last_data = data
+        if not fetch_all or last_data is None:
+            break
+        continuation_token = last_data.pagination.continuation_token
+        if not continuation_token:
+            break
+
+
+#############################################################################
 # Test decorator
 #############################################################################
 
@@ -243,6 +290,7 @@ class TestClient(inventory_service_pb2_grpc.KesselInventoryServiceStub):
     def __init__(self) -> None:
         self.permission_check_responses = dict()
         self.lookup_resources_responses = dict()
+        self.lookup_subjects_responses = dict()
 
     def add_permission_check_response(
         self, check: check_request_pb2.CheckRequest, response_int: int
@@ -321,6 +369,38 @@ class TestClient(inventory_service_pb2_grpc.KesselInventoryServiceStub):
             return self.lookup_resources_responses[subject_str]
         else:
             raise NotImplementedError(f"Response for lookup {subject_str} not implemented")
+
+    def add_lookup_subjects_response(
+        self, resource: ResourceRef, user_ids: list[str]
+    ) -> None:
+        """
+        When subjects for this resource are requested, return these user_ids.
+        """
+        resource_str = str(resource)
+        response_objs = [
+            SimpleNamespace(
+                subject=SimpleNamespace(
+                    resource=SimpleNamespace(resource_id=f"redhat/{uid}")
+                ),
+                pagination=SimpleNamespace(continuation_token=None)
+            )
+            for uid in user_ids
+        ]
+        self.lookup_subjects_responses[resource_str] = response_objs
+
+    def del_lookup_subjects_response(self, resource: ResourceRef):
+        resource_str = str(resource)
+        del self.lookup_subjects_responses[resource_str]
+
+    def StreamedListSubjects(
+        self, request: streamed_list_subjects_request_pb2.StreamedListSubjectsRequest
+    ) -> list:
+        resource = request.resource
+        resource_str = str(resource)
+        if resource_str in self.lookup_subjects_responses:
+            return self.lookup_subjects_responses[resource_str]
+        else:
+            raise NotImplementedError(f"Response for subject lookup {resource_str} not implemented")
 
 
 #############################################################################
@@ -417,6 +497,34 @@ class Kessel:
             "Getting host groups for subject - Result %s", result
         )
 
+        return result, time.time() - start
+
+    def subjects_with_permission(
+        self, resource: ResourceRef, relation: str
+    ) -> Tuple[list[str], float]:
+        """
+        Find all principals that have the given relation on the given resource.
+        Returns a list of user_id strings (with the 'redhat/' prefix stripped).
+        """
+        if not self.client:
+            logger.error("Kessel client not available (in subjects_with_permission)")
+            return [], 0.0
+        start = time.time()
+        logger.info(
+            "Getting subjects with %s on %s", relation, resource
+        )
+        result = []
+        for subject_ref in get_subjects(
+            self.client, principal_subject_type,
+            relation, resource.as_pb2()
+        ):
+            resource_id = subject_ref.resource.resource_id
+            if resource_id.startswith('redhat/'):
+                result.append(resource_id[len('redhat/'):])
+            else:
+                result.append(resource_id)
+
+        logger.debug("subjects_with_permission result: %s", result)
         return result, time.time() - start
 
 

--- a/api/advisor/api/management/commands/weekly_report_emails.py
+++ b/api/advisor/api/management/commands/weekly_report_emails.py
@@ -30,8 +30,11 @@ from api.models import (
     CurrentReport, InventoryHost, WeeklyReportSubscription, stale_systems_q, Ack
 )
 from api.permissions import (
-    RHIdentityAuthentication, has_rbac_permission, request_object_for_testing
+    RHIdentityAuthentication, has_rbac_permission, request_object_for_testing,
+    get_workspace_id,
 )
+from feature_flags import feature_flag_is_enabled, FLAG_ADVISOR_KESSEL_ENABLED
+import api.kessel as kessel
 from api.utils import user_account_details
 from api.views.stats import get_reports_stats, get_rules_stats
 from advisor_logging import logger
@@ -190,6 +193,64 @@ def get_reports(org_id):
     }
 
 
+def _get_kessel_permitted_user_ids(org_id):
+    """
+    Use Kessel StreamedListSubjects to find all user_ids that have the
+    weekly-report view permission on this org's default workspace.
+    Returns a set of user_id strings, or None if Kessel is not available.
+    """
+    if not (settings.KESSEL_ENABLED and feature_flag_is_enabled(FLAG_ADVISOR_KESSEL_ENABLED)):
+        return None
+    if not kessel.client or not kessel.client.client:
+        logger.warning("Kessel client not available for weekly report permission check")
+        return None
+    try:
+        request = request_object_for_testing(
+            auth_by=RHIdentityAuthentication, org_id=org_id
+        )
+        workspace_id, _ = get_workspace_id(request)
+        if not workspace_id:
+            logger.error("No workspace found for org %s", org_id)
+            return None
+        permitted_ids, _ = kessel.client.subjects_with_permission(
+            kessel.Workspace(workspace_id).to_ref(),
+            'advisor_weekly_report_view'
+        )
+        return set(permitted_ids)
+    except Exception as e:
+        logger.error("Error checking Kessel permissions for weekly report: %s", e)
+        return None
+
+
+def _user_has_permission(username, org_id, account, permitted_user_ids, account_data):
+    """
+    Check if a user has permission via Kessel (user_id match) or v1/access.
+    """
+    if permitted_user_ids is not None:
+        if 'id' not in account_data:
+            logger.warning("No 'id' in account data for user '%s', denying", username)
+            return False
+        user_id = str(account_data['id'])
+        if user_id not in permitted_user_ids:
+            logger.debug(
+                "User '%s' (id=%s) in org_id '%s' denied by Kessel",
+                username, user_id, org_id
+            )
+            return False
+        return True
+
+    request = request_object_for_testing(
+        auth_by=RHIdentityAuthentication, org_id=org_id, username=username
+    )
+    result, _ = has_rbac_permission(request, WEEKLY_REPORT_RBAC_PERMISSION)
+    if not result:
+        logger.debug(
+            "User '%s' in account '%s' org_id '%s' doesn't have permission "
+            "to receive the report email", username, account, org_id
+        )
+    return result
+
+
 def get_users_to_email(org_id, account, latest_email_time):
     subscription_for = {
         wrs.username: wrs
@@ -211,6 +272,8 @@ def get_users_to_email(org_id, account, latest_email_time):
     users_to_email = []
     expired_users = []
 
+    permitted_user_ids = _get_kessel_permitted_user_ids(org_id)
+
     for username in subscription_for:
         # Ensure we have account details for this user
         if username not in account_details_for:
@@ -222,14 +285,7 @@ def get_users_to_email(org_id, account, latest_email_time):
         if not ('is_active' in account_data and account_data['is_active']):
             expired_users.append(username)
             continue
-        org_id = subscription_data.org_id
-        request = request_object_for_testing(
-            auth_by=RHIdentityAuthentication, org_id=org_id, username=username
-        )
-        result, _ = has_rbac_permission(request, WEEKLY_REPORT_RBAC_PERMISSION)
-        # Don't need the elapsed time here.
-        if not result:
-            logger.debug("User '%s' in account '%s' org_id '%s' doesn't have permission to receive the report email", username, account, org_id)
+        if not _user_has_permission(username, org_id, account, permitted_user_ids, account_data):
             expired_users.append(username)
             continue
         user_to_email = account_data

--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -354,6 +354,27 @@ def find_host_groups(role_list: list[dict[str, str | dict[str, str]]], request):
         logger.debug(f"User has host groups {host_groups}")
 
 
+def check_permission(
+    request: Request, permission: str, scope: ResourceScope = ResourceScope.ORG
+) -> tuple[bool, float]:
+    """
+    Route a permission check through Kessel (gRPC) when enabled, or v1/access
+    otherwise.  Use this for standalone permission checks outside of DRF views
+    that don't go through InsightsRBACPermission.has_permission.
+    """
+    if not settings.RBAC_ENABLED:
+        return (True, 0.0)
+    if settings.KESSEL_ENABLED and feature_flag_is_enabled(FLAG_ADVISOR_KESSEL_ENABLED):
+        if scope == ResourceScope.WORKSPACE:
+            raise ValueError("check_permission does not support WORKSPACE scope")
+        user_data = request_to_user_data(request)
+        if not user_data or 'user_id' not in user_data:
+            logger.warning("check_permission: missing user_id for Kessel check, denying")
+            return (False, 0.0)
+        return has_kessel_permission(scope, RBACPermission(permission), request)
+    return has_rbac_permission(request, permission)
+
+
 def has_rbac_permission(request: Request, permission: str = 'advisor:*:*') -> tuple[bool, float]:
     """
     Check if this user in this account has the required permission.

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -24,12 +24,15 @@ from rest_framework.exceptions import AuthenticationFailed
 
 from api.kessel import add_kessel_response
 from api.models import InventoryHost
+from unittest.mock import patch
+
 from api.permissions import (
     AssociatePermission, BaseAssociatePermission, BaseRedHatUserPermission,
     CertAuthPermission, InsightsRBACPermission, IsRedHatInternalUser,
     RBACPermission, RHIdentityAuthentication, ResourceScope, OrgPermission,
     TurnpikeIdentityAuthentication, auth_header_for_testing, auth_header_key,
-    auth_to_request, has_kessel_permission, request_object_for_testing, request_to_username,
+    auth_to_request, check_permission, has_kessel_permission,
+    request_object_for_testing, request_to_username,
     turnpike_auth_header_for_testing, make_rbac_url, get_workspace_id,
 )
 from api.tests import constants
@@ -1001,3 +1004,67 @@ class TestAssociatePermission(TestCase):
         int_rq = auth_to_request(turnpike_auth_header_for_testing())
         fake_auth_check(int_rq, TurnpikeIdentityAuthentication)
         self.assertTrue(self.APClass.has_permission(int_rq, self.view))
+
+
+class CheckPermissionTestCase(TestCase):
+    """Test the check_permission() unified routing function."""
+
+    def test_rbac_disabled_returns_true(self):
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        with self.settings(RBAC_ENABLED=False):
+            result, elapsed = check_permission(request, 'advisor:weekly-report:read')
+            self.assertTrue(result)
+            self.assertEqual(elapsed, 0.0)
+
+    @responses.activate
+    def test_kessel_disabled_delegates_to_v1(self):
+        rbac_access_url = make_rbac_url(
+            'access/?application=advisor,tasks,inventory&limit=1000',
+            rbac_base=TEST_RBAC_URL,
+        )
+        responses.get(
+            rbac_access_url,
+            json={'data': [{'permission': 'advisor:weekly-report:read'}]},
+            status=200,
+        )
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        with self.settings(RBAC_ENABLED=True, RBAC_URL=TEST_RBAC_URL, KESSEL_ENABLED=False):
+            result, elapsed = check_permission(request, 'advisor:weekly-report:read')
+            self.assertTrue(result)
+
+    @patch('api.permissions.has_kessel_permission', return_value=(True, 0.1))
+    @patch('api.permissions.feature_flag_is_enabled', return_value=True)
+    def test_kessel_enabled_delegates_to_kessel(self, mock_flag, mock_kessel):
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        with self.settings(RBAC_ENABLED=True, KESSEL_ENABLED=True):
+            result, elapsed = check_permission(request, 'advisor:weekly-report:read')
+            self.assertTrue(result)
+            mock_kessel.assert_called_once()
+            args = mock_kessel.call_args
+            self.assertEqual(args[0][0], ResourceScope.ORG)
+            self.assertEqual(str(args[0][1]), 'advisor:weekly-report:read')
+
+    @patch('api.permissions.feature_flag_is_enabled', return_value=True)
+    def test_kessel_path_denies_when_no_user_id(self, mock_flag):
+        request = request_object_for_testing(
+            auth_by=RHIdentityAuthentication, user_id=None
+        )
+        with self.settings(RBAC_ENABLED=True, KESSEL_ENABLED=True):
+            result, elapsed = check_permission(request, 'advisor:weekly-report:read')
+            self.assertFalse(result)
+
+    @responses.activate
+    def test_kessel_disabled_v1_denies_when_no_matching_permission(self):
+        rbac_access_url = make_rbac_url(
+            'access/?application=advisor,tasks,inventory&limit=1000',
+            rbac_base=TEST_RBAC_URL,
+        )
+        responses.get(
+            rbac_access_url,
+            json={'data': [{'permission': 'advisor:recommendation-results:read'}]},
+            status=200,
+        )
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        with self.settings(RBAC_ENABLED=True, RBAC_URL=TEST_RBAC_URL, KESSEL_ENABLED=False):
+            result, elapsed = check_permission(request, 'advisor:weekly-report:read')
+            self.assertFalse(result)

--- a/api/advisor/api/tests/test_weekly_report_auto_subscribe_views.py
+++ b/api/advisor/api/tests/test_weekly_report_auto_subscribe_views.py
@@ -22,7 +22,7 @@ from django.urls import reverse
 
 from api.tests import constants
 from api.permissions import auth_header_for_testing
-from api.wrs_utils import update_wrs
+
 
 test_user_identity_header = auth_header_for_testing(username="test-user")
 test_user2_identity_header = auth_header_for_testing(username="test-user2")
@@ -98,10 +98,6 @@ class WeeklyReportAutoSubscribeTestCase(TestCase):
                 **test_user_identity_header
             )
             self.assertEqual(response.status_code, 403)
-            self._check_no_subscription_confirmation_sent()
-
-            # Test utils functions directly...
-            self.assertIsNone(update_wrs("test-user", "1234567", False, "9876543"))
             self._check_no_subscription_confirmation_sent()
 
     def test_missing_post_request_parameter(self):

--- a/api/advisor/api/tests/test_weekly_report_command.py
+++ b/api/advisor/api/tests/test_weekly_report_command.py
@@ -449,3 +449,113 @@ class WeeklyReportEmailTest(TestCase):
         ):
             call_command('weekly_report_emails', '--org-id=1234567', stdout=out)
         self.assertEqual(len(mail.outbox), 0)
+
+
+class KesselWeeklyReportTest(TestCase):
+    """Test the Kessel/StreamedListSubjects path in get_users_to_email."""
+    fixtures = [
+        'rulesets', 'system_types', 'rule_categories', 'upload_sources',
+        'basic_test_data', 'weekly_report_test_data',
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        update_stale_dates()
+
+    def setUp(self):
+        mail.outbox = []
+        reset_last_email_at()
+
+    @responses.activate
+    def test_kessel_path_filters_by_user_id(self):
+        """When Kessel is enabled, only users whose id is in the permitted
+        set from StreamedListSubjects should receive emails."""
+        from unittest.mock import patch
+        from api.management.commands.weekly_report_emails import get_users_to_email
+
+        responses.add_callback(
+            responses.POST, test_middleware_url + '/users',
+            callback=lookup_user_details,
+        )
+        # test-user has id=123456701 in user_details_table
+        # denied-user has id=123456704
+        # Only test-user's id is in the permitted set
+        with patch(
+            'api.management.commands.weekly_report_emails._get_kessel_permitted_user_ids',
+            return_value={'123456701'},
+        ):
+            with self.settings(MIDDLEWARE_HOST_URL=test_middleware_url):
+                users_to_email, expired = get_users_to_email(
+                    '9876543', '1234567', timezone.now()
+                )
+        usernames = [u['username'] for u in users_to_email]
+        self.assertIn('test-user', usernames)
+        self.assertNotIn('denied-user', usernames)
+        self.assertIn('denied-user', expired)
+
+    @responses.activate
+    def test_kessel_path_empty_permitted_set_sends_no_emails(self):
+        """When Kessel returns no permitted users, no emails are sent."""
+        from unittest.mock import patch
+        from api.management.commands.weekly_report_emails import get_users_to_email
+
+        responses.add_callback(
+            responses.POST, test_middleware_url + '/users',
+            callback=lookup_user_details,
+        )
+        with patch(
+            'api.management.commands.weekly_report_emails._get_kessel_permitted_user_ids',
+            return_value=set(),
+        ):
+            with self.settings(MIDDLEWARE_HOST_URL=test_middleware_url):
+                users_to_email, expired = get_users_to_email(
+                    '9876543', '1234567', timezone.now()
+                )
+        self.assertEqual(len(users_to_email), 0)
+
+    @responses.activate
+    def test_kessel_disabled_falls_back_to_v1(self):
+        """When Kessel is disabled, the v1 path is used."""
+        from api.management.commands.weekly_report_emails import get_users_to_email
+
+        responses.add_callback(
+            responses.POST, test_middleware_url + '/users',
+            callback=lookup_user_details,
+        )
+        responses.add_callback(
+            responses.GET, TEST_RBAC_V1_ACCESS,
+            callback=lookup_rbac_permissions,
+        )
+        with self.settings(
+            RBAC_URL=TEST_RBAC_URL, RBAC_ENABLED=True,
+            KESSEL_ENABLED=False,
+            MIDDLEWARE_HOST_URL=test_middleware_url,
+        ):
+            users_to_email, expired = get_users_to_email(
+                '9876543', '1234567', timezone.now()
+            )
+        usernames = [u['username'] for u in users_to_email]
+        self.assertIn('test-user', usernames)
+        self.assertNotIn('denied-user', usernames)
+
+    def test_kessel_error_returns_none(self):
+        """When Kessel errors, _get_kessel_permitted_user_ids returns None
+        so the v1 fallback is used."""
+        from unittest.mock import patch
+        from api.management.commands.weekly_report_emails import _get_kessel_permitted_user_ids
+
+        with patch('api.management.commands.weekly_report_emails.kessel') as mock_kessel:
+            mock_kessel.client.client = True
+            mock_kessel.Workspace.return_value.to_ref.return_value = 'ws-ref'
+            with patch(
+                'api.management.commands.weekly_report_emails.get_workspace_id',
+                side_effect=Exception("gRPC down"),
+            ):
+                with self.settings(KESSEL_ENABLED=True):
+                    with patch(
+                        'api.management.commands.weekly_report_emails.feature_flag_is_enabled',
+                        return_value=True,
+                    ):
+                        result = _get_kessel_permitted_user_ids('9876543')
+        self.assertIsNone(result)

--- a/api/advisor/api/tests/test_weekly_report_subscription_views.py
+++ b/api/advisor/api/tests/test_weekly_report_subscription_views.py
@@ -23,7 +23,7 @@ from django.urls import reverse
 from api.tests import constants
 from api.tests.test_weekly_report_command import count_posted_emails
 from api.permissions import auth_header_for_testing, make_rbac_url
-from api.wrs_utils import update_wrs
+
 
 test_user_identity_header = auth_header_for_testing(username='test-user')
 test_user2_identity_header = auth_header_for_testing(username='test-user2')
@@ -186,10 +186,6 @@ class WeeklyReportSubscriptionTestCase(TestCase):
                 data=not_subscribed, **test_user_identity_header
             )
             self.assertEqual(response.status_code, 403)
-            self._check_no_subscription_confirmation_sent()
-
-            # Test utils functions directly...
-            self.assertIsNone(update_wrs('test-user', '1234567', False, '9876543'))
             self._check_no_subscription_confirmation_sent()
 
     @responses.activate

--- a/api/advisor/api/views/user_preferences.py
+++ b/api/advisor/api/views/user_preferences.py
@@ -22,7 +22,7 @@ from drf_spectacular.utils import extend_schema
 from api.models import WeeklyReportSubscription
 from api.serializers import SettingsDDFSerializer, PreferencesInputSerializer
 from api.permissions import (
-    ResourceScope, has_rbac_permission, request_to_username,
+    ResourceScope, check_permission, request_to_username,
 )
 from api.utils import store_post_data
 from api.wrs_utils import update_wrs
@@ -57,7 +57,7 @@ class PreferencesViewSet(viewsets.ViewSet):
         # compile settings list
         settings = []
         # Can this be a bit more ... data driven?
-        if has_rbac_permission(request, 'advisor:weekly-report:*'):
+        if check_permission(request, 'advisor:weekly-report:read')[0]:
             # Get weekly report subscription setting
             wrs_qs = WeeklyReportSubscription.objects.filter(username=username, org_id=org_id)
             is_subscribed = wrs_qs.exists()

--- a/api/advisor/api/wrs_utils.py
+++ b/api/advisor/api/wrs_utils.py
@@ -16,14 +16,10 @@
 
 from os import environ
 
-from django.conf import settings
 from django.template.loader import render_to_string
 
 from api.models import WeeklyReportSubscription
 from api.management.commands.weekly_report_emails import MiddlewareClient
-from api.permissions import (
-    RHIdentityAuthentication, has_rbac_permission, request_object_for_testing
-)
 
 
 default_subject = environ.get(
@@ -37,8 +33,6 @@ default_html_template = environ.get(
 def send_confirmation_email(username):
     """
     Send a confirmation email to this user.
-
-    Permission check has been done in update_wrs (as the only caller).
     """
     client = MiddlewareClient()
     # Ignore errors if sending the email fails...
@@ -58,17 +52,10 @@ def update_wrs(username, account, sub_desired=True, org_id=None, auto_subscribed
     """
     Subscribe and/or Auto-Subscribe a user for a WeeklyReportSubscription.
 
-    Only available if the user has permission to update their weekly report
-    settings (and RBAC enabled, of course).
+    Permission is enforced at the view level by InsightsRBACPermission
+    (which handles both Kessel and v1/access branching).  All production
+    callers go through DRF views that apply this permission class.
     """
-    if settings.RBAC_ENABLED:
-        request = request_object_for_testing(
-            auth_by=RHIdentityAuthentication, org_id=org_id, username=username
-        )
-        success, elapsed = has_rbac_permission(request, 'advisor:weekly-report:write')
-        if not success:
-            return
-
     sub_qs = WeeklyReportSubscription.objects.filter(
         username=username, org_id=org_id,
     )


### PR DESCRIPTION
Three callers of `has_rbac_permission` bypass `InsightsRBACPermission.has_permission` (which already branches between Kessel gRPC and v1/access). When an org enables v2 access management in RBAC, v1/access calls
return HTTP 400 — so these callers break for v2 orgs. This PR eliminates all v1 RBAC calls when Kessel is enabled.

- **`user_preferences.py`** — replaced direct `has_rbac_permission` call with new `check_permission()` routing function; also fixes existing bug where tuple return was used as truthy value (always true)
- **`wrs_utils.py`** — removed redundant permission check inside `update_wrs`; all 3 production callers already pass through `InsightsRBACPermission` at the DRF view level
- **`weekly_report_emails.py`** — replaced N per-user v1/access calls with a single Kessel `StreamedListSubjects` gRPC call that batch-queries which users have the permission; falls back to v1 when Kessel is 
disabled

## Key design decisions

1. **`check_permission()`** — unified function in `permissions.py` that mirrors the Kessel/v1 branching from `InsightsRBACPermission.has_permission`. Includes `user_id` guard and rejects `WORKSPACE` scope (which 
returns a list, not a bool).

2. **`StreamedListSubjects` for weekly report** — the management command iterates all subscribed users. Rather than N individual Kessel `Check` calls (which would require real user_ids not available in synthetic 
requests), we query "which principals have this permission on this workspace?" in one gRPC call, then filter the subscription list by matching the middleware API `id` field against the result set.

3. **Middleware `id` == identity `user_id`** — verified by tracing both through BOP source code (`backoffice-proxy/util.js:339`). Both originate from `buildUserFromDetails()` reading `fullUser.id` from 
`user.api.redhat.com/v2/findUsers`. The gateway (`identity.lua:141`) sets `user_id = utils.safe_to_string(user_obj.id)` from the same BOP response.

## Review order

1. `api/advisor/api/permissions.py` — new `check_permission()` function (~20 lines)
2. `api/advisor/api/views/user_preferences.py` — 2-line change using `check_permission`
3. `api/advisor/api/wrs_utils.py` — removal of redundant permission block
4. `api/advisor/api/kessel.py` — `get_subjects()` generator + `subjects_with_permission()` + TestClient support
5. `api/advisor/api/management/commands/weekly_report_emails.py` — Kessel branch in `get_users_to_email()`
6. Test files

## Test

- [x] `pipenv run linter` — clean
- [x] `pipenv run testapi` — 689 tests (2 pre-existing pathway ordering failures unrelated to this PR)
- [x] `pipenv run testtasks` — 102 tests pass
- [x] `grep -rn "has_rbac_permission" api/ --include="*.py" | grep -v test | grep -v permissions.py` — only the v1 fallback in `weekly_report_emails.py` remains
- [x] With `KESSEL_ENABLED=true` + feature flag on: no v1/access calls from any of the three callers

## Summary by Sourcery

Eliminate direct v1 RBAC usage in non-view code paths by routing standalone permission checks through a new unified helper and updating weekly report logic to prefer Kessel-based subject queries, while relying on DRF view permissions elsewhere.

New Features:
- Add a unified check_permission helper that routes permission checks through Kessel or v1 RBAC depending on configuration.
- Introduce Kessel subject lookup utilities, including StreamedListSubjects support and a subjects_with_permission API, to find principals with specific permissions.
- Add Kessel-aware weekly report recipient selection that uses streamed subject queries when available and falls back to v1 RBAC when necessary.

Bug Fixes:
- Fix incorrect truthiness handling of has_rbac_permission results in the user preferences view by using the boolean component from check_permission.
- Avoid v1 RBAC calls for organizations with Kessel-enabled access management during weekly report email generation and user preference checks.

Enhancements:
- Remove redundant RBAC permission checks from weekly report subscription utilities, relying on existing DRF-level permission enforcement instead.
- Extend the Kessel TestClient and add tests to cover the new permission routing and Kessel-based weekly report paths, including error and fallback behaviors.

Tests:
- Add unit tests for the new check_permission helper covering Kessel and v1 RBAC branches and edge cases.
- Add tests for Kessel-based weekly report recipient selection, including filtering by permitted user ids, empty permission sets, disabled Kessel, and error fallback to v1 RBAC.