### PR TITLE
fix(RHINENG-27085): Remove auth for accessing tasks openapi.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,14 @@ pipenv install
 pipenv install --dev
 ```
 
-## Database
+## Database and Kafka
 
-To start the database, run required migrations and load required
+To start the database and Kafka, run required migrations and load required
 fixtures you will need to run the following commands:
 ```
 export ADVISOR_DB_HOST=localhost
-podman-compose up -d advisor-db
-pipenv shell
-python api/advisor/manage.py migrate
-python api/advisor/manage.py loaddata rulesets rule_categories system_types upload_sources basic_test_data
-```
-... or you can start the database, Kafka, Advisor service and API all together with podman-compose, like so:
-```
-export ADVISOR_DB_HOST=localhost
-podman-compose up -d advisor-db init-kafka kafka advisor-service advisor-api
+podman-compose up -d advisor-db init-kafka kafka
+./container_init_localdev.sh
 ```
 
 ## Feature Flags

--- a/api/advisor/tasks/README.md
+++ b/api/advisor/tasks/README.md
@@ -19,10 +19,8 @@ Start the Advisor DB and create the tables and populate it with fixture data:
 ```bash
 export ADVISOR_DB_HOST=localhost
 podman-compose up -d advisor-db
+./container_init_localdev.sh
 pipenv shell
-python api/advisor/manage.py migrate
-python api/advisor/manage.py mock_cyndi_table
-python api/advisor/manage.py loaddata basic_task_test_data
 ```
 Update the stale timestamps of the hosts in the DB to be in the future.  The
 hosts won't be considered stale then and will show up in queries:
@@ -169,36 +167,48 @@ system to the stage environment by following these steps.
 2. Unregister the system from production subscription-manager and configure it to use stage:
 ```shell
 # rhc disconnect
-# subscription-manager config --server.hostname=subscription.rhsm.stage.redhat.com
-# subscription-manager register --activationkey=<stage-activation-key> --org=<stage-org> --proxy=http://squid.corp.redhat.com:3128
 ```
-... rhc disconnect stops the rhcd service, unregisters the host from Insights and from Subscription Manager.
-
+Edit /etc/rhsm/rhsm.conf for the stage environment:
+```aiignore
+hostname = subscription.rhsm.stage.redhat.com
+proxy_hostname = squid.corp.redhat.com
+proxy_port = 3128
+baseurl = https://stagecdn.redhat.com
+```
+3. Register the system with subscription-manager using either your username/password or an activation key:
+```shell
+# subscription-manager register
+... or ...
+# subscription-manager register --activationkey=<stage-activation-key> --org=<stage-org>
+```
 Activation keys for stage can be found here: https://console.stage.redhat.com/insights/connector/activation-keys
 
-3. Edit `/etc/rhc/config.toml` to set these lines:
+4. Edit `/etc/rhc/config.toml` to set these lines:
 ```
 broker = ["wss://connect.cloud.stage.redhat.com:443"]
 data-host = "cert.cloud.stage.redhat.com"
-log-level = "debug"  # optional
+cert-file = "/etc/pki/consumer/cert.pem"
+key-file = "/etc/pki/consumer/key.pem"
+log-level = "trace"
+mqtt-reconnect-delay = "10s"
 ```
 Note, make sure its `cloud.stage` and not `console.stage` otherwise hosts may
 not get an RHC client ID and not show up in Tasks Web UI.
 
-4. (Optional) If using [rhc-0.2.5-1](https://issues.redhat.com/browse/RHINENG-15630) on RHEL8 or 9, also run this command:
+5. (Optional) If using [rhc-0.2.5-1](https://issues.redhat.com/browse/RHINENG-15630) on RHEL8 or 9, also run this command:
 ```shell
 echo 'env = ["HTTPS_PROXY=", "http_proxy=", "HTTP_PROXY=", "https_proxy="]' > /etc/rhc/workers/rhc-worker-playbook.worker.toml
 ```
 ... to workaround a bug in that version of rhc.  If the rhcd service is already running, then reboot the machine.
 
-5. Edit `/usr/lib/systemd/system/rhcd.service` to set these lines:
+6. Edit `/usr/lib/systemd/system/rhcd.service` to set these lines:
 ```
 [Service]
 Environment="HTTP_PROXY=http://squid.corp.redhat.com:3128"
 Environment="HTTPS_PROXY=http://squid.corp.redhat.com:3128"
 ```
 
-6. Edit `/etc/insights-client/insights-client.conf` to set these lines:
+7. Edit `/etc/insights-client/insights-client.conf` to set these lines:
 ```
 auto_config=False
 cert_verify=False
@@ -207,15 +217,16 @@ base_url=cert.console.stage.redhat.com:443/r/insights
 proxy=http://squid.corp.redhat.com:3128
 ```
 
-7. Run rhc connect:
+8. Run rhc connect:
 ```shell
 # rhc connect
 ```
-... which registers the host with Subscription Manager (requires your stage username/password
-if you didn't register using activation keys above) and with Insights and starts the rhcd service.
+... which registers the host with Subscription Manager (if not already done so) and Insights and starts the rhcd service.
 
 Note, if you are configuring a CentOS system for (pre-)conversion follow the instructions [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/converting_from_an_rpm-based_linux_distribution_to_rhel/index#proc_preparing-for-a-rhel-conversion-using-insights_converting-using-insights)
 and use the configuration above if you wish to register it to the Insights Stage environment.
+
+If there are any problems with the connection, esp rhc, see the 'Troubleshooting failed tasks' section below.
 
 Viewing playbook output
 ------------------------

--- a/api/advisor/tasks/tests/test_api_docs.py
+++ b/api/advisor/tasks/tests/test_api_docs.py
@@ -1,0 +1,92 @@
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+from django.test import TestCase
+from django.urls import reverse
+
+from project_settings import settings
+from tasks.tests import constants
+
+from openapi_spec_validator import validate
+
+
+class TasksApiDocsTestCaseClass(TestCase):
+    fixtures = ['basic_task_test_data']
+    schema_path_name = 'tasks-schema'
+    auth_dict = {}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        response = cls.client_class().get(
+            reverse(cls.schema_path_name), HTTP_ACCEPT=constants.json_mime,
+            **cls.auth_dict
+        )
+        cls.status_code = response.status_code
+        cls.content = response.content.decode('utf-8')
+        cls.swagger = response.json()
+
+
+class NoauthTasksSchemaTestCase(TasksApiDocsTestCaseClass):
+    """Test that the Tasks schema is accessible without authentication."""
+    def test_schema_has_docs(self):
+        self.assertEqual(self.status_code, 200, self.content)
+        self.assertIn('info', self.swagger)
+        self.assertIn('title', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['title'], '')
+        self.assertIn('description', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['description'], '')
+        self.assertIn('version', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['version'], '')
+        self.assertIn('paths', self.swagger)
+        self.assertIsInstance(self.swagger['paths'], dict)
+
+    def test_schema_has_tasks_title(self):
+        self.assertEqual(self.swagger['info']['title'], 'Insights Tasks API')
+
+    def test_schema_paths_use_tasks_prefix(self):
+        prefix = '/' + settings.TASKS_PATH_PREFIX
+        for path in self.swagger['paths']:
+            self.assertTrue(
+                path.startswith(prefix),
+                f"Path '{path}' does not start with tasks prefix '{prefix}'"
+            )
+
+
+class NoauthTasksJSONSpecTestCase(TasksApiDocsTestCaseClass):
+    """Test the Tasks schema via the JSON endpoint accessible without authentication."""
+    schema_path_name = 'tasks-openapi-spec-json'
+
+    def test_schema_has_docs(self):
+        self.assertEqual(self.status_code, 200, self.content)
+        self.assertIn('info', self.swagger)
+        self.assertIn('title', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['title'], '')
+        self.assertIn('description', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['description'], '')
+        self.assertIn('version', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['version'], '')
+        self.assertIn('paths', self.swagger)
+        self.assertIsInstance(self.swagger['paths'], dict)
+
+
+class TasksOpenAPI3SchemaValidation(TasksApiDocsTestCaseClass):
+    """Validate the Tasks schema against the OpenAPI 3 specification."""
+
+    def test_openapi_3_schema_validation(self):
+        self.assertIn('version', self.swagger['info'])
+        self.assertNotEqual(self.swagger['info']['version'], '')
+        self.assertIsNone(validate(self.swagger))

--- a/api/advisor/tasks/urls.py
+++ b/api/advisor/tasks/urls.py
@@ -17,6 +17,7 @@
 from django.conf import settings
 from django.urls import path, include
 from rest_framework.routers import APIRootView, DefaultRouter
+from rest_framework.permissions import AllowAny
 from drf_spectacular.views import (
     SpectacularAPIView, SpectacularJSONAPIView, SpectacularSwaggerView
 )
@@ -85,6 +86,8 @@ def spectacular_view(*args, **kwargs):
     permissions.rbac_perm_cache = dict()
     rtn = SpectacularAPIView.as_view(
         custom_settings=tasks_schema_settings,
+        authentication_classes=[],
+        permission_classes=[AllowAny],
     )(*args, **kwargs)
     permissions.rbac_perm_cache = None
     return rtn
@@ -100,6 +103,8 @@ def spectacular_json_view(*args, **kwargs):
     permissions.rbac_perm_cache = dict()
     rtn = SpectacularJSONAPIView.as_view(
         custom_settings=tasks_schema_settings,
+        authentication_classes=[],
+        permission_classes=[AllowAny],
     )(*args, **kwargs)
     permissions.rbac_perm_cache = None
     return rtn


### PR DESCRIPTION
- piggyback Tasks documentation updates

## Summary by Sourcery

Allow unauthenticated access to the Tasks OpenAPI schema endpoints and update related local development and staging setup docs.

Bug Fixes:
- Remove authentication requirements from Tasks OpenAPI schema and JSON spec endpoints so documentation can be fetched without credentials.

Enhancements:
- Add tests to verify unauthenticated access and OpenAPI 3 validity for the Tasks API schema.
- Update local development instructions to use container_init_localdev.sh for DB/Kafka initialization.
- Refine staging environment setup docs for subscription-manager, rhc, and insights-client configuration.