### PR TITLE
chore: use only 1 env var for the DB partition

### DIFF
--- a/api/advisor/api/migrations/0046_advisor_inventory_host.py
+++ b/api/advisor/api/migrations/0046_advisor_inventory_host.py
@@ -7,7 +7,7 @@ from api.scripts.partitioned_table_index_helper import (
     drop_partitioned_table_index,
 )
 
-PARTITION_COUNT = int(os.getenv('PARTITION_COUNT', '16'))
+PARTITION_COUNT = int(os.getenv('ADVISOR_INVENTORY_HOST_NUM_PARTITIONS', '1'))
 PARENT_TABLE = 'advisor_inventory_host'
 
 CREATE_PARENT_SQL = f"""

--- a/api/advisor/api/scripts/partitioned_table_index_helper.py
+++ b/api/advisor/api/scripts/partitioned_table_index_helper.py
@@ -16,7 +16,7 @@ from django.db import connection, connections
 
 logger = logging.getLogger(__name__)
 
-TABLE_NUM_PARTITIONS = int(os.getenv('ADVISOR_INVENTORY_HOST_NUM_PARTITIONS', '16'))
+TABLE_NUM_PARTITIONS = int(os.getenv('ADVISOR_INVENTORY_HOST_NUM_PARTITIONS', '1'))
 
 MigrationMode = Literal['automated', 'managed']
 

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -463,7 +463,7 @@ HBI_SUBSCRIPTION = os.getenv("HBI_SUBSCRIPTION", "advisor_hosts_sub_v1_0_2")
 HBI_DROP_SUBSCRIPTION = os.getenv("HBI_DROP_SUBSCRIPTION", "")
 HBI_DROP_TABLES = os.getenv("HBI_DROP_TABLES", "false").lower() == "true"
 HBI_SSL_MODE = os.getenv("HBI_SSL_MODE", "")
-HBI_TABLES_NUM_PARTITIONS = int(os.getenv("HBI_TABLES_NUM_PARTITIONS", 1))
+HBI_TABLES_NUM_PARTITIONS = int(os.getenv("ADVISOR_INVENTORY_HOST_NUM_PARTITIONS", 1))
 
 # Kafka settings
 


### PR DESCRIPTION
use only 1 env var for the DB partition

## Summary by Sourcery

Enhancements:
- Replace legacy partition count environment variables with a unified ADVISOR_INVENTORY_HOST_NUM_PARTITIONS setting for inventory host tables.