### PR TITLE
More documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,35 +461,38 @@ as well as your curl command.
 Start API dependencies. We still use podman-compose here
 but only for the dependencies. This method is meant for
 more rapid development.
+
+Note: all the following commands assume you have activated the pipenv shell and run `export ADVISOR_DB_HOST=localhost`
+
+Start the DB:
 ```bash
-export ADVISOR_DB_HOST=localhost
 podman-compose up -d advisor-db
 ```
-Setup the DB (if this is the first time running).
+Populate the DB (if this is the first time running).
 ```bash
-pipenv shell
+./container_init_localdev.sh
+```
+... or manually run the following commands (which are mostly in the container_init_localdev.sh script):
+```bash
 python api/advisor/manage.py migrate
 python api/advisor/manage.py mock_cyndi_table
 python api/advisor/manage.py loaddata rulesets rule_categories system_types \
        upload_sources basic_test_data basic_task_test_data
 ```
-Start the API manually
-```bash
-LOG_LEVEL=DEBUG python api/advisor/manage.py runserver --insecure 0.0.0.0:8000
-```
-NOTE: If you are running with a PROMETHEUS_PORT defined other than 8000 then
-you will need to run Django differently.
 
+Start the API manually:
+```bash
+LOG_LEVEL=DEBUG api/advisor/manage.py runserver --insecure 0.0.0.0:8000
+```
 The runserver `--insecure` flag is for serving static files even if DEBUG is False.
 It should only be used for local development.
 ```bash
-python api/advisor/manage.py runserver --noreload --insecure 0.0.0.0:8000
+LOG_LEVEL=DEBUG api/advisor/manage.py runserver --noreload --insecure 0.0.0.0:8000
 ```
 NOTE: If you want to enable the Auto-Subscribe endpoint, define the
 `ENABLE_AUTOSUB` environment variable to `true` before running the server.
-
 ```bash
-ENABLE_AUTOSUB=true python api/advisor/manage.py runserver --insecure 0.0.0.0:8000
+ENABLE_AUTOSUB=true LOG_LEVEL=DEBUG api/advisor/manage.py runserver --insecure 0.0.0.0:8000
 ```
 
 # Testing Tasks API

--- a/api/README.md
+++ b/api/README.md
@@ -26,8 +26,7 @@ The Advisor API actually covers three APIs:
     `git clone https://github.com/RedHatInsights/insights-advisor`
 
 - Setup virtualenv dev environment
-
-    ```
+    ```bash
     cd insights-advisor
     pip install pipenv
     pipenv install --dev
@@ -63,7 +62,7 @@ down`.  `podman-compose up` will re-initialize the data.
 
 You can also run Advisor from the host.  Here's how ...
 
-- Install the Django database
+- Install/run the Django database
 
     The application uses a PostgreSQL database by default.  You can install
     PostgreSQL using the `postgresql-*` packages and use `psql` to configure
@@ -76,13 +75,22 @@ You can also run Advisor from the host.  Here's how ...
         -e POSTGRESQL_PASSWORD=InsightsData -e POSTGRESQL_DATABASE=insightsapi \
         registry.access.redhat.com/rhscl/postgresql-12-rhel7
     ```
+    ... or you can start a postgresql container using podman-compose:
+    ```bash
+    $ podman-compose up -d advisor-db
+    ```
 
 - Populating the database
 
-    You will need to populate the database in order to test the API.  To
-    create and populate the tables run:
+    You will need to populate the database to test the API.
+    Note: all the following commands assume you have activated the pipenv shell and run `export ADVISOR_DB_HOST=localhost`
 
+- To create and populate the tables run:
+    ```bash
+    $ ./container_init_localdev.sh
     ```
+    Or you can run the commands manually like so:
+    ```bash
     $ api/advisor/manage.py migrate
     $ api/advisor/manage.py loaddata rulesets rule_categories system_types upload_sources
     $ api/advisor/manage.py mock_cyndi_table
@@ -92,11 +100,11 @@ You can also run Advisor from the host.  Here's how ...
 
 - Start the API:
     - Via the Django webserver:
-    ```
+    ```bash
     $ LOG_LEVEL=DEBUG api/advisor/manage.py runserver --insecure 0.0.0.0:8000
     ```
     - or via gunicorn:
-    ```
+    ```bash
     $ ./app.sh
     [2018-06-21 14:30:23 -0400] [31722] [INFO] Starting gunicorn 19.8.1
     [2018-06-21 14:30:23 -0400] [31722] [INFO] Listening at: http://0.0.0.0:8000 (31722)

--- a/api/advisor/tasks/fixtures/basic_task_test_data.json
+++ b/api/advisor/tasks/fixtures/basic_task_test_data.json
@@ -487,7 +487,7 @@
         "active": false, "type": "S", "filters": []
   }
 },{
-    "model": "tasks.Task", "pk": 4, "fields": {
+    "model": "tasks.Task", "pk": 104, "fields": {
         "slug": "convert2rhel_check", "title": "Use Convert2RHEL to check a system for conversion",
         "description": "Produce a report to check what needs to be done to convert a set of systems to RHEL",
         "publish_date": "2023-05-29T23:47:21Z",
@@ -498,7 +498,7 @@
     }
 }, {
     "model": "tasks.TaskParameter", "pk": 1, "fields": {
-        "task_id": 4, "key": "extra_repositories", "default": "false",
+        "task_id": 104, "key": "extra_repositories", "default": "false",
         "description": "Should extra repositories be enabled?",
         "required": false, "values": ["true", "false"],
         "title": "Enable Extra Repositories",
@@ -507,7 +507,7 @@
     }
 }, {
     "model": "tasks.TaskParameter", "pk": 2, "fields": {
-        "task_id": 4, "key": "repository_names", "default": null,
+        "task_id": 104, "key": "repository_names", "default": null,
         "description": "Names of extra repositories to include",
         "required": false, "values": ["els", "epel", "extra", ""],
         "title": "Extra Repository Names",
@@ -516,7 +516,7 @@
     }
 }, {
     "model": "tasks.TaskParameter", "pk": 3, "fields": {
-        "task_id": 4, "key": "has_internet_access", "default": "true",
+        "task_id": 104, "key": "has_internet_access", "default": "true",
         "description": "Should convert2rhel check the internet for updates?",
         "required": true, "values": ["true", "false"],
         "title": "Check for Updates Online",
@@ -525,7 +525,7 @@
     }
 }, {
     "model": "tasks.TaskParameter", "pk": 4, "fields": {
-        "task_id": 4, "key": "organisation_id", "default": null,
+        "task_id": 104, "key": "organisation_id", "default": null,
         "description": "Organisation ID for subscription checks",
         "required": true, "values": ["1248", "1369", "1720"],
         "title": "Organisation ID",
@@ -563,7 +563,7 @@
 }, {
     "model": "tasks.ExecutedTask", "pk": 5, "fields": {
         "name": "Use Convert2RHEL to check a system for conversion",
-        "task_id": 4, "org_id": "9876543", "initiated_by": "testing",
+        "task_id": 104, "org_id": "9876543", "initiated_by": "testing",
         "start_time": "2023-05-30T00:25:09Z", "status": 4,
         "token": "00112233-4455-6677-8899-aabbccddee05"
     }

--- a/api/advisor/tasks/tests/__init__.py
+++ b/api/advisor/tasks/tests/__init__.py
@@ -43,7 +43,7 @@ class constants(object):
     bash_task_id = 3
     bash_task_slug = 'bash-script'
 
-    parameters_task_id = 4
+    parameters_task_id = 104
     parameters_task_slug = 'convert2rhel_check'
     parameters_task_title = 'Use Convert2RHEL to check a system for conversion'
     parameters_task_filter_message = 'Only eligible CentOS 7 systems are shown'

--- a/container_init_localdev.sh
+++ b/container_init_localdev.sh
@@ -31,7 +31,7 @@ pipenv run python api/advisor/manage.py loaddata --verbosity=3 production_tasks 
 # Create fake inventory data for the dev environment, and load basic test data for the API, eg rules and hosts
 echo "Creating mocked inventory table and loading test data ..."
 pipenv run python api/advisor/manage.py mock_cyndi_table
-pipenv run python api/advisor/manage.py loaddata --verbosity=3 basic_test_data
+pipenv run python api/advisor/manage.py loaddata --verbosity=3 basic_test_data basic_task_test_data
 pipenv run python api/advisor/manage.py freshen_hosts
 
 # Import content from the dumped content directory if it exists

--- a/service/README.md
+++ b/service/README.md
@@ -91,8 +91,10 @@ manual_tests/send_fake_engine_results.
 
 Once you have deployed the environment and set up the database, you can run the
 service and begin engine results analysis.
+
+NOTE: all the following commands assume you have activated the pipenv shell and run `export ADVISOR_DB_HOST=localhost`
 ```
-podman-compose up advisor-api
+podman-compose up -d advisor-api
 BOOTSTRAP_SERVERS=localhost:9092 PROMETHEUS_PORT=8001 LOG_LEVEL=DEBUG python service/service.py
 ... or ...
 podman-compose up advisor-service
@@ -103,8 +105,7 @@ podman-compose up advisor-service
 You can send in fake results for analysis using two methods.
 The first method is sending in fake engine results for direct consumption in this service.
 ```
-pipenv shell
-python manual_test/send_fake_engine_results.py
+python service/manual_test/send_fake_engine_results.py
 python api/advisor/manage.py freshen_hosts
 ```
 
@@ -114,7 +115,7 @@ a shared engine instance. However, if you have one running you can use the
 following script which will send a message to the shared engine, then broadcast
 its results for consumption in this service.
 ```
-python manual_test/send_fake_inventory_engine_message.py
+python service/manual_test/send_fake_inventory_engine_message.py
 ```
 
 # Testing


### PR DESCRIPTION
- added ./container_init_localdev.sh to docs
- allowed basic_task_test_data fixture to work alongside production_tasks

## Summary by Sourcery

Update local development and service documentation and align task test data with production fixtures.

Enhancements:
- Update container_init_localdev.sh to load both basic_test_data and basic_task_test_data for a more complete local dataset.

Documentation:
- Document use of container_init_localdev.sh and clarify environment assumptions for local API and service setup.
- Improve README examples for running the API and database locally, including podman-compose usage and command formatting.

Tests:
- Adjust task constants and basic_task_test_data fixture to align test IDs with the production task set.