### PR TITLE
fix(RHINENG-8555): Accept null/empty value host tags

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -517,7 +517,7 @@ host_id_query_param = OpenApiParameter(
 
 host_tags_query_param = OpenApiParameter(
     name='tags', type=OpenApiTypes.REGEX, location=OpenApiParameter.QUERY,
-    pattern=r'^[^/]+/[^=]+=.+$',
+    pattern=r'^[^/]+/[^=]+=.*$',
     description="Tags have a namespace, key and value in the form namespace/key=value",
     required=False, many=True, style='form',
 )
@@ -718,7 +718,7 @@ def filter_on_host_tags(request, field_name='host_id'):
 
         namespace = unescape(namespace)
         key = unescape(key)
-        value = unescape(value)
+        value = unescape(value) if value else None
         logger.debug(f"Processed tag: namespace={namespace}, key={key}, value={value}")
 
         tag_query &= Q(tags__contains=[{"namespace": namespace, "key": key, "value": value}])

--- a/api/advisor/api/tests/test_parameter_parsing.py
+++ b/api/advisor/api/tests/test_parameter_parsing.py
@@ -235,12 +235,6 @@ class HostTagsParameterParsingTestCase(TestCase):
                 tags='namespace/keyvalue'
             ))
 
-        # No value - rejected by regex pattern
-        with self.assertRaises(ValidationError):
-            filter_on_host_tags(make_request_obj(
-                tags='n/k/e/y/'
-            ))
-
         # No key - rejected by regex pattern
         with self.assertRaises(ValidationError):
             filter_on_host_tags(make_request_obj(
@@ -250,6 +244,21 @@ class HostTagsParameterParsingTestCase(TestCase):
     def test_multiple_tags_in_parameter(self):
         q = filter_on_host_tags(make_request_obj(
             tags='namespace/key=value,Sat/env=prod,n/k=v'
+        ))
+        self.assertIsInstance(q, Q)
+        self.assertTrue(q)
+
+    def test_null_value_tag_parameter(self):
+        # Tags with empty values are valid (namespace/key=)
+        q = filter_on_host_tags(make_request_obj(
+            tags='namespace/key='
+        ))
+        self.assertIsInstance(q, Q)
+        self.assertTrue(q)
+
+        # Multiple tags with some having empty values
+        q = filter_on_host_tags(make_request_obj(
+            tags='namespace/key=,other/tag=value'
         ))
         self.assertIsInstance(q, Q)
         self.assertTrue(q)

--- a/service/manual_test/fake_engine_result_rhel.json
+++ b/service/manual_test/fake_engine_result_rhel.json
@@ -28,7 +28,8 @@
         {"namespace": "insights-client", "key": "custom/Last Reboot", "value": "2023-07-14 11:26:07"},
         {"namespace": "insights-client", "key": "Private IPv4", "value": "192.168.1.100"},
         {"namespace": "insights-client", "key": "key_12345678-1234-1234-1234-123456789012_$/$", "value": "&abc&=key_12345678-1234-1234-1234-123456789012"},
-        {"key": "key_12345678-1234-1234-1234-123456789012_%24%252F%24", "value": "%26abc%26%253Dkey_12345678-1234-1234-1234-123456789012", "namespace": "insights-client"}
+        {"key": "key_12345678-1234-1234-1234-123456789012_%24%252F%24", "value": "%26abc%26%253Dkey_12345678-1234-1234-1234-123456789012", "namespace": "insights-client"},
+        {"namespace": "ns", "key": "k", "value": null}
       ],
       "updated": null
     },


### PR DESCRIPTION
## Summary by Sourcery

Allow host tag filters to accept tags with empty values and update validation and parsing to support them.

Bug Fixes:
- Relax host tag query parameter validation to allow tags with empty values instead of rejecting them.
- Adjust host tag value parsing to treat missing values as null rather than an empty string.

Tests:
- Update parameter parsing tests to cover valid tags with empty values and remove assertion that such tags are invalid.