### PR TITLE
Support host groups in localdev environment

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -803,11 +803,41 @@ Use the Authorize button and paste the `$RH_IDENTITY` value into the `x-rh-ident
 
 Visit `http://localhost:8000/api/insights/v1/` in a browser to see the full list of available endpoints (DRF's browsable API).
 
+## Testing RBAC
+
+Start the mock-rbac service and specify the permissions your users have.  The mock-rbac service can be started with manage.py:
+```bash
+python api/advisor/manage.py mock_rbac --permissions "advisor:recommendation-results:read,advisor:advisor-roots:read"
+```
+... or via podman-compose.  Uncomment and set the environment variable permissions for the mock-rbac service and start the container.
+For example, set `MOCK_RBAC_PERMISSIONS=advisor:recommendation-results:read,advisor:advisor-roots:read`
+```bash
+podman-compose up mock-rbac
+```
+The user will be able to access a number of API endpoints, but not acks or hostacks as they require `advisor:disable-recommendations:read` permissions.
+View the logs of the advisor-api service to see RBAC debugging information.
+
+## Testing host groups
+
+Upload a fake archive for a system and specify the host group the system is a part of, eg my_group:
+```bash
+pipenv shell
+export ADVISOR_DB_HOST=localhost
+python service/manual_test/send_fake_engine_results.py --groups my_group
+python api/advisor/manage.py freshen_hosts
+```
+Then start the mock-rbac service and specify the host group your users are part of:
+```bash
+python api/advisor/manage.py mock_rbac --permissions "advisor:*:*" --groups "$(python3 -c "import uuid; print(uuid.uuid5(uuid.NAMESPACE_DNS, 'my_group'))")"
+```
+Then in the UI, your user should only be able to see the `57c4c38b-a8c6-4289-9897-223681fd804d` host when accessing the `system` endpoint,
+because that's the only host in the `my_group` host group.
+
 ### Django ORM
 
 ```bash
-export ADVISOR_DB_HOST=localhost
 pipenv shell
+export ADVISOR_DB_HOST=localhost
 python service/manual_test/send_fake_engine_results.py
 python api/advisor/manage.py freshen_hosts
 python api/advisor/manage.py shell
@@ -868,8 +898,8 @@ print(json.dumps(list(qs), indent=2, cls=DjangoJSONEncoder))
 ### Raw SQL
 
 ```bash
-export ADVISOR_DB_HOST=localhost
 pipenv shell
+export ADVISOR_DB_HOST=localhost
 python service/manual_test/send_fake_engine_results.py
 python api/advisor/manage.py freshen_hosts
 python api/advisor/manage.py dbshell

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -91,14 +91,15 @@ services:
       - ENABLE_AUTOSUB="true" # enable auto-subscribe endpoint
       - ENABLE_INIT_CONTAINER_IMPORT_CONTENT=true
       - ENABLE_INIT_CONTAINER_MIGRATIONS=true
-      - LOG_LEVEL=INFO
+      - LOG_LEVEL=DEBUG
       - TASKS_REWRITE_INTERNAL_URLS_FOR=internal.localhost
       - TASKS_REWRITE_INTERNAL_URLS=true
       - USE_DJANGO_WEBSERVER=false
       - WEB_CONCURRENCY=2
       # Uncomment to enable RBAC via the mock-rbac service:
       # - RBAC_ENABLED=true
-      # - RBAC_URL=http://mock-rbac:8111
+      # - RBAC_URL=http://mock-rbac:8111 # Use when mock-rbac runs in a separate container
+      # - RBAC_URL=http://host.containers.internal:8111 # Use when mock-rbac runs via manage.py mock_rbac
     depends_on:
       kafka:
         condition: service_started

--- a/service/manual_test/fake_engine_result_rhel.json
+++ b/service/manual_test/fake_engine_result_rhel.json
@@ -32,7 +32,8 @@
         {"namespace": "insights-client", "key": "key_1234567890_hat", "value": null},
         {"namespace": "insights-client", "key": "key_1234567890_hat", "value": "user@example"}
       ],
-      "updated": null
+      "updated": null,
+      "groups": []
     },
     "platform_metadata": {
       "org_id": "9876543",

--- a/service/manual_test/insert_inventory_host.py
+++ b/service/manual_test/insert_inventory_host.py
@@ -84,6 +84,7 @@ def insert_host(host_data):
                 ON CONFLICT (id) DO UPDATE SET
                     display_name = EXCLUDED.display_name,
                     tags = EXCLUDED.tags,
+                    groups = EXCLUDED.groups,
                     updated = EXCLUDED.updated,
                     stale_timestamp = EXCLUDED.stale_timestamp,
                     system_profile = EXCLUDED.system_profile,

--- a/service/manual_test/send_fake_engine_results.py
+++ b/service/manual_test/send_fake_engine_results.py
@@ -14,8 +14,10 @@
 # You should have received a copy of the GNU General Public License along
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
+import argparse
 import json
 import os
+import uuid
 
 from confluent_kafka import Producer
 from insert_inventory_host import insert_host
@@ -25,6 +27,17 @@ ENGINE_RESULTS_TOPIC = os.environ.get('ENGINE_RESULTS_TOPIC', 'platform.engine.r
 ENGINE_RESULTS_FILE = os.path.basename(os.environ.get('ENGINE_RESULTS_FILE', 'fake_engine_result_rhel.json'))
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
+parser = argparse.ArgumentParser(description='Send fake engine results to Kafka')
+parser.add_argument(
+    '--groups', type=str, default=None,
+    help=(
+        'Comma-separated host group names to assign to the host. '
+        'Each name gets a deterministic UUID. '
+        'Example: --groups "group_1,group_2"'
+    ),
+)
+args = parser.parse_args()
+
 print('Using BOOTSTRAP_SERVERS %s' % (BOOTSTRAP_SERVERS))
 
 p = Producer({'bootstrap.servers': BOOTSTRAP_SERVERS})
@@ -32,8 +45,22 @@ p = Producer({'bootstrap.servers': BOOTSTRAP_SERVERS})
 with open(os.path.join(THIS_DIR, ENGINE_RESULTS_FILE)) as f:
     engine_results_message = json.load(f)
 
+host_data = engine_results_message['input']['host']
+
+# Inject host groups if --groups is specified
+if args.groups:
+    groups = []
+    for name in args.groups.split(','):
+        name = name.strip()
+        # Generate a deterministic UUID from the group name so that
+        # re-running with the same name produces the same ID.
+        group_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
+        groups.append({'id': group_id, 'name': name})
+    host_data['groups'] = groups
+    print(f'Host groups: {groups}')
+
 # Insert the host into inventory.hosts_table so the API can find it
-insert_host(engine_results_message['input']['host'])
+insert_host(host_data)
 
 
 def delivery_report(err, msg):


### PR DESCRIPTION
- Added information about mock-rbac to the API README

## Summary by Sourcery

Document and enable testing of RBAC and host groups in the local development environment.

New Features:
- Allow fake engine result sender to assign deterministic host groups via a new --groups option.
- Support persisting host group data in the manual inventory host insertion script.

Enhancements:
- Add README guidance for testing RBAC and host groups locally, including mock-rbac usage.
- Increase advisor-api log verbosity in podman-compose to aid RBAC debugging and document alternate RBAC_URL values for different mock-rbac setups.

Documentation:
- Extend API README with instructions for running mock-rbac and testing host group–based access control in localdev.