### PR TITLE
feat(RHINENG-23273): Process Kafka messages in batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,115 @@ means that Advisor would be able to directly write to the InventoryHost model
 and its underlying table.  This gives several advantage - faster updates,
 fewer containers running, and more flexibility in how Advisor works.
 
+## Inventory Event Consumer
+
+The `advisor_inventory_service` management command (`api/advisor/api/management/commands/advisor_inventory_service.py`) runs a Kafka consumer that replicates host data from the Host-Based Inventory (HBI) service into Advisor's own `AdvisorInventoryHost` and `Host` tables. It consumes messages from the `platform.inventory.events` topic in configurable batches (controlled by the `INVENTORY_BATCH_SIZE` setting).
+
+The consumer is gated by the `INVENTORY_EVENT_REPLICATION` setting or the `advisor.inventory_event_replication` feature flag. When neither is enabled, incoming events are logged and discarded.
+
+### How it works
+
+Messages are consumed in batches and dispatched to `handle_inventory_event()`, which:
+
+1. Classifies each message by its `type` field (`created`, `updated`, or `delete`).
+2. Parses valid messages into typed value objects (`ParsedInventoryHost` or `ParsedDeleteEvent`).
+3. Deduplicates upserts by `(org_id, host_id)` within the batch — when multiple events target the same host, only the last one is applied.
+4. Executes bulk DB operations: `bulk_create(update_conflicts=True)` for upserts, and a combined `Q` filter for deletes.
+
+### Message schemas
+
+The consumer handles three event types. Not all fields in the HBI message are used by Advisor; required fields are marked below.
+
+#### Created / Updated events
+
+```json
+{
+    "type": "created",                          // required: "created" or "updated"
+    "timestamp": "<timestamp>",
+    "platform_metadata": "<metadata_json_doc>",
+    "metadata": {                               // required
+        "request_id": "<request_id>"            // required
+    },
+    "host": {                                   // required
+        "id": "<uuid>",                         // required
+        "account": "<account_number>",          // optional
+        "org_id": "<org_id>",                   // required
+        "display_name": "<display_name>",       // required
+        "ansible_host": "<ansible_host>",
+        "fqdn": "<fqdn>",
+        "insights_id": "<insights_id>",         // required (must be non-empty)
+        "subscription_manager_id": "<sub_mgr_id>",
+        "satellite_id": "<satellite_id>",       // optional
+        "bios_uuid": "<bios_uuid>",
+        "ip_addresses": ["<ip_addresses>"],
+        "mac_addresses": ["<mac_addresses>"],
+        "facts": ["<facts>"],
+        "provider_id": "<provider_id>",
+        "provider_type": "<provider_type>",
+        "created": "<created_date>",            // required
+        "updated": "<updated_date>",            // required
+        "last_check_in": "<last_check_in>",     // required
+        "stale_timestamp": "<stale_timestamp>",  // required
+        "stale_warning_timestamp": "<stale_warning_timestamp>",
+        "culled_timestamp": "<culled_timestamp>",
+        "reporter": "<reporter>",               // required
+        "tags": [<tags>],                       // required
+        "system_profile": {                     // required
+            "host_type": "<host_type>",
+            "operating_system": {
+                "name": "<os_name>",
+                "major": <os_major>,
+                "minor": <os_minor>
+            },
+            "bootc_status": {
+                "booted": {
+                    "image": "<image>",
+                    "image_digest": "<digest>"
+                }
+            },
+            "owner_id": "<owner_uuid>",
+            "rhc_client_id": "<rhc_uuid>",
+            "workloads": {<workloads>},
+            "system_update_method": "<method>"
+        },
+        "per_reporter_staleness": {             // required
+            "<reporter>": {
+                "stale_timestamp": "<timestamp>",
+                "stale_warning_timestamp": "<timestamp>",
+                "culled_timestamp": "<timestamp>"
+            }
+        },
+        "groups": [{                            // required
+            "id": "<group_uuid>",
+            "name": "<group_name>"
+        }],
+        "openshift_cluster_id": "<openshift_cluster_id>"
+    }
+}
+```
+
+Fields within `system_profile` are all optional — the consumer handles missing or
+empty values gracefully.  Only the first entry in `groups` is used to populate
+`workspace_id` and `workspace_name`.
+
+#### Delete events
+
+```json
+{
+    "type": "delete",           // required
+    "id": "<uuid>",             // required — the inventory host ID
+    "timestamp": "<timestamp>",
+    "account": "<account>",     // optional
+    "org_id": "<org_id>",       // required
+    "insights_id": "<insights_id>",
+    "request_id": "<request_id>" // required
+}
+```
+
+Deleting a host cascades through `Host` (which cascades to `Upload`,
+`CurrentReport`, and `HostAck`) and then removes the `AdvisorInventoryHost`
+record.
+
 ## Content load and import
 
 There are four main types of data stored in Advisor.

--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -321,7 +321,11 @@ class Command(BaseCommand):
         Run the handler loop continuously until interrupted by SIGTERM.
         """
         logger.info('Advisor Inventory replication service starting up')
-        settings.KAFKA_SETTINGS.update({'group.id': settings.GROUP_ID})
+        settings.KAFKA_SETTINGS.update({
+            'group.id': settings.GROUP_ID,
+            'enable.auto.commit': False,
+            'enable.auto.offset.store': False,
+        })
         receiver = KafkaDispatcher()
         receiver.register_handler(settings.INVENTORY_EVENTS_TOPIC, handle_inventory_event)
 

--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -23,6 +23,7 @@ import prometheus
 import signal
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.db.models import Q
 from django.utils.dateparse import parse_datetime
 
@@ -165,6 +166,7 @@ def handle_inventory_event(topic: str, messages: list[dict[str, JsonValue]]) -> 
             if 'type' not in message:
                 logger.error("Message received on topic %s with no 'type' field", topic)
                 prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
+                prometheus.INVENTORY_EVENT_MALFORMED.inc()
                 continue
 
             match message['type']:
@@ -173,20 +175,33 @@ def handle_inventory_event(topic: str, messages: list[dict[str, JsonValue]]) -> 
                     if parsed is not None:
                         upserts.append(parsed)
                         created_count += 1
+                    else:
+                        prometheus.INVENTORY_EVENT_MALFORMED.inc()
                 case 'updated':
                     parsed = parse_created_event(message)
                     if parsed is not None:
                         upserts.append(parsed)
                         updated_count += 1
+                    else:
+                        prometheus.INVENTORY_EVENT_MALFORMED.inc()
                 case 'delete':
                     parsed = parse_deleted_event(message)
                     if parsed is not None:
                         delete_data.append(parsed)
+                    else:
+                        prometheus.INVENTORY_EVENT_MALFORMED.inc()
                 case msg_type:
                     logger.error("Inventory event: Unknown message type: %s", msg_type)
+                    prometheus.INVENTORY_EVENT_MALFORMED.inc()
         except Exception:
             logger.exception("Failed to parse inventory event, skipping")
+            prometheus.INVENTORY_EVENT_MALFORMED.inc()
             continue
+
+    if delete_data:
+        logger.debug("Starting bulk delete of %d hosts", len(delete_data))
+        bulk_delete_hosts(delete_data)
+        logger.debug("Bulk delete committed successfully")
 
     if upserts:
         # TOCTOU: a concurrent write between this check and bulk_upsert_hosts
@@ -199,14 +214,6 @@ def handle_inventory_event(topic: str, messages: list[dict[str, JsonValue]]) -> 
                       len(upserts), created_count, updated_count)
         bulk_upsert_hosts(upserts)
         logger.debug("Bulk upsert committed successfully")
-        prometheus.INVENTORY_HOST_CREATED.inc(created_count)
-        prometheus.INVENTORY_HOST_UPDATED.inc(updated_count)
-
-    if delete_data:
-        logger.debug("Starting bulk delete of %d hosts", len(delete_data))
-        bulk_delete_hosts(delete_data)
-        logger.debug("Bulk delete committed successfully")
-        prometheus.INVENTORY_HOST_DELETED.inc(len(delete_data))
 
 
 def log_missing_key(request_id: str, event_type: str, key_name: str):
@@ -347,44 +354,49 @@ def parse_deleted_event(message: dict[str, JsonValue]) -> ParsedDeleteEvent | No
 def bulk_upsert_hosts(upserts: list[ParsedInventoryHost]) -> None:
     """Bulk upsert AdvisorInventoryHost and Host records."""
     inv_instances = [item.to_advisor_model() for item in upserts]
-    AdvisorInventoryHost.objects.bulk_create(
-        inv_instances,
-        update_conflicts=True,
-        unique_fields=['org_id', 'inventory_id'],
-        update_fields=[
-            'display_name', 'account', 'tags', 'workspace_id', 'workspace_name',
-            'created', 'updated', 'last_check_in', 'insights_id', 'stale_timestamp',
-            'reporter', 'per_reporter_staleness', 'os_name', 'os_major', 'os_minor',
-            'host_type', 'bootc_booted_image', 'bootc_booted_image_digest',
-            'owner_id', 'rhc_client_id', 'workloads', 'system_update_method',
-        ],
-    )
-    logger.debug("Bulk upserted %d AdvisorInventoryHost records", len(inv_instances))
-
     host_instances = [item.to_host_model() for item in upserts]
-    Host.objects.bulk_create(
-        host_instances,
-        update_conflicts=True,
-        unique_fields=['inventory_id'],
-        update_fields=['account', 'org_id', 'satellite_id'],
-    )
-    logger.debug("Bulk upserted %d Host records", len(host_instances))
 
+    with transaction.atomic():
+        advisor_inv_upserted = len(AdvisorInventoryHost.objects.bulk_create(
+            inv_instances,
+            update_conflicts=True,
+            unique_fields=['org_id', 'inventory_id'],
+            update_fields=[
+                'display_name', 'account', 'tags', 'workspace_id', 'workspace_name',
+                'created', 'updated', 'last_check_in', 'insights_id', 'stale_timestamp',
+                'reporter', 'per_reporter_staleness', 'os_name', 'os_major', 'os_minor',
+                'host_type', 'bootc_booted_image', 'bootc_booted_image_digest',
+                'owner_id', 'rhc_client_id', 'workloads', 'system_update_method',
+            ],
+        ))
+        logger.debug("Bulk upserted %d AdvisorInventoryHost records", advisor_inv_upserted)
+
+        host_upserted = len(Host.objects.bulk_create(
+            host_instances,
+            update_conflicts=True,
+            unique_fields=['inventory_id'],
+            update_fields=['account', 'org_id', 'satellite_id'],
+        ))
+        logger.debug("Bulk upserted %d Host records", host_upserted)
+
+        prometheus.INVENTORY_HOST_UPSERTED.inc(advisor_inv_upserted + host_upserted)
 
 def bulk_delete_hosts(deletes: list[ParsedDeleteEvent]) -> None:
-    """Bulk delete Host and AdvisorInventoryHost records."""
+    """Bulk delete Host and AdvisorInventoryHost records in a single transaction."""
     requested = len(deletes)
     delete_q = Q()
     for item in deletes:
         delete_q |= Q(inventory_id=item.inventory_id, org_id=item.org_id)
 
-    deleted_hosts = Host.objects.filter(delete_q).delete()
-    logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
+    with transaction.atomic():
+        deleted_hosts = Host.objects.filter(delete_q).delete()
+        logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
 
-    deleted_inv = AdvisorInventoryHost.objects.filter(delete_q).delete()
-    logger.info("Batch deleted %d records based on AdvisorInventoryHost: %s.", *deleted_inv)
+        deleted_inv_num, _ = AdvisorInventoryHost.objects.filter(delete_q).delete()
+        logger.info("Batch deleted %d records based on AdvisorInventoryHost", deleted_inv_num)
+        prometheus.INVENTORY_HOST_DELETED.inc(deleted_inv_num)
 
-    deleted_count = deleted_inv[0]
+    deleted_count = deleted_inv_num
     missing = requested - deleted_count
     if missing > 0:
         logger.warning(

--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -14,58 +14,201 @@
 # You should have received a copy of the GNU General Public License along
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
+import operator
+from dataclasses import dataclass
+from functools import reduce
+from typing import Any
+
 import prometheus
 import signal
-
 from django.conf import settings
-# NB: it would be better if we imported the topics directly, because that
-# detects a name error at compile time rather than run time (cf Rusty's API
-# design manifesto, level 9 is better than level 5).
-# Reference: https://gist.github.com/mjball/9cd028ac793ae8b351df1379f1e721f9
 from django.core.management.base import BaseCommand
+from django.db.models import Q
+from django.utils.dateparse import parse_datetime
 
 from advisor_logging import logger
 from feature_flags import (
     feature_flag_is_enabled, FLAG_INVENTORY_EVENT_REPLICATION
 )
-from api.models import AdvisorInventoryHost, Host  # pyright: ignore[reportImplicitRelativeImport]
+from api.models import AdvisorInventoryHost, Host
 
-from kafka_utils import JsonValue, KafkaDispatcher  # , send_kafka_message
+from kafka_utils import JsonValue, KafkaDispatcher
 
 
-#############################################################################
-def handle_inventory_event(topic: str, message: dict[str, JsonValue]) -> None:
+@dataclass
+class ParsedInventoryHost:
+    host_id: str
+    display_name: str
+    account: str | None
+    org_id: str
+    tags: list[Any]
+    workspace_id: str | None
+    workspace_name: str | None
+    created: str
+    updated: str
+    last_check_in: str
+    insights_id: str
+    satellite_id: str | None
+    stale_timestamp: str
+    reporter: str
+    per_reporter_staleness: dict[str, Any]
+    os_name: str | None
+    os_major: int | None
+    os_minor: int | None
+    host_type: str | None
+    bootc_booted_image: str | None
+    bootc_booted_image_digest: str | None
+    owner_id: str | None
+    rhc_client_id: str | None
+    workloads: dict[str, Any]
+    system_update_method: str | None
+
+    def to_advisor_model(self) -> AdvisorInventoryHost:
+        return AdvisorInventoryHost(
+            inventory_id=self.host_id,
+            org_id=self.org_id,
+            display_name=self.display_name,
+            account=self.account,
+            tags=self.tags,
+            workspace_id=self.workspace_id,
+            workspace_name=self.workspace_name,
+            created=self.created,
+            updated=self.updated,
+            last_check_in=parse_datetime(self.last_check_in),
+            insights_id=self.insights_id,
+            stale_timestamp=parse_datetime(self.stale_timestamp),
+            reporter=self.reporter,
+            per_reporter_staleness=self.per_reporter_staleness,
+            os_name=self.os_name,
+            os_major=self.os_major,
+            os_minor=self.os_minor,
+            host_type=self.host_type,
+            bootc_booted_image=self.bootc_booted_image,
+            bootc_booted_image_digest=self.bootc_booted_image_digest,
+            owner_id=self.owner_id,
+            rhc_client_id=self.rhc_client_id,
+            workloads=self.workloads,
+            system_update_method=self.system_update_method,
+        )
+
+    def to_host_model(self) -> Host:
+        return Host(
+            inventory_id=self.host_id,
+            account=self.account,
+            org_id=self.org_id,
+            satellite_id=self.satellite_id or None,
+        )
+
+
+@dataclass
+class ParsedDeleteEvent:
+    inventory_id: str
+    org_id: str
+
+
+def _filter_stale_events(upserts: list[ParsedInventoryHost]) -> list[ParsedInventoryHost]:
+    """Filter out events older than what's already in the DB."""
+    deduped: dict[tuple, ParsedInventoryHost] = {}
+    for item in upserts:
+        key = (item.org_id, item.host_id)
+        if key not in deduped or item.last_check_in > deduped[key].last_check_in:
+            deduped[key] = item
+    unique = list(deduped.values())
+
+    existing = AdvisorInventoryHost.objects.filter(
+        reduce(operator.or_, (
+            Q(org_id=item.org_id, inventory_id=item.host_id)
+            for item in unique
+        ))
+    ).values_list('org_id', 'inventory_id', 'last_check_in')
+
+    existing_ts = {
+        (org_id, str(inv_id)): last_check_in
+        for org_id, inv_id, last_check_in in existing
+    }
+
+    fresh = [
+        item for item in unique
+        if (item.org_id, item.host_id) not in existing_ts
+        or parse_datetime(item.last_check_in) > existing_ts[(item.org_id, item.host_id)]
+    ]
+
+    stale_count = len(unique) - len(fresh)
+    if stale_count:
+        logger.info("Filtered out %d stale events from batch", stale_count)
+
+    return fresh
+
+
+def handle_inventory_event(topic: str, messages: list[dict[str, JsonValue]]) -> None:
     """
-    Handle inventory events.
-
-    The inventory event messages are documented at:
-    https://inscope.corp.redhat.com/docs/default/component/host-based-inventory/#created-event
+    Handle a batch of inventory events.
     """
-    if 'type' not in message:
-        logger.error("Message received on topic %s with no 'type' field", topic)
-        return
-
     if settings.INVENTORY_EVENT_REPLICATION:
-        # If the environment variable is set, always process the event.
         pass
     elif not feature_flag_is_enabled(FLAG_INVENTORY_EVENT_REPLICATION):
-        sys_uuid: str = message.get('host', {}).get('id', 'unknown UUID')
         logger.info(
-            "Received Inventory %s event for %s - feature flag not enabled, ignoring",
-            message['type'], sys_uuid
+            "Received %d Inventory events - feature flag not enabled, ignoring",
+            len(messages)
         )
         return
 
-    match message['type']:
-        case 'delete':
-            handle_deleted_event(message)
-        case 'created' | 'updated':
-            handle_created_event(message)
-        case msg_type:
-            logger.error("Inventory event: Unknown message type: %s", msg_type)
+    logger.info("Processing batch of %d inventory events", len(messages))
+
+    upserts: list[ParsedInventoryHost] = []
+    created_count = 0
+    updated_count = 0
+    delete_data: list[ParsedDeleteEvent] = []
+
+    for message in messages:
+        try:
+            if 'type' not in message:
+                logger.error("Message received on topic %s with no 'type' field", topic)
+                prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
+                continue
+
+            match message['type']:
+                case 'created':
+                    parsed = parse_created_event(message)
+                    if parsed is not None:
+                        upserts.append(parsed)
+                        created_count += 1
+                case 'updated':
+                    parsed = parse_created_event(message)
+                    if parsed is not None:
+                        upserts.append(parsed)
+                        updated_count += 1
+                case 'delete':
+                    parsed = parse_deleted_event(message)
+                    if parsed is not None:
+                        delete_data.append(parsed)
+                case msg_type:
+                    logger.error("Inventory event: Unknown message type: %s", msg_type)
+        except Exception:
+            logger.exception("Failed to parse inventory event, skipping")
+            continue
+
+    if upserts:
+        # TOCTOU: a concurrent write between this check and bulk_upsert_hosts
+        # could be overwritten. Low risk (Kafka partitions by host ID) and
+        # self-correcting on the next event.
+        upserts = _filter_stale_events(upserts)
+
+    if upserts:
+        logger.debug("Starting bulk upsert of %d hosts (%d created, %d updated)",
+                      len(upserts), created_count, updated_count)
+        bulk_upsert_hosts(upserts)
+        logger.debug("Bulk upsert committed successfully")
+        prometheus.INVENTORY_HOST_CREATED.inc(created_count)
+        prometheus.INVENTORY_HOST_UPDATED.inc(updated_count)
+
+    if delete_data:
+        logger.debug("Starting bulk delete of %d hosts", len(delete_data))
+        bulk_delete_hosts(delete_data)
+        logger.debug("Bulk delete committed successfully")
+        prometheus.INVENTORY_HOST_DELETED.inc(len(delete_data))
 
 
-#############################################################################
 def log_missing_key(request_id: str, event_type: str, key_name: str):
     logger.error(
         "Request %s: Inventory %s event did not contain required key '%s'",
@@ -74,69 +217,18 @@ def log_missing_key(request_id: str, event_type: str, key_name: str):
     prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
 
 
-#############################################################################
-def handle_created_event(message: dict[str, JsonValue]):
+def parse_created_event(message: dict[str, JsonValue]) -> ParsedInventoryHost | None:
     """
-    Handle a 'created' or 'updated' event message.
-
-    We break this down into two parts:
-        1. Create or update the basic information of the host.
-        2. Update the host's system_profile and other complex fields.
-
-    This just breaks down the amount of data being updated in each transaction.
-
-    Message is of the form:
-        {
-           "type": "created",  # or 'updated' - already checked.
-           "timestamp": "<timestamp>",
-           "platform_metadata": "<metadata_json_doc>",
-           "metadata": {
-               "request_id": "<request_id>",
-           },
-           "host": {
-              "id": "<id>",
-              "account": "<account_number>",
-              "org_id": "<org_id>",
-              "display_name": "<display_name>",
-              "ansible_host": "<ansible_host>",
-              "fqdn": "<fqdn>",
-              "insights_id": "<insights_id>",
-              "subscription_manager_id": "<subscription_manager_id>",
-              "satellite_id": "<satellite_id>",
-              "bios_uuid": "<bios_uuid>",
-              "ip_addresses": [<ip_addresses>],
-              "mac_addresses": [<mac_addresses>],
-              "facts": [<facts>],
-              "provider_id": "<provider_id>",
-              "provider_type": "<provider_type>",
-              "created": "<created_date>",
-              "updated": "<updated_date>",
-              "last_check_in": "<last_check_in_date>",
-              "stale_timestamp": "<stale_timestamp>",
-              "stale_warning_timestamp": "<stale_warning_timestamp>",
-              "culled_timestamp": "<culled_timestamp>",
-              "reporter": "<reporter>",
-              "tags": [<tags>],
-              "system_profile": {<system_profile>},
-              "per_reporter_staleness": {<per_reporter_staleness>},
-              "groups": [{
-                "id": <group_id>,
-                "name": <group_name>
-              }],
-              "openshift_cluster_id": "<openshift_cluster_id>",
-           }
-        }
-
+    Validate and extract fields from a created/updated event message.
+    Returns a ParsedInventoryHost, or None if validation fails.
     """
-    # We know this exists because handle_inventory_message used it
     event_type: str = str(message['type'])
-    logger.info(f"Handling '{event_type}' event")
+    host_data = message.get('host', {}) or {}
+    org_id = host_data.get('org_id')
+    host_id = host_data.get('id')
+    logger.info("Handling '%s' event for org=%s, host_id=%s", event_type, org_id, host_id)
 
-    # Maybe this is a weird way of handling checking the keys, but ... it
-    # saves writing what amounts to an exception handler.
     request_id = 'Unknown'
-    # Only use 'get' specifically on optional fields, everything else should
-    # be required.
     try:
         metadata: dict[str, str] = message['metadata']
         request_id = metadata['request_id']
@@ -152,22 +244,18 @@ def handle_created_event(message: dict[str, JsonValue]):
         last_check_in = host['last_check_in']
         insights_id = host['insights_id']
         satellite_id = host.get('satellite_id')  # optional
-        # No branch_id ?
-        # Sadly the staleness fields are still mandatory even though we
-        # should not use them.
         stale_timestamp = host['stale_timestamp']
         system_profile_field = host['system_profile']
         reporter = host['reporter']
         per_reporter_staleness = host['per_reporter_staleness']
     except KeyError as key_name:
-        # Might be missing metadata or request_id...
-        key_name = str(key_name).strip("'")  # Error is quoted in single quotes
+        key_name = str(key_name).strip("'")
         if key_name == 'metadata':
             request_id = 'metadata'
         elif key_name == 'request_id':
             request_id = 'unknown request_id'
-        # else the request_id variable exists from above
-        return log_missing_key(request_id, event_type, key_name)
+        log_missing_key(request_id, event_type, key_name)
+        return None
 
     if not insights_id:
         logger.error(
@@ -175,7 +263,7 @@ def handle_created_event(message: dict[str, JsonValue]):
             request_id, event_type, host_id
         )
         prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
-        return
+        return None
 
     system_profile_raw: dict[str, JsonValue] = system_profile_field
     os_info = system_profile_raw.get('operating_system', {})
@@ -188,86 +276,39 @@ def handle_created_event(message: dict[str, JsonValue]):
     workspace_id = groups[0].get('id') if groups else None
     workspace_name = groups[0].get('name') if groups else None
 
-    inv_host, was_created = AdvisorInventoryHost.objects.update_or_create(
+    return ParsedInventoryHost(
+        host_id=host_id,
+        display_name=display_name,
+        account=account,
         org_id=org_id,
-        inventory_id=host_id,
-        defaults={
-            'display_name': display_name,
-            'account': account,
-            'tags': tags,
-            'workspace_id': workspace_id,
-            'workspace_name': workspace_name,
-            'created': created,
-            'updated': updated,
-            'last_check_in': last_check_in,
-            'insights_id': insights_id,
-            'stale_timestamp': stale_timestamp,
-            'reporter': reporter,
-            'per_reporter_staleness': per_reporter_staleness,
-            'os_name': os_info.get('name') if isinstance(os_info, dict) else None,
-            'os_major': os_info.get('major') if isinstance(os_info, dict) else None,
-            'os_minor': os_info.get('minor') if isinstance(os_info, dict) else None,
-            'host_type': system_profile_raw.get('host_type'),
-            'bootc_booted_image': bootc_booted.get('image') if isinstance(bootc_booted, dict) else None,
-            'bootc_booted_image_digest': bootc_booted.get('image_digest') if isinstance(bootc_booted, dict) else None,
-            'owner_id': system_profile_raw.get('owner_id') or None,
-            'rhc_client_id': system_profile_raw.get('rhc_client_id') or None,
-            'workloads': workloads,
-            'system_update_method': system_profile_raw.get('system_update_method'),
-        }
-    )
-    if was_created:
-        prometheus.INVENTORY_HOST_CREATED.inc()
-        action = 'Created'
-    else:
-        prometheus.INVENTORY_HOST_UPDATED.inc()
-        action = 'Updated'
-    logger.debug(
-        "%s Inventory host %s account %s org_id %s",
-        action, inv_host.inventory_id, account, org_id
-    )
-
-    # Also add the Host record
-    host_data = {
-        'account': account,
-        'org_id': org_id,
-        # branch_id not in Inventory create/update message?
-    }
-    if satellite_id:
-        host_data['satellite_id'] = satellite_id
-    host_obj, was_created = Host.objects.update_or_create(
-        inventory_id=inv_host.inventory_id,
-        defaults=host_data
-    )
-    action = 'Created' if was_created else 'Updated'
-    logger.debug(
-        "%s Host %s account %s org_id %s",
-        action, host_obj.inventory_id, account, org_id
+        tags=tags,
+        workspace_id=workspace_id,
+        workspace_name=workspace_name,
+        created=created,
+        updated=updated,
+        last_check_in=last_check_in,
+        insights_id=insights_id,
+        satellite_id=satellite_id,
+        stale_timestamp=stale_timestamp,
+        reporter=reporter,
+        per_reporter_staleness=per_reporter_staleness,
+        os_name=os_info.get('name') if isinstance(os_info, dict) else None,
+        os_major=os_info.get('major') if isinstance(os_info, dict) else None,
+        os_minor=os_info.get('minor') if isinstance(os_info, dict) else None,
+        host_type=system_profile_raw.get('host_type'),
+        bootc_booted_image=bootc_booted.get('image') if isinstance(bootc_booted, dict) else None,
+        bootc_booted_image_digest=bootc_booted.get('image_digest') if isinstance(bootc_booted, dict) else None,
+        owner_id=system_profile_raw.get('owner_id') or None,
+        rhc_client_id=system_profile_raw.get('rhc_client_id') or None,
+        workloads=workloads,
+        system_update_method=system_profile_raw.get('system_update_method'),
     )
 
 
-#############################################################################
-def handle_deleted_event(message: dict[str, JsonValue]):
+def parse_deleted_event(message: dict[str, JsonValue]) -> ParsedDeleteEvent | None:
     """
-    Handle a 'deleted' event message.
-
-    Delete events are of the form:
-    {
-        "type": "delete",
-        "id": "<host id>",
-        "timestamp": "<delete timestamp>",
-        "account": "<account number>",
-        "org_id": "<org_id>",
-        "insights_id": "<insights id>",
-        "request_id": "<request id>",
-        "subscription_manager_id": "<subscription_manager_id>",
-        "initiated_by_frontend": "<initiated_by_frontend>",
-        "platform_metadata": "<metadata_json_doc>",
-        "metadata": {
-            "request_id": "<request_id>",
-        },
-    }
-
+    Validate and extract fields from a delete event message.
+    Returns a ParsedDeleteEvent, or None if validation fails.
     """
     logger.info("Handling 'deleted' event")
 
@@ -282,35 +323,75 @@ def handle_deleted_event(message: dict[str, JsonValue]):
             request_id = 'unknown request_id'
         else:
             request_id = message['request_id']
-        return log_missing_key(request_id, 'delete', key_name)
+        log_missing_key(request_id, 'delete', key_name)
+        return None
 
-    payload_info = {
-        'request_id': request_id,
-        'inventory_id': inventory_id,
-        'account': account,
-        'org_id': org_id,
-        'source': 'inventory'
-    }
     logger.info(
         "Received DELETE event from Inventory for host %s.",
-        inventory_id, extra=payload_info
+        inventory_id,
+        extra={
+            'request_id': request_id,
+            'inventory_id': inventory_id,
+            'account': account,
+            'org_id': org_id,
+            'source': 'inventory'
+        }
     )
 
-    # Delete Host object and related records - CurrentReport, HostAck,
-    # SatMaintenanceAction, and Upload
-    deleted_records = Host.objects.filter(
-        inventory_id=inventory_id, org_id=org_id
-    ).delete()
-    logger.info("Deleted %d records based on Host: %s.", *deleted_records)
-    # Delete AdvisorInventoryHost record
-    deleted_records = AdvisorInventoryHost.objects.filter(
-        inventory_id=inventory_id, org_id=org_id
-    ).delete()
-    logger.info("Deleted %d records based on AdvisorInventoryHost: %s.", *deleted_records)
-    prometheus.INVENTORY_HOST_DELETED.inc()
+    return ParsedDeleteEvent(
+        inventory_id=inventory_id,
+        org_id=org_id,
+    )
 
 
-# Main command
+def bulk_upsert_hosts(upserts: list[ParsedInventoryHost]) -> None:
+    """Bulk upsert AdvisorInventoryHost and Host records."""
+    inv_instances = [item.to_advisor_model() for item in upserts]
+    AdvisorInventoryHost.objects.bulk_create(
+        inv_instances,
+        update_conflicts=True,
+        unique_fields=['org_id', 'inventory_id'],
+        update_fields=[
+            'display_name', 'account', 'tags', 'workspace_id', 'workspace_name',
+            'created', 'updated', 'last_check_in', 'insights_id', 'stale_timestamp',
+            'reporter', 'per_reporter_staleness', 'os_name', 'os_major', 'os_minor',
+            'host_type', 'bootc_booted_image', 'bootc_booted_image_digest',
+            'owner_id', 'rhc_client_id', 'workloads', 'system_update_method',
+        ],
+    )
+    logger.debug("Bulk upserted %d AdvisorInventoryHost records", len(inv_instances))
+
+    host_instances = [item.to_host_model() for item in upserts]
+    Host.objects.bulk_create(
+        host_instances,
+        update_conflicts=True,
+        unique_fields=['inventory_id'],
+        update_fields=['account', 'org_id', 'satellite_id'],
+    )
+    logger.debug("Bulk upserted %d Host records", len(host_instances))
+
+
+def bulk_delete_hosts(deletes: list[ParsedDeleteEvent]) -> None:
+    """Bulk delete Host and AdvisorInventoryHost records."""
+    requested = len(deletes)
+    delete_q = Q()
+    for item in deletes:
+        delete_q |= Q(inventory_id=item.inventory_id, org_id=item.org_id)
+
+    deleted_hosts = Host.objects.filter(delete_q).delete()
+    logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
+
+    deleted_inv = AdvisorInventoryHost.objects.filter(delete_q).delete()
+    logger.info("Batch deleted %d records based on AdvisorInventoryHost: %s.", *deleted_inv)
+
+    deleted_count = deleted_inv[0]
+    missing = requested - deleted_count
+    if missing > 0:
+        logger.warning(
+            "Delete mismatch: requested=%d, deleted=%d, missing=%d",
+            requested, deleted_count, missing
+        )
+        prometheus.INVENTORY_HOST_DELETE_MISSING.inc(missing)
 
 
 class Command(BaseCommand):
@@ -327,7 +408,7 @@ class Command(BaseCommand):
             'enable.auto.offset.store': False,
         })
         receiver = KafkaDispatcher()
-        receiver.register_handler(settings.INVENTORY_EVENTS_TOPIC, handle_inventory_event)
+        receiver.register_handler(settings.INVENTORY_EVENTS_TOPIC, handle_inventory_event, batch=True)
 
         def terminate(signum: int, _):
             logger.info("Signal %d received, triggering shutdown", signum)
@@ -335,7 +416,5 @@ class Command(BaseCommand):
 
         _ = signal.signal(signal.SIGTERM, terminate)
         _ = signal.signal(signal.SIGINT, terminate)
-
-        # Loops until receiver.quit is set
-        receiver.receive()
+        receiver.receive(batch_size=settings.INVENTORY_BATCH_SIZE)
         logger.info('Advisor Inventory replication service shutting down')

--- a/api/advisor/api/tests/test_advisor_inventory_service.py
+++ b/api/advisor/api/tests/test_advisor_inventory_service.py
@@ -17,11 +17,14 @@
 # import responses
 from copy import deepcopy
 from datetime import datetime, timedelta
+from unittest.mock import patch
 from django.test import TestCase  # , override_settings
 from django.utils import timezone
 
+import prometheus
 from feature_flags import set_unleash_flag, FLAG_INVENTORY_EVENT_REPLICATION
-from kafka_utils import JsonValue
+from django.core.signals import request_started, request_finished
+from kafka_utils import DummyConsumer, JsonValue, KafkaDispatcher
 # from project_settings import kafka_settings
 from api.management.commands.advisor_inventory_service import (
     handle_inventory_event, parse_created_event, parse_deleted_event,
@@ -689,3 +692,53 @@ class TestAdvisorInventoryServer(TestCase):
 
         inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
         self.assertEqual(inv_host.display_name, 'new-name')
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    @patch.object(prometheus.INVENTORY_EVENT_MALFORMED, 'inc')
+    def test_malformed_messages_increment_prometheus_counter(self, mock_malformed_inc):
+        """Malformed messages increment INVENTORY_EVENT_MALFORMED once per skipped message."""
+        malformed_msg = deepcopy(create_new_host_msg)
+        malformed_msg['host'] = "oops"
+        batch = [
+            {'key': 'value'},           # no type
+            {'type': 'foo'},            # unknown type
+            malformed_msg,              # unexpected parse error
+            deepcopy(delete_host_msg),  # missing request_id
+        ]
+        del batch[3]['request_id']
+
+        with self.assertLogs(logger='advisor-log'):
+            handle_inventory_event('topic', batch)
+
+        self.assertEqual(mock_malformed_inc.call_count, 4)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_delete_failure_prevents_batch_ack(self):
+        """A failed delete commit must fail the batch so offsets are not committed."""
+        from django.db import close_old_connections
+
+        consumer = DummyConsumer()
+        consumer.add_message('topic', delete_host_msg)
+
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('topic', handle_inventory_event, batch=True)
+
+        request_started.disconnect(close_old_connections)
+        request_finished.disconnect(close_old_connections)
+        try:
+            with patch(
+                'api.management.commands.advisor_inventory_service.bulk_delete_hosts',
+                side_effect=RuntimeError("delete failed"),
+            ):
+                messages = consumer.consume(num_messages=1, timeout=1)
+                with self.assertLogs(logger='advisor-log'):
+                    result = dispatcher._handle_batch_messages(messages)
+        finally:
+            request_started.connect(close_old_connections)
+            request_finished.connect(close_old_connections)
+
+        self.assertFalse(result)
+        self.assertEqual(consumer.commit_count, 0)
+        self.assertTrue(
+            Host.objects.filter(inventory_id=constants.host_01_uuid).exists()
+        )

--- a/api/advisor/api/tests/test_advisor_inventory_service.py
+++ b/api/advisor/api/tests/test_advisor_inventory_service.py
@@ -17,7 +17,6 @@
 # import responses
 from copy import deepcopy
 from datetime import datetime, timedelta
-
 from django.test import TestCase  # , override_settings
 from django.utils import timezone
 
@@ -25,7 +24,7 @@ from feature_flags import set_unleash_flag, FLAG_INVENTORY_EVENT_REPLICATION
 from kafka_utils import JsonValue
 # from project_settings import kafka_settings
 from api.management.commands.advisor_inventory_service import (
-    handle_inventory_event, handle_created_event, handle_deleted_event
+    handle_inventory_event, parse_created_event, parse_deleted_event,
 )
 from api.models import AdvisorInventoryHost, CurrentReport, Host, HostAck, InventoryHost, Upload
 from api.tests import constants
@@ -199,19 +198,21 @@ class TestAdvisorInventoryServer(TestCase):
         """
         with self.assertLogs(logger='advisor-log') as logs:
             # No 'type' field in message
-            handle_inventory_event('topic', {'key': 'value'})
-            self.assertEqual(len(logs.output), 1)
+            handle_inventory_event('topic', [{'key': 'value'}])
             self.assertEqual(
-                "ERROR:advisor-log:Message received on topic topic with no 'type' field",
+                "INFO:advisor-log:Processing batch of 1 inventory events",
                 logs.output[0]
             )
-            # Unknown message type
-            handle_inventory_event('topic', {'type': 'foo'})
             self.assertEqual(
-                "ERROR:advisor-log:Inventory event: Unknown message type: foo",
+                "ERROR:advisor-log:Message received on topic topic with no 'type' field",
                 logs.output[1]
             )
-            self.assertEqual(len(logs.output), 2)
+            # Unknown message type
+            handle_inventory_event('topic', [{'type': 'foo'}])
+            self.assertEqual(
+                "ERROR:advisor-log:Inventory event: Unknown message type: foo",
+                logs.output[3]
+            )
         # Test the actual calls to create and delete in their own test methods.
 
     @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
@@ -221,28 +222,27 @@ class TestAdvisorInventoryServer(TestCase):
         """
         # Start by processing the create message using handle_inventory_event
         with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
-            handle_inventory_event('topic', create_new_host_msg)
+            handle_inventory_event('topic', [create_new_host_msg])
             # We aim to remove this debug log soon but in the meantime
             log_lines: list[str] = list(filter(
                 lambda line: 'Using Cyndi replication view' not in line, logs.output
             ))
             self.assertEqual(
-                "INFO:advisor-log:Handling 'created' event",
+                "INFO:advisor-log:Processing batch of 1 inventory events",
                 log_lines[0]
             )
-            self.assertEqual(
-                "DEBUG:advisor-log:Created Inventory host %s account %s org_id %s" % (
-                    new_host_id, constants.standard_acct, constants.standard_org
-                ),
-                log_lines[1]
+            self.assertTrue(
+                any("Handling 'created' event" in line for line in log_lines),
+                "Should log handling of created event"
             )
-            self.assertEqual(
-                "DEBUG:advisor-log:Created Host %s account %s org_id %s" % (
-                    new_host_id, constants.standard_acct, constants.standard_org
-                ),
-                log_lines[2]
+            self.assertTrue(
+                any("Bulk upserted 1 AdvisorInventoryHost records" in line for line in log_lines),
+                "Should log bulk upsert of AdvisorInventoryHost"
             )
-            self.assertEqual(len(log_lines), 3)
+            self.assertTrue(
+                any("Bulk upserted 1 Host records" in line for line in log_lines),
+                "Should log bulk upsert of Host"
+            )
             self.assertEqual(
                 AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).count(),
                 1
@@ -306,14 +306,14 @@ class TestAdvisorInventoryServer(TestCase):
                         del modified_msg[missing_field]
                     case host_field:  # everything else inside host
                         del modified_msg['host'][host_field]
-                handle_created_event(modified_msg)
+                result = parse_created_event(modified_msg)
                 # We aim to remove this debug log soon but in the meantime
                 log_lines: list[str] = list(filter(
                     lambda line: 'Using Cyndi replication view' not in line, logs.output
                 ))
-                self.assertEqual(
-                    "INFO:advisor-log:Handling 'created' event",
-                    log_lines[0]
+                self.assertTrue(
+                    any("Handling 'created' event" in line for line in log_lines),
+                    "Should log handling of created event"
                 )
                 if missing_field == 'metadata':
                     this_req_id = 'metadata'
@@ -321,89 +321,43 @@ class TestAdvisorInventoryServer(TestCase):
                     this_req_id = 'unknown request_id'
                 else:
                     this_req_id = modified_msg['metadata']['request_id']
-                self.assertEqual(
-                    "ERROR:advisor-log:Request %s: Inventory created event did not contain required key '%s'" % (
-                        this_req_id, missing_field
+                self.assertTrue(
+                    any(
+                        "Request %s: Inventory created event did not contain required key '%s'" % (
+                            this_req_id, missing_field
+                        ) in line
+                        for line in log_lines
                     ),
-                    log_lines[1],
                     f"Field {missing_field} is required"
                 )
-                self.assertEqual(len(log_lines), 2)
+                self.assertIsNone(result)
         # The optional fields should allow a success though.
-        # This also tests that receiving a 'create' event on a host that
-        # already exists is treated as an update.
         with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
             modified_msg = deepcopy(create_new_host_msg)
             del modified_msg['host']['account']
-            handle_created_event(modified_msg)
+            result = parse_created_event(modified_msg)
             log_lines: list[str] = list(filter(
                 lambda line: 'Using Cyndi replication view' not in line, logs.output
             ))
-            self.assertEqual(
-                "INFO:advisor-log:Handling 'created' event",
-                log_lines[0]
+            self.assertTrue(
+                any("Handling 'created' event" in line for line in log_lines),
+                "Should log handling of created event"
             )
-            self.assertEqual(
-                "DEBUG:advisor-log:Created Inventory host %s account %s org_id %s" % (
-                    new_host_id, None, constants.standard_org
-                ),
-                log_lines[1]
-            )
-            self.assertEqual(
-                "DEBUG:advisor-log:Created Host %s account %s org_id %s" % (
-                    new_host_id, None, constants.standard_org
-                ),
-                log_lines[2]
-            )
-            self.assertEqual(len(log_lines), 3)
-            # Check existence of AdvisorInventoryHost record
-            self.assertEqual(
-                AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).count(),
-                1
-            )
-            self.assertEqual(
-                Host.objects.filter(inventory_id=new_host_id).count(),
-                1
-            )
-            host = Host.objects.get(inventory_id=new_host_id)
-            self.assertEqual(str(host.satellite_id), new_host_satid.lower())
+            self.assertIsNotNone(result)
+            self.assertIsNone(result.account)
         with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
             modified_msg = deepcopy(create_new_host_msg)
             del modified_msg['host']['satellite_id']
-            handle_created_event(modified_msg)
+            result = parse_created_event(modified_msg)
             log_lines: list[str] = list(filter(
                 lambda line: 'Using Cyndi replication view' not in line, logs.output
             ))
-            self.assertEqual(
-                "INFO:advisor-log:Handling 'created' event",
-                log_lines[0]
+            self.assertTrue(
+                any("Handling 'created' event" in line for line in log_lines),
+                "Should log handling of created event"
             )
-            self.assertEqual(
-                "DEBUG:advisor-log:Updated Inventory host %s account %s org_id %s" % (
-                    new_host_id, constants.standard_acct, constants.standard_org
-                ),
-                log_lines[1]
-            )
-            self.assertEqual(
-                "DEBUG:advisor-log:Updated Host %s account %s org_id %s" % (
-                    new_host_id, constants.standard_acct, constants.standard_org
-                ),
-                log_lines[2]
-            )
-            self.assertEqual(len(log_lines), 3)
-            # Check existence of AdvisorInventoryHost record
-            self.assertEqual(
-                AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).count(),
-                1
-            )
-            self.assertEqual(
-                Host.objects.filter(inventory_id=new_host_id).count(),
-                1
-            )
-            host = Host.objects.get(inventory_id=new_host_id)
-            # Because the host is being updated, the Satellite ID has carried
-            # over from the previous update.
-            self.assertEqual(str(host.satellite_id), new_host_satid.lower())
+            self.assertIsNotNone(result)
+            self.assertIsNone(result.satellite_id)
 
     @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
     def test_updated_message_success(self):
@@ -412,29 +366,24 @@ class TestAdvisorInventoryServer(TestCase):
         """
         with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
             # Call via handle_inventory_event to exercise update handling
-            handle_inventory_event('topic', update_host_msg)
+            handle_inventory_event('topic', [update_host_msg])
             # Now check the logs
             # We aim to remove this debug log soon but in the meantime
             log_lines: list[str] = list(filter(
                 lambda line: 'Using Cyndi replication view' not in line, logs.output
             ))
             self.assertEqual(
-                "INFO:advisor-log:Handling 'updated' event",
+                "INFO:advisor-log:Processing batch of 1 inventory events",
                 log_lines[0]
             )
-            self.assertEqual(
-                "DEBUG:advisor-log:Updated Inventory host %s account %s org_id %s" % (
-                    constants.host_01_uuid, constants.standard_acct, constants.standard_org
-                ),
-                log_lines[1]
+            self.assertTrue(
+                any("Handling 'updated' event" in line for line in log_lines),
+                "Should log handling of updated event"
             )
-            self.assertEqual(
-                "DEBUG:advisor-log:Updated Host %s account %s org_id %s" % (
-                    constants.host_01_uuid, constants.standard_acct, constants.standard_org
-                ),
-                log_lines[2]
+            self.assertTrue(
+                any("Bulk upserted" in line for line in log_lines),
+                "Should log bulk upsert"
             )
-            self.assertEqual(len(log_lines), 3)
 
             inv_host = AdvisorInventoryHost.objects.get(inventory_id=constants.host_01_uuid)
             self.assertEqual(inv_host.os_name, "RHEL")
@@ -446,37 +395,37 @@ class TestAdvisorInventoryServer(TestCase):
         """
         Test successful deletion of existing host.
         """
-        # Call handle_created_event directly
+        # Call handle_inventory_event with batch
         with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
-            handle_inventory_event('topic', delete_host_msg)
+            handle_inventory_event('topic', [delete_host_msg])
             # Now check the logs
             # We aim to remove this debug log soon but in the meantime
             log_lines: list[str] = list(filter(
                 lambda line: 'Using Cyndi replication view' not in line, logs.output
             ))
             self.assertEqual(
-                "INFO:advisor-log:Handling 'deleted' event",
+                "INFO:advisor-log:Processing batch of 1 inventory events",
                 log_lines[0]
             )
             self.assertEqual(
-                "INFO:advisor-log:Received DELETE event from Inventory for host %s." % (
-                    constants.host_01_uuid
-                ),
+                "INFO:advisor-log:Handling 'deleted' event",
                 log_lines[1]
             )
-            self.assertEqual(
-                "INFO:advisor-log:Deleted %d records based on Host: %s." % (
-                    9, "{'api.CurrentReport': 4, 'api.HostAck': 1, 'api.Upload': 3, 'api.Host': 1}"
+            self.assertTrue(
+                any(
+                    "Received DELETE event from Inventory for host %s." % constants.host_01_uuid in line
+                    for line in log_lines
                 ),
-                log_lines[2]
+                "Should log the DELETE event details"
             )
-            self.assertEqual(
-                "INFO:advisor-log:Deleted %d records based on AdvisorInventoryHost: %s." % (
-                    1, "{'api.AdvisorInventoryHost': 1}"
-                ),
-                log_lines[3]
+            self.assertTrue(
+                any("Batch deleted" in line and "Host" in line for line in log_lines),
+                "Should log batch deletion of Host"
             )
-            self.assertEqual(len(log_lines), 4)
+            self.assertTrue(
+                any("Batch deleted" in line and "AdvisorInventoryHost" in line for line in log_lines),
+                "Should log batch deletion of AdvisorInventoryHost"
+            )
         # Now test that we actually deleted all those things:
         self.assertEqual(
             AdvisorInventoryHost.objects.filter(inventory_id=constants.host_01_uuid).count(),
@@ -509,7 +458,7 @@ class TestAdvisorInventoryServer(TestCase):
             with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
                 modified_msg: dict[str, JsonValue] = deepcopy(delete_host_msg)
                 del modified_msg[missing_field]
-                handle_deleted_event(modified_msg)
+                result = parse_deleted_event(modified_msg)
                 # We aim to remove this debug log soon but in the meantime
                 log_lines: list[str] = list(filter(
                     lambda line: 'Using Cyndi replication view' not in line, logs.output
@@ -530,6 +479,7 @@ class TestAdvisorInventoryServer(TestCase):
                     f"Field {missing_field} is required"
                 )
                 self.assertEqual(len(log_lines), 2)
+                self.assertIsNone(result)
 
     @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
     def test_created_nullable_fields(self):
@@ -540,7 +490,7 @@ class TestAdvisorInventoryServer(TestCase):
         modified_msg['host']['system_profile'] = {}
         modified_msg['host']['groups'] = []
         with self.assertLogs(logger='advisor-log', level='DEBUG'):
-            handle_created_event(modified_msg)
+            handle_inventory_event('topic', [modified_msg])
         inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
         self.assertIsNone(inv_host.workspace_id)
         self.assertIsNone(inv_host.workspace_name)
@@ -554,3 +504,188 @@ class TestAdvisorInventoryServer(TestCase):
         self.assertIsNone(inv_host.rhc_client_id)
         self.assertEqual(inv_host.workloads, {})
         self.assertIsNone(inv_host.system_update_method)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_batch_created_and_updated(self):
+        """Test that handle_inventory_event processes a batch of create and update messages."""
+        batch = [create_new_host_msg, update_host_msg]
+        handle_inventory_event('topic', batch)
+
+        # New host was created
+        self.assertTrue(
+            AdvisorInventoryHost.objects.filter(
+                inventory_id=new_host_id, org_id=constants.standard_org
+            ).exists()
+        )
+        self.assertTrue(
+            Host.objects.filter(inventory_id=new_host_id).exists()
+        )
+        # Existing host was updated
+        inv_host = AdvisorInventoryHost.objects.get(
+            inventory_id=constants.host_01_uuid, org_id=constants.standard_org
+        )
+        self.assertEqual(inv_host.display_name, constants.host_01_name)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_batch_deleted(self):
+        """Test that handle_inventory_event processes a batch of delete messages."""
+        # First create the host so we can delete it
+        handle_inventory_event('topic', [create_new_host_msg])
+        self.assertTrue(Host.objects.filter(inventory_id=new_host_id).exists())
+
+        delete_new_host_msg = {
+            "type": "delete",
+            "id": new_host_id,
+            "timestamp": "<delete timestamp>",
+            "org_id": constants.standard_org,
+            "insights_id": "FFEEDDCC-BBAA-9988-7766-554433221120",
+            "request_id": "<request id>",
+        }
+        handle_inventory_event('topic', [delete_new_host_msg])
+
+        self.assertFalse(Host.objects.filter(inventory_id=new_host_id).exists())
+        self.assertFalse(
+            AdvisorInventoryHost.objects.filter(
+                inventory_id=new_host_id, org_id=constants.standard_org
+            ).exists()
+        )
+
+    def test_batch_ignored_when_flag_disabled(self):
+        """
+        Test that batched messages are ignored when INVENTORY_EVENT_REPLICATION
+        is disabled (env + feature flag), and that no DB changes occur.
+        """
+        batch = [create_new_host_msg]
+
+        with self.assertLogs(logger='advisor-log') as logs:
+            handle_inventory_event('topic', batch)
+
+        self.assertTrue(
+            any("feature flag not enabled, ignoring" in line for line in logs.output),
+            msg="Expected 'feature flag not enabled, ignoring' log message",
+        )
+        self.assertFalse(
+            AdvisorInventoryHost.objects.filter(
+                inventory_id=new_host_id, org_id=constants.standard_org
+            ).exists()
+        )
+        self.assertFalse(
+            Host.objects.filter(inventory_id=new_host_id).exists()
+        )
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_batch_skips_invalid_messages(self):
+        """Test that invalid messages in a batch are skipped while valid ones proceed."""
+        invalid_msg_no_type = {'key': 'value'}
+        invalid_msg_unknown_type = {'type': 'foo'}
+        batch = [invalid_msg_no_type, invalid_msg_unknown_type, create_new_host_msg]
+
+        with self.assertLogs(logger='advisor-log') as logs:
+            handle_inventory_event('topic', batch)
+
+        # Valid create message should still succeed
+        self.assertTrue(
+            AdvisorInventoryHost.objects.filter(
+                inventory_id=new_host_id, org_id=constants.standard_org
+            ).exists()
+        )
+        # Error logs for the invalid messages
+        self.assertTrue(any("no 'type' field" in line for line in logs.output))
+        self.assertTrue(any("Unknown message type: foo" in line for line in logs.output))
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_malformed_host_payload_does_not_abort_batch(self):
+        """Test that a message with wrong shape (e.g. host as string) is skipped."""
+        malformed_msg = deepcopy(create_new_host_msg)
+        malformed_msg['host'] = "oops"
+
+        batch = [malformed_msg, create_new_host_msg]
+
+        with self.assertLogs(logger='advisor-log') as logs:
+            handle_inventory_event('topic', batch)
+
+        self.assertTrue(
+            any("Failed to parse inventory event" in line for line in logs.output)
+        )
+        self.assertTrue(
+            AdvisorInventoryHost.objects.filter(
+                inventory_id=new_host_id, org_id=constants.standard_org
+            ).exists()
+        )
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_stale_update_does_not_overwrite_newer_data(self):
+        """Test that an event with an older last_check_in is filtered out."""
+        newer_ts = "2026-06-01T12:00:00Z"
+        older_ts = "2025-01-01T00:00:00Z"
+
+        # Insert host with newer last_check_in
+        msg = deepcopy(create_new_host_msg)
+        msg['host']['last_check_in'] = newer_ts
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [msg])
+
+        inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+        original_display_name = inv_host.display_name
+
+        # Send update with older last_check_in and different display_name
+        stale_msg = deepcopy(create_new_host_msg)
+        stale_msg['type'] = 'updated'
+        stale_msg['host']['last_check_in'] = older_ts
+        stale_msg['host']['display_name'] = 'stale-name-should-not-appear'
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [stale_msg])
+
+        inv_host.refresh_from_db()
+        self.assertEqual(inv_host.display_name, original_display_name)
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_newer_update_overwrites_older_data(self):
+        """Test that an event with a newer last_check_in updates the record."""
+        older_ts = "2025-01-01T00:00:00Z"
+        newer_ts = "2026-06-01T12:00:00Z"
+
+        # Insert host with older last_check_in
+        msg = deepcopy(create_new_host_msg)
+        msg['host']['last_check_in'] = older_ts
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [msg])
+
+        # Send update with newer last_check_in and different display_name
+        update_msg = deepcopy(create_new_host_msg)
+        update_msg['type'] = 'updated'
+        update_msg['host']['last_check_in'] = newer_ts
+        update_msg['host']['display_name'] = 'updated-name'
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [update_msg])
+
+        inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+        self.assertEqual(inv_host.display_name, 'updated-name')
+
+    @set_unleash_flag(FLAG_INVENTORY_EVENT_REPLICATION, True)
+    def test_batch_dedup_keeps_latest_timestamp(self):
+        """Test that duplicate host events in a batch keep the one with latest last_check_in."""
+        older_msg = deepcopy(create_new_host_msg)
+        older_msg['host']['last_check_in'] = "2025-01-01T00:00:00Z"
+        older_msg['host']['display_name'] = 'old-name'
+
+        newer_msg = deepcopy(create_new_host_msg)
+        newer_msg['host']['last_check_in'] = "2026-06-01T12:00:00Z"
+        newer_msg['host']['display_name'] = 'new-name'
+
+        # Send older first, newer second
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [older_msg, newer_msg])
+
+        inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+        self.assertEqual(inv_host.display_name, 'new-name')
+
+        # Clean up and test reverse order
+        AdvisorInventoryHost.objects.filter(inventory_id=new_host_id).delete()
+        Host.objects.filter(inventory_id=new_host_id).delete()
+
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [newer_msg, older_msg])
+
+        inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+        self.assertEqual(inv_host.display_name, 'new-name')

--- a/api/advisor/api/tests/test_kafka_utils.py
+++ b/api/advisor/api/tests/test_kafka_utils.py
@@ -39,6 +39,23 @@ class DummyHandler:
         self.handled = {}
 
 
+class DummyBatchHandler:
+    """
+    Record the batch of messages sent to the handler by the dispatcher.
+    """
+    def __init__(self, name: str):
+        self.handled: dict[str, list[list[JsonValue]]] = {}
+        self.__name__: str = name
+
+    def __call__(self, topic: str, messages: list[JsonValue]):
+        if topic not in self.handled:
+            self.handled[topic] = []
+        self.handled[topic].append(messages)
+
+    def reset(self):
+        self.handled = {}
+
+
 class TestKafkaUtils(TestCase):
     """
     Test the Kafka Utils functionality, particularly around the KafkaDispatcher.
@@ -137,3 +154,119 @@ class TestKafkaUtils(TestCase):
             self.assertEqual(
                 logs.output[0], "INFO:advisor-log:Kafka message delivered to test_topic [0]"
             )
+
+    def test_dummy_consumer_consume(self):
+        """Test that DummyConsumer.consume() returns batches of messages."""
+        consumer = DummyConsumer()
+        consumer.add_message('topic1', {'key': 'value1'})
+        consumer.add_message('topic1', {'key': 'value2'})
+        consumer.add_message('topic1', {'key': 'value3'})
+
+        # Consume batch of 2 — should return first 2
+        batch = consumer.consume(num_messages=2, timeout=1)
+        self.assertEqual(len(batch), 2)
+        self.assertEqual(batch[0].topic(), 'topic1')
+        self.assertEqual(batch[1].topic(), 'topic1')
+
+        # Consume next batch of 2 — only 1 left
+        batch = consumer.consume(num_messages=2, timeout=1)
+        self.assertEqual(len(batch), 1)
+
+        # Consume again — empty, triggers close
+        batch = consumer.consume(num_messages=2, timeout=1)
+        self.assertEqual(len(batch), 0)
+        self.assertTrue(consumer.closed)
+
+    def test_batch_message_handling(self):
+        """Test that _handle_batch_messages processes a batch and calls the handler once per topic."""
+        consumer = DummyConsumer()
+        consumer.add_message('batch-topic', {'key': 'value1'})
+        consumer.add_message('batch-topic', {'key': 'value2'})
+        consumer.add_message('batch-topic', {'key': 'value3'})
+
+        batch_handler = DummyBatchHandler('batch_handler')
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('batch-topic', batch_handler, batch=True)
+
+        messages = consumer.consume(num_messages=3, timeout=1)
+        dispatcher._handle_batch_messages(messages)
+
+        self.assertIn('batch-topic', batch_handler.handled)
+        self.assertEqual(len(batch_handler.handled['batch-topic']), 1)
+        bodies = batch_handler.handled['batch-topic'][0]
+        self.assertEqual(len(bodies), 3)
+        self.assertEqual(bodies[0], {'key': 'value1'})
+        self.assertEqual(bodies[1], {'key': 'value2'})
+        self.assertEqual(bodies[2], {'key': 'value3'})
+
+    def test_batch_message_skips_errors_and_unmatched(self):
+        """Test that _handle_batch_messages skips errors, malformed JSON, and unmatched topics."""
+        consumer = DummyConsumer()
+        # A good message
+        consumer.add_message('batch-topic', {'key': 'good'})
+        # A message for an unregistered topic
+        consumer.add_message('unknown-topic', {'key': 'lost'})
+        # An error message
+        error_msg = DummyMessage(topic='batch-topic', value=b'{"key": "err"}')
+        error_msg.set_error("Test error")
+        consumer.add_message_obj(error_msg)
+        # A malformed JSON message
+        malformed = DummyMessage(topic='batch-topic', value=b'not{json')
+        consumer.add_message_obj(malformed)
+        # Another good message
+        consumer.add_message('batch-topic', {'key': 'also-good'})
+
+        batch_handler = DummyBatchHandler('batch_handler')
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('batch-topic', batch_handler, batch=True)
+
+        messages = consumer.consume(num_messages=10, timeout=1)
+        with self.assertLogs(logger='advisor-log'):
+            dispatcher._handle_batch_messages(messages)
+
+        # Only the 2 good messages should reach the handler
+        bodies = batch_handler.handled['batch-topic'][0]
+        self.assertEqual(len(bodies), 2)
+        self.assertEqual(bodies[0], {'key': 'good'})
+        self.assertEqual(bodies[1], {'key': 'also-good'})
+
+    def test_receive_with_batch_size(self):
+        """Test that receive(batch_size=N) uses consume() and _handle_batch_messages."""
+        consumer = DummyConsumer()
+        consumer.add_message('batch-topic', {'msg': 1})
+        consumer.add_message('batch-topic', {'msg': 2})
+        consumer.add_message('batch-topic', {'msg': 3})
+
+        batch_handler = DummyBatchHandler('batch_handler')
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('batch-topic', batch_handler, batch=True)
+        consumer.set_dispatcher_quit(dispatcher)
+
+        dispatcher.receive(batch_size=2)
+
+        # Handler should have been called with batches
+        self.assertIn('batch-topic', batch_handler.handled)
+        all_bodies = []
+        for call in batch_handler.handled['batch-topic']:
+            all_bodies.extend(call)
+        self.assertEqual(len(all_bodies), 3)
+
+    def test_non_batch_handler_with_batch_receive(self):
+        """Test that a non-batch handler is called once per message even with batch_size."""
+        consumer = DummyConsumer()
+        consumer.add_message('topic', {'msg': 1})
+        consumer.add_message('topic', {'msg': 2})
+        consumer.add_message('topic', {'msg': 3})
+
+        handler = DummyHandler('single_handler')
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('topic', handler)
+        consumer.set_dispatcher_quit(dispatcher)
+
+        dispatcher.receive(batch_size=10)
+
+        self.assertIn('topic', handler.handled)
+        self.assertEqual(len(handler.handled['topic']), 3)
+        self.assertEqual(handler.handled['topic'][0], {'msg': 1})
+        self.assertEqual(handler.handled['topic'][1], {'msg': 2})
+        self.assertEqual(handler.handled['topic'][2], {'msg': 3})

--- a/api/advisor/api/tests/test_kafka_utils.py
+++ b/api/advisor/api/tests/test_kafka_utils.py
@@ -270,3 +270,70 @@ class TestKafkaUtils(TestCase):
         self.assertEqual(handler.handled['topic'][0], {'msg': 1})
         self.assertEqual(handler.handled['topic'][1], {'msg': 2})
         self.assertEqual(handler.handled['topic'][2], {'msg': 3})
+
+    def test_handle_batch_messages_returns_true_on_success(self):
+        """Test that _handle_batch_messages returns True when all handlers succeed."""
+        consumer = DummyConsumer()
+        consumer.add_message('topic', {'msg': 1})
+
+        batch_handler = DummyBatchHandler('batch_handler')
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('topic', batch_handler, batch=True)
+
+        messages = consumer.consume(num_messages=1, timeout=1)
+        result = dispatcher._handle_batch_messages(messages)
+
+        self.assertTrue(result)
+
+    def test_handle_batch_messages_returns_false_on_handler_exception(self):
+        """Test that _handle_batch_messages returns False when a batch handler raises."""
+        consumer = DummyConsumer()
+        consumer.add_message('topic', {'msg': 1})
+
+        def failing_handler(topic, messages):
+            raise RuntimeError("DB is down")
+
+        failing_handler.__name__ = 'failing_handler'
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('topic', failing_handler, batch=True)
+
+        messages = consumer.consume(num_messages=1, timeout=1)
+        with self.assertLogs(logger='advisor-log'):
+            result = dispatcher._handle_batch_messages(messages)
+
+        self.assertFalse(result)
+
+    def test_receive_commits_on_success(self):
+        """Test that receive() commits offsets after successful batch processing."""
+        consumer = DummyConsumer()
+        consumer.add_message('topic', {'msg': 1})
+        consumer.add_message('topic', {'msg': 2})
+
+        batch_handler = DummyBatchHandler('batch_handler')
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('topic', batch_handler, batch=True)
+        consumer.set_dispatcher_quit(dispatcher)
+
+        dispatcher.receive(batch_size=10)
+
+        self.assertGreater(consumer.store_offsets_count, 0)
+        self.assertGreater(consumer.commit_count, 0)
+
+    def test_receive_does_not_commit_on_failure(self):
+        """Test that receive() skips commit when a batch handler raises."""
+        consumer = DummyConsumer()
+        consumer.add_message('topic', {'msg': 1})
+
+        def failing_handler(topic, messages):
+            raise RuntimeError("DB is down")
+
+        failing_handler.__name__ = 'failing_handler'
+        dispatcher = KafkaDispatcher(consumer)
+        dispatcher.register_handler('topic', failing_handler, batch=True)
+        consumer.set_dispatcher_quit(dispatcher)
+
+        with self.assertLogs(logger='advisor-log'):
+            dispatcher.receive(batch_size=10)
+
+        self.assertEqual(consumer.store_offsets_count, 0)
+        self.assertEqual(consumer.commit_count, 0)

--- a/api/advisor/kafka_utils.py
+++ b/api/advisor/kafka_utils.py
@@ -477,6 +477,10 @@ class KafkaDispatcher(object):
                     logger.debug("Offsets committed successfully")
                 except Exception as e:
                     logger.exception("Error committing Kafka offsets: %s", e)
+            else:
+                logger.error(
+                    "Batch processing failed; stopping consumer to restart from last committed offset")
+                self.quit = True
 
     def _receive_single(self):
         while not self.quit:

--- a/api/advisor/kafka_utils.py
+++ b/api/advisor/kafka_utils.py
@@ -35,6 +35,7 @@ type HandlerFunc = Callable[[str, JsonValue], None]
 class HandlerEntry(TypedDict):
     handler: HandlerFunc
     filters: dict[str, str]
+    batch: bool
 
 
 type HandlerDataValue = HandlerEntry
@@ -141,6 +142,8 @@ class DummyConsumer():
         self.message_index: int = 0
         self.subscribed_topics: list[str] = []
         self.closed: bool = False
+        self.commit_count: int = 0
+        self.store_offsets_count: int = 0
         self.dispatcher_to_quit: 'KafkaDispatcher' | None = None
 
     def add_message(
@@ -194,6 +197,27 @@ class DummyConsumer():
         # This would be a good point for the calling message handler to have
         # set up a function which sets the KafkaHandler's `quit` property.
         return None
+
+    def consume(self, num_messages: int = 1, timeout: float = 1.0) -> list[DummyMessage]:
+        """
+        Return up to num_messages from the queue, or an empty list if exhausted.
+        """
+        batch = []
+        try:
+            for _ in range(num_messages):
+                msg = self.poll(timeout)
+                if msg is None:
+                    break
+                batch.append(msg)
+        except KafkaError:
+            pass
+        return batch
+
+    def store_offsets(self, message=None, offsets=None):
+        self.store_offsets_count += 1
+
+    def commit(self, asynchronous=False):
+        self.commit_count += 1
 
     def close(self):
         """Close the consumer."""
@@ -288,7 +312,7 @@ class KafkaDispatcher(object):
     def __init__(self, consumer: Consumer | None = None):
         self.registered_handlers: dict[str, HandlerEntry] = {}
         self.quit: bool = False
-        self.loop_timeout: int = 1
+        self.loop_timeout: float = 0.5
         # When being tested, supply a DummyConsumer object that has added
         # messages via consumer.add_message().  Those messages will be processed
         # in the order they were added.
@@ -297,7 +321,7 @@ class KafkaDispatcher(object):
         else:
             self.consumer: Consumer = Consumer(settings.KAFKA_SETTINGS)
 
-    def register_handler(self, topic: str, handler_fn: HandlerFunc, **filters: dict[str, str]):
+    def register_handler(self, topic: str, handler_fn: HandlerFunc, batch: bool = False, **filters: dict[str, str]):
         if topic in self.registered_handlers:
             logger.warning(
                 duplicate_handler_warning_message,
@@ -307,38 +331,34 @@ class KafkaDispatcher(object):
             return
         self.registered_handlers[topic] = {
             'handler': handler_fn,
-            'filters': filters
+            'filters': filters,
+            'batch': batch,
         }
 
-    def _handle_message(self, message: confluent_kafka.Message | DummyMessage | None):
+    def _prepare_message(
+        self, message: confluent_kafka.Message | DummyMessage | None
+    ) -> tuple[str, JsonValue] | None:
         """
-        Receive a message, find the handler for this topic, and run the
-        message handler for this topic.
+        Validate a raw Kafka message: check for errors, verify topic
+        registration, match header filters, and decode JSON.
+
+        Returns (topic, body) or None if the message should be skipped.
         """
         if message is None:
-            return
+            return None
         if message.error():
             logger.error(message.error())
-            return
+            return None
 
         topic = message.topic()
         if topic not in self.registered_handlers:
-            # Would this be too noisy?
             logger.info("Received message for unregistered topic '%s'", topic)
-            return
+            return None
 
-        # It is important we filter by headers so that we don't json.loads
-        # every upload that is sent to CRC.
-        # The headers come in as a list of tuples.  The filters is a dictionary.
-        # Example Filters: {'service': 'tasks'}
-        # Example Headers: [('service', b'tasks')]
         headers: list[tuple[str, bytes]] | None = message.headers()
         if headers is None:
             headers = []
         header_filters: dict[str, str] = self.registered_handlers[topic]['filters']
-
-        # It's a toss-up here whether converting this to a dictionary makes
-        # for faster comparisons, but it makes the code easier to read.
         header_dict: dict[str, str] = {
             key: value.decode('utf-8')
             for key, value in headers
@@ -348,22 +368,38 @@ class KafkaDispatcher(object):
             (key in header_dict and header_dict[key] == value)
             for key, value in header_filters.items()
         )
-
         if not filters_matched:
-            return
+            return None
 
-        # Decode JSON
         try:
             body = json.loads(message.value().decode('utf-8').strip('"'))
         except Exception as e:
             logger.exception(f"Malformed JSON when handling {topic}: {e}")
+            return None
+
+        return topic, body
+
+    def _handle_message(self, message: confluent_kafka.Message | DummyMessage | None):
+        """
+        Receive a message, find the handler for this topic, and run the
+        message handler for this topic.
+        """
+        prepared = self._prepare_message(message)
+        if prepared is None:
             return
-        # Tell Django we're starting a 'request' (db connection restarts...)
+
+        topic, body = prepared
+        handler_entry = self.registered_handlers[topic]
+        if handler_entry['batch']:
+            logger.error(
+                "Handler for topic '%s' requires batch mode but receive() "
+                "was called without batch_size — skipping message", topic
+            )
+            return
+
         request_started.send(sender=self.__class__)
-        # Call handler with JSON
         try:
-            handler = self.registered_handlers[topic]['handler']
-            # assert isinstance(handler, AbcCallable)
+            handler = handler_entry['handler']
             handler(topic, body)
         except Exception as e:
             logger.exception(
@@ -374,17 +410,88 @@ class KafkaDispatcher(object):
                     'error': str(e)
                 }
             )
-        # and we're finishing the 'request'
         request_finished.send(sender=self.__class__)
 
-    def receive(self):
+    def _handle_batch_messages(self, messages: list[confluent_kafka.Message | DummyMessage]) -> bool:
+        """
+        Handle a batch of messages: group by topic, call each handler once
+        with the full list of parsed bodies.
+
+        Returns True if all batch handlers succeeded, False if any raised.
+        """
+        grouped: dict[str, list[JsonValue]] = {}
+        for message in messages:
+            prepared = self._prepare_message(message)
+            if prepared is None:
+                continue
+            topic, body = prepared
+            if topic not in grouped:
+                grouped[topic] = []
+            grouped[topic].append(body)
+
+        batch_success = True
+        for topic, bodies in grouped.items():
+            handler_entry = self.registered_handlers[topic]
+            handler = handler_entry['handler']
+            invocations = [bodies] if handler_entry['batch'] else bodies
+
+            for payload in invocations:
+                request_started.send(sender=self.__class__)
+                try:
+                    handler(topic, payload)
+                except Exception as e:
+                    batch_success = False
+                    logger.exception(
+                        "Error processing kafka message",
+                        extra={
+                            'topic': topic,
+                            'error': str(e)
+                        }
+                    )
+                request_finished.send(sender=self.__class__)
+
+        return batch_success
+
+    def _store_offsets(self, messages: list[confluent_kafka.Message | DummyMessage]) -> None:
+        for message in messages:
+            if message.error():
+                continue
+            self.consumer.store_offsets(message=message)
+
+    def _receive_batch(self, batch_size: int):
+        while not self.quit:
+            try:
+                messages = self.consumer.consume(num_messages=batch_size, timeout=self.loop_timeout)
+            except Exception as e:
+                logger.exception("Error consuming Kafka messages: %s", e)
+                continue
+            if not messages:
+                continue
+            success = self._handle_batch_messages(messages)
+            if success:
+                try:
+                    logger.debug("Storing offsets for %d messages", len(messages))
+                    self._store_offsets(messages)
+                    logger.debug("Committing offsets for %d messages", len(messages))
+                    self.consumer.commit(asynchronous=False)
+                    logger.debug("Offsets committed successfully")
+                except Exception as e:
+                    logger.exception("Error committing Kafka offsets: %s", e)
+
+    def _receive_single(self):
+        while not self.quit:
+            self._handle_message(self.consumer.poll(self.loop_timeout))
+
+    def receive(self, batch_size: int | None = None):
         """
         Run the receive loop continuously until told to stop.
+        When batch_size is provided, consume messages in batches.
         """
         self.consumer.subscribe(list(self.registered_handlers.keys()))
 
-        while not self.quit:
-            # longer polling timeouts mean fewer iterations through this loop,
-            # but a longer time to respond to SIGTERM.  Here's the compromise:
-            self._handle_message(self.consumer.poll(self.loop_timeout))
+        if batch_size is not None:
+            self._receive_batch(batch_size)
+        else:
+            self._receive_single()
+
         self.consumer.close()

--- a/api/advisor/logging_conf.py
+++ b/api/advisor/logging_conf.py
@@ -54,10 +54,16 @@ LOGGING = {
         'console': {
             'level': LOG_LEVEL,
             'class': 'logging.StreamHandler' if ENVIRONMENT == 'dev' else 'advisor_logging.AdvisorStreamHandler',
+            'formatter': 'dev' if ENVIRONMENT == 'dev' else 'json',
             'filters': ['hide_metrics']
         },
     },
     'formatters': {
+        'dev': {
+            'format': '[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] '
+                      '[%(thread)d  %(threadName)s] [%(process)d] %(message)s',
+            'datefmt': '%H:%M:%S',
+        },
         'json': {
             'class': 'advisor_logging.OurFormatter',
             'format': json.dumps({"extra": {"component": 'insights-advisor-api'}}),

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -130,7 +130,7 @@ CLOUD_CONNECTOR_PORT = os.getenv('CLOUD_CONNECTOR_PORT')
 TASKS_API_BATCH_SIZE = int(os.getenv('TASKS_BATCH_SIZE', '50'))
 
 # Batch size when consuming Kafka messages in the Inventory replication service.
-INVENTORY_BATCH_SIZE = int(os.getenv('INVENTORY_BATCH_SIZE', '500'))
+INVENTORY_BATCH_SIZE = int(os.getenv('INVENTORY_BATCH_SIZE', '50'))
 
 # Rewrite URL links in internal tasks HTML documents - temporary(?) workaround hack for RHINENG-7966
 TASKS_REWRITE_INTERNAL_URLS = string_to_bool(os.getenv('TASKS_REWRITE_INTERNAL_URLS', 'false'))

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -129,6 +129,9 @@ CLOUD_CONNECTOR_PORT = os.getenv('CLOUD_CONNECTOR_PORT')
 # Batch size when starting or cancelling jobs on hosts in Tasks.
 TASKS_API_BATCH_SIZE = int(os.getenv('TASKS_BATCH_SIZE', '50'))
 
+# Batch size when consuming Kafka messages in the Inventory replication service.
+INVENTORY_BATCH_SIZE = int(os.getenv('INVENTORY_BATCH_SIZE', '500'))
+
 # Rewrite URL links in internal tasks HTML documents - temporary(?) workaround hack for RHINENG-7966
 TASKS_REWRITE_INTERNAL_URLS = string_to_bool(os.getenv('TASKS_REWRITE_INTERNAL_URLS', 'false'))
 TASKS_REWRITE_INTERNAL_URLS_FOR = os.getenv('TASKS_REWRITE_INTERNAL_URLS_FOR', 'internal.console.')

--- a/api/advisor/prometheus.py
+++ b/api/advisor/prometheus.py
@@ -95,6 +95,10 @@ INVENTORY_HOST_DELETED = Counter(
     'insights_advisor_service_inventory_host_deleted',
     'Count how many inventory hosts were deleted'
 )
+INVENTORY_HOST_DELETE_MISSING = Counter(
+    'insights_advisor_service_inventory_host_delete_missing',
+    'Count how many inventory host delete events had no matching record in the DB'
+)
 PAYLOAD_TRACKER_DELIVERY_ERRORS = Counter(
     'insights_advisor_service_payload_tracker_delivery_errors',
     'Counter for how many payload tracker messsages failed delivery'

--- a/api/advisor/prometheus.py
+++ b/api/advisor/prometheus.py
@@ -83,13 +83,13 @@ INVENTORY_EVENT_ERROR = Counter(
     'insights_advisor_service_inventory_event_error',
     'Counter for how many inventory events errored'
 )
-INVENTORY_HOST_CREATED = Counter(
-    'insights_advisor_service_inventory_host_created',
-    'Count how many inventory hosts were created'
+INVENTORY_EVENT_MALFORMED = Counter(
+    'insights_advisor_service_inventory_event_malformed',
+    'Counter for inventory events that failed validation or parsing'
 )
-INVENTORY_HOST_UPDATED = Counter(
-    'insights_advisor_service_inventory_host_updated',
-    'Count how many inventory hosts were updated'
+INVENTORY_HOST_UPSERTED = Counter(
+    'insights_advisor_service_inventory_host_upserted',
+    'Count how many inventory hosts were upserted'
 )
 INVENTORY_HOST_DELETED = Counter(
     'insights_advisor_service_inventory_host_deleted',


### PR DESCRIPTION
This PR addresses [RHINENG-23273](https://redhat.atlassian.net/browse/RHINENG-23273).

Process Kafka inventory events in configurable batches instead of one-at-a-time, with bulk DB writes for significantly reduced database round-trips.

## Changes
### KafkaDispatcher (kafka_utils.py)

Added `_handle_batch_messages()` — groups messages by topic, filters headers, parses JSON, calls handler once per topic with a list of bodies
Added `batch_size` parameter to `receive()` — when provided, uses `consumer.consume(batch_size)` instead of `consumer.poll()`. Without it, existing single-message path is untouched
Added `consume()` method to `DummyConsumer` for testing batch consumption

### Inventory Service (advisor_inventory_service.py)

`handle_inventory_event` now receives a list of messages instead of a single message
Validates each message individually, accumulates into three lists: `created_data`, `updated_data`, `delete_data`
Upserts use `bulk_create(update_conflicts=True)` for both `AdvisorInventoryHost` and `Host` — single SQL query per model per batch
Deletes use Q object pair-matching for exact (inventory_id, org_id) pairs
Prometheus metrics tracked per event type: `CREATED`, `UPDATED`, `DELETED`

### Settings

New env var: `INVENTORY_BATCH_SIZE` (default 500)

[RHINENG-23273]: https://redhat.atlassian.net/browse/RHINENG-23273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Process inventory Kafka events in configurable batches with bulk database operations to reduce round-trips and improve throughput.

New Features:
- Add batch-aware KafkaDispatcher that can consume messages in batches and dispatch them either as batches or individually per handler.
- Introduce batched processing of inventory events so handlers receive lists of messages per topic instead of single events.
- Add configurable INVENTORY_BATCH_SIZE setting to control Kafka batch consumption size for the inventory replication service.

Enhancements:
- Refactor inventory event handling into parsing and bulk upsert/delete helpers for AdvisorInventoryHost and Host models to support efficient batch operations.
- Improve logging and Prometheus metrics around inventory event processing to reflect batch handling and per-event-type counts.
- Extend DummyConsumer and test utilities to support batch consumption scenarios and validate batch dispatch semantics.

Tests:
- Update existing inventory service tests for batched handlers and add coverage for batch create/update/delete flows and invalid-message skipping within batches.
- Add Kafka utils tests for DummyConsumer.consume, batched message handling, mixed valid/invalid messages, and receive() with and without batch handlers.