### PR TITLE
fix(RHINENG-25936): Handle 'namespace/key' host tags

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -517,8 +517,8 @@ host_id_query_param = OpenApiParameter(
 
 host_tags_query_param = OpenApiParameter(
     name='tags', type=OpenApiTypes.REGEX, location=OpenApiParameter.QUERY,
-    pattern=r'^[^/]+/[^=]+=.*$',
-    description="Tags have a namespace, key and value in the form namespace/key=value",
+    pattern=r'^[^/]+/[^=]+(=.*)?$',
+    description="Tags have a namespace and key, with an optional value, in the form namespace/key=value or namespace/key",
     required=False, many=True, style='form',
 )
 
@@ -714,11 +714,15 @@ def filter_on_host_tags(request, field_name='host_id'):
     for tag in host_tags:
         logger.debug(f"Processing tag: {tag}")
         namespace, key_and_value = tag.split('/', 1)
-        key, value = key_and_value.split('=', 1)
+        if '=' in key_and_value:
+            key, value = key_and_value.split('=', 1)
+            value = unescape(value) if value else None
+        else:
+            key = key_and_value
+            value = None
 
         namespace = unescape(namespace)
         key = unescape(key)
-        value = unescape(value) if value else None
         logger.debug(f"Processed tag: namespace={namespace}, key={key}, value={value}")
 
         tag_query &= Q(tags__contains=[{"namespace": namespace, "key": key, "value": value}])

--- a/api/advisor/api/tests/test_parameter_parsing.py
+++ b/api/advisor/api/tests/test_parameter_parsing.py
@@ -229,17 +229,26 @@ class HostTagsParameterParsingTestCase(TestCase):
                 tags='key'
             ))
 
-        # No key=value separator '=' - rejected by regex pattern
-        with self.assertRaises(ValidationError):
-            filter_on_host_tags(make_request_obj(
-                tags='namespace/keyvalue'
-            ))
-
         # No key - rejected by regex pattern
         with self.assertRaises(ValidationError):
             filter_on_host_tags(make_request_obj(
                 tags='namespace/=value'
             ))
+
+    def test_key_only_tag_parameter(self):
+        # Tags with no equals sign are valid (namespace/key)
+        q = filter_on_host_tags(make_request_obj(
+            tags='namespace/key'
+        ))
+        self.assertIsInstance(q, Q)
+        self.assertTrue(q)
+
+        # Key-only tag mixed with key=value tags
+        q = filter_on_host_tags(make_request_obj(
+            tags='namespace/key,other/tag=value'
+        ))
+        self.assertIsInstance(q, Q)
+        self.assertTrue(q)
 
     def test_multiple_tags_in_parameter(self):
         q = filter_on_host_tags(make_request_obj(

--- a/api/advisor/tasks/README.md
+++ b/api/advisor/tasks/README.md
@@ -170,7 +170,7 @@ system to the stage environment by following these steps.
 ```shell
 # rhc disconnect
 # subscription-manager config --server.hostname=subscription.rhsm.stage.redhat.com
-# subscription-manager register --activationkey=<stage-activation-key> --org=<stage-org>
+# subscription-manager register --activationkey=<stage-activation-key> --org=<stage-org> --proxy=http://squid.corp.redhat.com:3128
 ```
 ... rhc disconnect stops the rhcd service, unregisters the host from Insights and from Subscription Manager.
 
@@ -201,11 +201,10 @@ Environment="HTTPS_PROXY=http://squid.corp.redhat.com:3128"
 6. Edit `/etc/insights-client/insights-client.conf` to set these lines:
 ```
 auto_config=False
-base_url=cert.console.stage.redhat.com:443/r/insights
 cert_verify=False
+authmethod=CERT
+base_url=cert.console.stage.redhat.com:443/r/insights
 proxy=http://squid.corp.redhat.com:3128
-username=<stage-username>
-password=<stage-password>
 ```
 
 7. Run rhc connect:
@@ -246,16 +245,16 @@ For example, tasks can be activated / deactivated and filters / filter messages 
 The tasks in stage can also be accessed from the command line with curl, like so:
 ```shell
 $ curl -sX GET 'https://console.stage.redhat.com/api/tasks/v1/task/<SLUG>' \
--u $USERPASS -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 | \
+-H "Authorization: Bearer $X_RH_IDENTITY" -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 | \
 jq .
 ```
-Note: `$USERPASS` is an environment variable containing a stage username and password in the form `username:password`.
-Substitute with other authentication methods you are familiar with, eg `-n` for a `.netrc` file, or a basic auth header.
+The `$X_RH_IDENTITY` value can be obtained from the browser dev tools, in the Authorization Bearer header
+of requests to https://console.stage.redhat.com/api/tasks/v1/task and assigning it to an X_RH_IDENTITY environment variable.
 
 For example, to view the slug and title of all tasks in stage, you can use curl and jq, like so:
 ```shell
 $ curl -sX GET 'https://console.stage.redhat.com/api/tasks/v1/task' \
--u $USERPASS -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 | \
+-H "Authorization: Bearer $X_RH_IDENTITY" -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 | \
 jq -r '.data[] | "\(.slug): \(.title)"'
 ...
 insights-client: Run the insights-client
@@ -289,14 +288,14 @@ Running tasks in Stage via the command line
 To run the ping task against a particular host, `POST` to the `executed_task` endpoint with the host's UUID:
 ```shell
 curl -sX POST 'https://console.stage.redhat.com/api/tasks/v1/executed_task' \
--u $USERPASS -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 \
+-H "Authorization: Bearer $X_RH_IDENTITY" -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 \
 --data-raw '{"task": "ping", "hosts": ["<host_UUID_from_inventory>"]}'
 ```
 To run a task with parameters, you only need to specify the parameter keys and values for parameters that are
 different from their default values, eg:
 ```shell
 curl -sX POST 'https://console.stage.redhat.com/api/tasks/v1/executed_task' \
--u $USERPASS -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 \
+-H "Authorization: Bearer $X_RH_IDENTITY" -H 'Content-Type: application/json' --proxy http://squid.corp.redhat.com:3128 \
 --data-raw '{"task": "insights-client", "hosts": ["<host_UUID_from_inventory>"], "parameters": [{"key": "status", "value": "True"}]}'
 ```
 ... where the `True` value for the `status` parameter is different from its default value.

--- a/service/manual_test/fake_engine_result_rhel.json
+++ b/service/manual_test/fake_engine_result_rhel.json
@@ -29,7 +29,8 @@
         {"namespace": "insights-client", "key": "Private IPv4", "value": "192.168.1.100"},
         {"namespace": "insights-client", "key": "key_12345678-1234-1234-1234-123456789012_$/$", "value": "&abc&=key_12345678-1234-1234-1234-123456789012"},
         {"key": "key_12345678-1234-1234-1234-123456789012_%24%252F%24", "value": "%26abc%26%253Dkey_12345678-1234-1234-1234-123456789012", "namespace": "insights-client"},
-        {"namespace": "ns", "key": "k", "value": null}
+        {"namespace": "insights-client", "key": "key_1234567890_hat", "value": null},
+        {"namespace": "insights-client", "key": "key_1234567890_hat", "value": "user@example"}
       ],
       "updated": null
     },


### PR DESCRIPTION
- piggybacked in some changes to the Tasks docs too

## Summary by Sourcery

Support optional values in host tag query parameters and update stage tasks documentation accordingly.

Bug Fixes:
- Allow host tag filters to accept tags with only namespace and key without a value.

Documentation:
- Update tasks README instructions to use proxy configuration and bearer token authentication for stage environment access.

Tests:
- Add coverage for parsing key-only host tag parameters and combinations of key-only and key=value tags.