### PR TITLE
fix: postgres.E005 'django.contrib.postgres' must be in INSTALLED_APPS to use ArrayField

### DIFF
--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -190,6 +190,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.postgres',
     'rest_framework',
     'drf_spectacular',
     'django_prometheus',


### PR DESCRIPTION
Bug Fixes:
- Resolve runtime error when using ArrayField by ensuring 'django.contrib.postgres' is included in INSTALLED_APPS.

## Summary by Sourcery

Bug Fixes:
- Include 'django.contrib.postgres' in INSTALLED_APPS to prevent runtime errors when using ArrayField.