### PR TITLE
feat(RHINENG-25301): Replace RBAC PSK auth with service account JWT

### DIFF
--- a/api/advisor/api/kessel.py
+++ b/api/advisor/api/kessel.py
@@ -20,7 +20,8 @@ from types import SimpleNamespace
 from typing import Generator, Optional, Tuple
 from uuid import UUID
 
-from kessel.auth import fetch_oidc_discovery, OAuth2ClientCredentials
+from kessel.auth import fetch_oidc_discovery, OAuth2ClientCredentials, oauth2_auth_request
+from kessel.rbac.v2 import fetch_default_workspace  # noqa: F401 (used via kessel.fetch_default_workspace)
 from kessel.inventory.v1beta2 import (
     ClientBuilder,
     allowed_pb2,
@@ -404,6 +405,25 @@ class TestClient(inventory_service_pb2_grpc.KesselInventoryServiceStub):
 
 
 #############################################################################
+# Shared service account credentials
+#############################################################################
+
+_service_account_credentials = None
+
+
+def get_service_account_credentials():
+    global _service_account_credentials
+    if _service_account_credentials is None and settings.KESSEL_AUTH_ENABLED:
+        discovery = fetch_oidc_discovery(settings.KESSEL_AUTH_OIDC_ISSUER)
+        _service_account_credentials = OAuth2ClientCredentials(
+            client_id=settings.KESSEL_AUTH_CLIENT_ID,
+            client_secret=settings.KESSEL_AUTH_CLIENT_SECRET,
+            token_endpoint=discovery.token_endpoint,
+        )
+    return _service_account_credentials
+
+
+#############################################################################
 # The interface we provide to the rest of our code.
 #############################################################################
 
@@ -434,12 +454,7 @@ class Kessel:
             if settings.KESSEL_INSECURE:
                 builder.insecure()
             elif settings.KESSEL_AUTH_ENABLED:
-                discovery = fetch_oidc_discovery(settings.KESSEL_AUTH_OIDC_ISSUER)
-                credentials = OAuth2ClientCredentials(
-                    client_id=settings.KESSEL_AUTH_CLIENT_ID,
-                    client_secret=settings.KESSEL_AUTH_CLIENT_SECRET,
-                    token_endpoint=discovery.token_endpoint
-                )
+                credentials = get_service_account_credentials()
                 builder.oauth2_client_authenticated(credentials)
             else:
                 builder.unauthenticated()
@@ -529,3 +544,8 @@ class Kessel:
 
 
 client = Kessel()
+
+# RBAC workspace auth and cache for v2/workspaces calls
+_sa_creds = get_service_account_credentials()
+service_account_auth = oauth2_auth_request(_sa_creds) if _sa_creds else None
+workspace_cache: dict[tuple[str, str], str] = {}

--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -17,6 +17,7 @@
 import base64
 from enum import Enum
 import json
+import time
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse, urlunparse
 import uuid
@@ -69,16 +70,6 @@ def identity_to_subject(identity: dict) -> kessel.SubjectRef:
         raise ValueError(f"Unknown identity type: {identity['type']}")
     user_id = identity[identity_field]['user_id']
     return kessel.SubjectRef(f"redhat/{user_id}", 'principal')
-
-
-##############################################################################
-# Kessel workspace caching
-##############################################################################
-
-# This is a simple cache within the process.  Workspace IDs will remain
-# constant for their lifetime so they can be reused across multiple requests.
-# The key is (org_id, workspace_str), the value is the ID.
-workspace_for_org: dict[tuple[str, str], str] = {}
 
 
 ##############################################################################
@@ -228,44 +219,43 @@ def set_rbac_success(request: Request, message: str) -> None:
 
 def make_rbac_request(rbac_url: str, request: Request) -> tuple[Response | None, float]:
     """
-    Make a request to the RBAC service.  With RBAC v1 we check permissions,
-    with RBAC v2 we check workspaces.
+    Make a request to the RBAC service for v1/access permission checks.
+    Uses service account JWT when credentials are available (replaces PSK),
+    otherwise falls back to x-rh-identity passthrough.
     """
     logger.debug(f"RBAC request to {rbac_url}")
     identity = request.auth
-    # This has already been checked in callers to this code so we assume
-    # we can get the org_id and username keys.
-    if settings.RBAC_PSK:
-        rbac_header = {
-            "x-rh-rbac-client-id": settings.RBAC_CLIENT_ID,
-            "x-rh-rbac-psk": settings.RBAC_PSK,
-            "x-rh-rbac-org-id": identity['org_id'],
-        }
-        # If there's a simpler way of doing this safely, let me know.
-        urlparts = urlparse(rbac_url)
-        query_params = parse_qs(urlparts.query)
-        query_params['username'] = identity['user']['username']
-        new_query = urlencode(query_params, doseq=True)
-        rbac_url = urlunparse(urlparts._replace(query=new_query))
-    else:
-        # Supply the full x-rh-identity header if we have it, because
-        # that gives is_org_admin and other flags used by RBAC.
-        if request and auth_header_key in request.META:
-            # We don't want the other cruft in request.META...
-            rbac_header = {
-                http_auth_header_key: request.META[auth_header_key]
-            }
-        else:
-            rbac_header = auth_header_for_testing(
-                username=identity['username'], org_id=identity['org_id'],
-                supply_http_header=True, user_opts={
-                    'is_org_admin': identity['user']['is_org_admin']
-                },
-            )
-
     # Do import here because of preloading of permissions classes - if
     # we do it in header then Django's test framework imports get confused.
     from api.utils import retry_request
+
+    creds = kessel.get_service_account_credentials()
+    if creds:
+        rbac_header = {
+            "x-rh-rbac-org-id": identity['org_id'],
+        }
+        user_data = request_to_user_data(request)
+        urlparts = urlparse(rbac_url)
+        query_params = parse_qs(urlparts.query)
+        query_params['username'] = user_data.get('username', '')
+        rbac_url = urlunparse(urlparts._replace(query=urlencode(query_params, doseq=True)))
+        return retry_request(
+            'RBAC', rbac_url, headers=rbac_header,
+            auth=kessel.service_account_auth, timeout=10
+        )
+
+    if request and auth_header_key in request.META:
+        rbac_header = {
+            http_auth_header_key: request.META[auth_header_key]
+        }
+    else:
+        rbac_header = auth_header_for_testing(
+            username=identity['username'], org_id=identity['org_id'],
+            supply_http_header=True, user_opts={
+                'is_org_admin': identity['user']['is_org_admin']
+            },
+        )
+
     return retry_request('RBAC', rbac_url, headers=rbac_header, timeout=10)
 
 
@@ -375,6 +365,7 @@ def check_permission(
     return has_rbac_permission(request, permission)
 
 
+
 def has_rbac_permission(request: Request, permission: str = 'advisor:*:*') -> tuple[bool, float]:
     """
     Check if this user in this account has the required permission.
@@ -417,8 +408,6 @@ def has_rbac_permission(request: Request, permission: str = 'advisor:*:*') -> tu
         response = rbac_perm_cache[auth_tuple]
         elapsed = 0.0
     else:
-        # Use PSK if it's defined, otherwise fallback to crafting an identity
-        # header for username
         rbac_url = make_rbac_url("access/?application=advisor,tasks,inventory&limit=1000")
         response, elapsed = make_rbac_request(rbac_url, request)
         if (response is None) or response.status_code == 500:
@@ -472,72 +461,25 @@ def get_workspace_id(
     request: Request, workspace: str = "default"
 ) -> tuple[str, float]:
     """
-    Get the ID of the workspace from the RBAC REST API, for the given
-    identity.
+    Get the ID of the workspace from the RBAC REST API via the Kessel SDK's
+    fetch_default_workspace, using OAuth2 service account auth.
     """
-    elapsed = 0.0
-
-    def log_and_return_fail(message: str, *args) -> tuple[str, float]:
-        logger.error(message, *args)
-        return ('', elapsed)
-
     org_id = request.auth['org_id']
-    workspace_key = (org_id, workspace)
-    if workspace_for_org is not None and workspace_key in workspace_for_org:
-        return (workspace_for_org[workspace_key], 0.0)
-    # Note that we should really just use the default 'default' value, so
-    # we're not doing any work with URL-encoding that string... caveat petens.
-    rbac_url = make_rbac_url(f"workspaces/?type={workspace}", version=2)
-    response, elapsed = make_rbac_request(rbac_url, request)
-    if response.status_code != 200:
-        # Report actual time to make RBAC request
-        return log_and_return_fail(
-            "Error: Got status %d from RBAC: '%s'",
-            response.status_code, response.content.decode()
+    cache_key = (org_id, workspace)
+    if cache_key in kessel.workspace_cache:
+        return kessel.workspace_cache[cache_key], 0.0
+    start = time.time()
+    try:
+        ws = kessel.fetch_default_workspace(
+            rbac_base_endpoint=settings.RBAC_URL,
+            org_id=org_id,
+            auth=kessel.service_account_auth,
         )
-    # Check that the actual content is a list of workspaces
-    page = response.json()
-    if not isinstance(page, dict):
-        return log_and_return_fail(
-            "Error: Response from RBAC is not a dictionary: '%s'",
-            page,
-        )
-    if 'data' not in page:
-        return log_and_return_fail(
-            "Error: Response from RBAC is missing 'data' key: '%s'",
-            page,
-        )
-    if not isinstance(page['data'], list):
-        return log_and_return_fail(
-            "Error: Response from RBAC is not a list: '%s'",
-            page['data'],
-        )
-    if len(page['data']) == 0:
-        return log_and_return_fail(
-            "Error: Data from RBAC is empty: '%s'",
-            page['data'],
-        )
-    # There should only ever be one workspace with a given name, certainly
-    # for 'default'.
-    if not isinstance(page['data'][0], dict):
-        return log_and_return_fail(
-            "Error: First data item from RBAC is not a dictionary: '%s'",
-            page['data'][0],
-        )
-    if 'id' not in page['data'][0]:
-        return log_and_return_fail(
-            "Error: First data item from RBAC is missing 'id' key: '%s'",
-            page['data'][0],
-        )
-    workspace_id = page['data'][0]['id']
-    if workspace_id is None:
-        return log_and_return_fail(
-            "Error: Workspace '%s' not found in RBAC response",
-            workspace,
-        )
-    if workspace_for_org is not None:
-        workspace_for_org[workspace_key] = workspace_id
-    return workspace_id, elapsed
+        kessel.workspace_cache[cache_key] = ws.id
+        return ws.id, time.time() - start
+    except Exception as e:
+        logger.error("Error fetching workspace from RBAC: %s", e)
+        return '', time.time() - start
 
 
 def has_kessel_permission(

--- a/api/advisor/api/permissions.py
+++ b/api/advisor/api/permissions.py
@@ -365,7 +365,6 @@ def check_permission(
     return has_rbac_permission(request, permission)
 
 
-
 def has_rbac_permission(request: Request, permission: str = 'advisor:*:*') -> tuple[bool, float]:
     """
     Check if this user in this account has the required permission.

--- a/api/advisor/api/tests/__init__.py
+++ b/api/advisor/api/tests/__init__.py
@@ -289,6 +289,14 @@ class constants(object):
 
     # KESSELWORKSPACE1
     kessel_std_workspace_id = '4f574c45-5353-454b-3145-434150534b52'
+    kessel_std_workspace_response = {
+        'data': [{
+            'id': kessel_std_workspace_id,
+            'name': 'Default Workspace',
+            'type': 'default',
+            'description': '',
+        }]
+    }
 
     # Kessel RBAC permission constants
     kessel_std_org_obj = kessel.Workspace(kessel_std_workspace_id).to_ref().as_pb2()

--- a/api/advisor/api/tests/test_ack_views.py
+++ b/api/advisor/api/tests/test_ack_views.py
@@ -163,7 +163,7 @@ class AckViewTestCase(TestCase):
     def test_ack_add_kessel_enabled_full_write(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
 
         # Post with an existing acked rule should return that ack
@@ -206,7 +206,7 @@ class AckViewTestCase(TestCase):
     def test_ack_add_kessel_enabled_only_read(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
         # We should be able to see the ack in the list for this account
         response = self.client.get(reverse('ack-list'), **self.default_header)

--- a/api/advisor/api/tests/test_cert_auth.py
+++ b/api/advisor/api/tests/test_cert_auth.py
@@ -209,7 +209,7 @@ class CertAuthTestCase(TestCase):
     def test_list_system_kessel_on_cert_auth(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
         response = self.client.get(
             reverse('system-list'), **self.self_cert_auth_header

--- a/api/advisor/api/tests/test_host_groups.py
+++ b/api/advisor/api/tests/test_host_groups.py
@@ -380,7 +380,7 @@ class HostGroupsTestCase(TestCase):
     def test_groups_match_kessel_enabled_recom_read_only(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
         # No RBACv1 use when Kessel enabled
         page = self._get_view('rule-list')

--- a/api/advisor/api/tests/test_system_views.py
+++ b/api/advisor/api/tests/test_system_views.py
@@ -652,7 +652,7 @@ class SystemViewTestCase(TestCase):
     def test_list_system_kessel_on(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
         response = self.client.get(
             reverse('system-list'), **self.std_auth_header

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -15,6 +15,7 @@
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
 import responses
+from unittest.mock import patch, MagicMock
 
 from django.http import HttpRequest
 from django.test import TestCase, override_settings
@@ -31,7 +32,7 @@ from api.permissions import (
     CertAuthPermission, InsightsRBACPermission, IsRedHatInternalUser,
     RBACPermission, RHIdentityAuthentication, ResourceScope, OrgPermission,
     TurnpikeIdentityAuthentication, auth_header_for_testing, auth_header_key,
-    auth_to_request, check_permission, has_kessel_permission,
+    auth_to_request, check_permission, has_kessel_permission, make_rbac_request,
     request_object_for_testing, request_to_username,
     turnpike_auth_header_for_testing, make_rbac_url, get_workspace_id,
 )
@@ -45,6 +46,10 @@ def b64s(s):
 
 
 TEST_RBAC_URL = 'http://rbac.svc'
+TEST_RBAC_V1_ACCESS = make_rbac_url(
+    "access/?application=advisor,tasks,inventory&limit=1000",
+    rbac_base=TEST_RBAC_URL
+)
 TEST_RBAC_V2_WKSPC = make_rbac_url(
     "workspaces/?type=default",
     version=2, rbac_base=TEST_RBAC_URL
@@ -556,133 +561,130 @@ class BadUsesOfAuthHeaderTestCase(TestCase):
 class GetWorkspaceIdTestCase(TestCase):
     @responses.activate
     @override_settings(RBAC_URL=TEST_RBAC_URL)
-    def test_get_workspace_id_failures(self):
+    def test_get_workspace_id_http_error(self):
+        import api.kessel as kessel_mod
+        kessel_mod.workspace_cache.clear()
         request = request_object_for_testing(auth_by=RHIdentityAuthentication)
-        # Have to not use the workspace_for_org cache in this test
-        from api import permissions
-        permissions.workspace_for_org = None  # prevents cache use
         with self.assertLogs(logger='advisor-log') as logs:
-            # Non-200 response
-            _ = responses.add(
+            responses.add(
                 responses.GET, TEST_RBAC_V2_WKSPC,
                 status=404,
             )
             workspace_id, elapsed = get_workspace_id(request)
             self.assertFalse(workspace_id)
-            self.assertGreater(elapsed, 0.0)  # This reflects the actual request.
-            self.assertIn(
-                "ERROR:advisor-log:Error: Got status 404 from RBAC: ''",
-                logs.output
-            )
-            # Not a dict
-            _ = responses.add(
-                responses.GET, TEST_RBAC_V2_WKSPC,
-                json='Foo!',
-            )
-            workspace_id, elapsed = get_workspace_id(request)
-            ehdr = 'ERROR:advisor-log:Error: '
-            self.assertFalse(workspace_id)
             self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}Response from RBAC is not a dictionary: 'Foo!'",
-                logs.output
-            )
-            # No 'data' item in dict
-            _ = responses.add(
-                responses.GET, TEST_RBAC_V2_WKSPC,
-                json={'foo': 'bar'},
-            )
-            workspace_id, elapsed = get_workspace_id(request)
-            self.assertFalse(workspace_id)
-            self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}Response from RBAC is missing 'data' key: '{{'foo': 'bar'}}'",
-                logs.output
-            )
-            ehdr = 'ERROR:advisor-log:Error: '
-            # Data not a list
-            _ = responses.add(
-                responses.GET, TEST_RBAC_V2_WKSPC,
-                json={'data': 'bar'},
-            )
-            workspace_id, elapsed = get_workspace_id(request)
-            self.assertFalse(workspace_id)
-            self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}Response from RBAC is not a list: 'bar'",
-                logs.output
-            )
-            # Data list empty
-            _ = responses.add(
+            self.assertTrue(any('Error fetching workspace from RBAC' in msg for msg in logs.output))
+
+    @responses.activate
+    @override_settings(RBAC_URL=TEST_RBAC_URL)
+    def test_get_workspace_id_empty_data(self):
+        import api.kessel as kessel_mod
+        kessel_mod.workspace_cache.clear()
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        with self.assertLogs(logger='advisor-log') as logs:
+            responses.add(
                 responses.GET, TEST_RBAC_V2_WKSPC,
                 json={'data': []},
             )
             workspace_id, elapsed = get_workspace_id(request)
             self.assertFalse(workspace_id)
             self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}Data from RBAC is empty: '[]'",
-                logs.output
-            )
-            # Data list does not contain a dictionary
-            _ = responses.add(
-                responses.GET, TEST_RBAC_V2_WKSPC,
-                json={'data': ['Foo part 2: Return of Foo']},
-            )
-            workspace_id, elapsed = get_workspace_id(request)
-            self.assertFalse(workspace_id)
-            self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}First data item from RBAC is not a dictionary: 'Foo part 2: Return of Foo'",
-                logs.output
-            )
-            # Data list dictionary does not contain an 'id' element
-            _ = responses.add(
-                responses.GET, TEST_RBAC_V2_WKSPC,
-                json={'data': [{'foo': 'bar'}]},
-            )
-            workspace_id, elapsed = get_workspace_id(request)
-            self.assertFalse(workspace_id)
-            self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}First data item from RBAC is missing 'id' key: '{{'foo': 'bar'}}'",
-                logs.output
-            )
-            # Data list dictionary does not contain an 'id' element
-            _ = responses.add(
-                responses.GET, TEST_RBAC_V2_WKSPC,
-                json={'data': [{'foo': 'bar', 'id': None}]},
-            )
-            workspace_id, elapsed = get_workspace_id(request)
-            self.assertFalse(workspace_id)
-            self.assertGreater(elapsed, 0.0)
-            self.assertIn(
-                f"{ehdr}Workspace 'default' not found in RBAC response",
-                logs.output
-            )
+            self.assertTrue(any('Error fetching workspace from RBAC' in msg for msg in logs.output))
+
+    @responses.activate
+    @override_settings(RBAC_URL=TEST_RBAC_URL)
+    def test_get_workspace_id_success(self):
+        import api.kessel as kessel_mod
+        kessel_mod.workspace_cache.clear()
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        responses.add(
+            responses.GET, TEST_RBAC_V2_WKSPC,
+            json=constants.kessel_std_workspace_response
+        )
+        workspace_id, elapsed = get_workspace_id(request)
+        self.assertEqual(workspace_id, constants.kessel_std_workspace_id)
 
     @responses.activate
     @override_settings(RBAC_URL=TEST_RBAC_URL)
     def test_workspace_id_cached(self):
+        import api.kessel as kessel_mod
+        kessel_mod.workspace_cache.clear()
         request = request_object_for_testing(auth_by=RHIdentityAuthentication)
-        # Make the first request to cache the workspace ID
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
-        # Grab the cache dict to manipulate it in testing.
-        from api import permissions
-        permissions.workspace_for_org = dict()
         workspace_id, elapsed = get_workspace_id(request)
         self.assertEqual(workspace_id, constants.kessel_std_workspace_id)
-        self.assertGreater(elapsed, 0.0)
-        # Make a second request to verify the workspace ID is cached
+        # Second call should use the SDK's cache — no additional HTTP request
         workspace_id, elapsed = get_workspace_id(request)
-        # Only one request made.
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(workspace_id, constants.kessel_std_workspace_id)
-        self.assertEqual(elapsed, 0.0)
-        self.assertEqual(len(permissions.workspace_for_org), 1)
+
+
+class JWTAuthPathTestCase(TestCase):
+    """Tests that make_rbac_request uses JWT Bearer auth when service account creds are available."""
+
+    @responses.activate
+    @override_settings(RBAC_ENABLED=True, RBAC_URL=TEST_RBAC_URL)
+    def test_make_rbac_request_jwt_sends_bearer_and_org_header(self):
+        mock_creds = MagicMock()
+        mock_creds.get_token.return_value = MagicMock(access_token='test-jwt-token')
+        mock_auth = MagicMock()
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        rbac_url = make_rbac_url("access/?application=advisor&limit=1000", rbac_base=TEST_RBAC_URL)
+
+        responses.add(responses.GET, TEST_RBAC_URL + '/api/rbac/v1/access/',
+                      json={'data': []}, status=200)
+
+        with patch('api.kessel.get_service_account_credentials', return_value=mock_creds), \
+             patch('api.kessel.service_account_auth', mock_auth):
+            response, elapsed = make_rbac_request(rbac_url, request)
+
+        self.assertEqual(response.status_code, 200)
+        sent_request = responses.calls[0].request
+        self.assertIn('x-rh-rbac-org-id', sent_request.headers)
+        self.assertIn('username=', sent_request.url)
+
+    @responses.activate
+    @override_settings(RBAC_ENABLED=True, RBAC_URL=TEST_RBAC_URL)
+    def test_make_rbac_request_identity_passthrough_when_no_creds(self):
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        rbac_url = make_rbac_url("access/?application=advisor&limit=1000", rbac_base=TEST_RBAC_URL)
+
+        responses.add(responses.GET, TEST_RBAC_URL + '/api/rbac/v1/access/',
+                      json={'data': []}, status=200)
+
+        with patch('api.kessel.get_service_account_credentials', return_value=None):
+            response, elapsed = make_rbac_request(rbac_url, request)
+
+        self.assertEqual(response.status_code, 200)
+        sent_request = responses.calls[0].request
+        self.assertIn('x-rh-identity', sent_request.headers)
+        self.assertNotIn('x-rh-rbac-org-id', sent_request.headers)
+
+    @responses.activate
+    @override_settings(RBAC_ENABLED=True, RBAC_URL=TEST_RBAC_URL)
+    def test_make_rbac_request_jwt_works_for_service_account(self):
+        mock_creds = MagicMock()
+        mock_creds.get_token.return_value = MagicMock(access_token='test-jwt-token')
+        mock_auth = MagicMock()
+        request = request_object_for_testing(
+            auth_by=RHIdentityAuthentication,
+            service_account=constants.service_account,
+        )
+        rbac_url = make_rbac_url("access/?application=advisor&limit=1000", rbac_base=TEST_RBAC_URL)
+
+        responses.add(responses.GET, TEST_RBAC_URL + '/api/rbac/v1/access/',
+                      json={'data': []}, status=200)
+
+        with patch('api.kessel.get_service_account_credentials', return_value=mock_creds), \
+             patch('api.kessel.service_account_auth', mock_auth):
+            response, elapsed = make_rbac_request(rbac_url, request)
+
+        self.assertEqual(response.status_code, 200)
+        sent_request = responses.calls[0].request
+        self.assertIn('username=', sent_request.url)
 
 
 class TestInsightsRBACPermissionKessel(TestCase):
@@ -772,7 +774,7 @@ class TestInsightsRBACPermissionKessel(TestCase):
     def test_kessel_resourcescope_host_object_permissions(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
         # Set up the various permissions objects
         request = request_object_for_testing(auth_by=RHIdentityAuthentication)

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -25,7 +25,6 @@ from rest_framework.exceptions import AuthenticationFailed
 
 from api.kessel import add_kessel_response
 from api.models import InventoryHost
-from unittest.mock import patch
 
 from api.permissions import (
     AssociatePermission, BaseAssociatePermission, BaseRedHatUserPermission,

--- a/api/advisor/api/tests/test_view_auth.py
+++ b/api/advisor/api/tests/test_view_auth.py
@@ -620,6 +620,19 @@ class GetWorkspaceIdTestCase(TestCase):
         workspace_id, elapsed = get_workspace_id(request)
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(workspace_id, constants.kessel_std_workspace_id)
+        self.assertEqual(elapsed, 0.0)
+
+    @override_settings(RBAC_URL=TEST_RBAC_URL)
+    def test_get_workspace_id_generic_exception(self):
+        import api.kessel as kessel_mod
+        kessel_mod.workspace_cache.clear()
+        request = request_object_for_testing(auth_by=RHIdentityAuthentication)
+        with patch('api.kessel.fetch_default_workspace', side_effect=ValueError("boom")), \
+             self.assertLogs(logger='advisor-log') as logs:
+            workspace_id, elapsed = get_workspace_id(request)
+        self.assertFalse(workspace_id)
+        self.assertGreater(elapsed, 0.0)
+        self.assertTrue(any('Error fetching workspace from RBAC: boom' in msg for msg in logs.output))
 
 
 class JWTAuthPathTestCase(TestCase):

--- a/api/advisor/api/tests/test_weekly_report_command.py
+++ b/api/advisor/api/tests/test_weekly_report_command.py
@@ -350,16 +350,6 @@ class WeeklyReportEmailTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0]['recipients'], ['"Test User" test-user@example.com'])
 
-        # Repeat test using Advisor PSK
-        mail.outbox = []
-        reset_last_email_at()
-        with self.settings(
-            RBAC_ENABLED=True, RBAC_URL=TEST_RBAC_URL,
-            RBAC_PSK="007", MIDDLEWARE_HOST_URL=test_middleware_url
-        ):
-            call_command('weekly_report_emails', stdout=out)
-        self.assertEqual(len(mail.outbox), 1)
-
         # Change permissions so no users have permissions on Insights - expect no emails sent
         # Test using identity headers
         global user_permissions_table
@@ -375,15 +365,6 @@ class WeeklyReportEmailTest(TestCase):
             call_command('weekly_report_emails', stdout=out)
         self.assertEqual(len(mail.outbox), 0)
 
-        mail.outbox = []
-        reset_last_email_at()
-        # Repeat test using Advisor PSK
-        with self.settings(
-            RBAC_URL=TEST_RBAC_URL, RBAC_PSK="007",
-            RBAC_ENABLED=True, MIDDLEWARE_HOST_URL=test_middleware_url
-        ):
-            call_command('weekly_report_emails', stdout=out)
-        self.assertEqual(len(mail.outbox), 0)
         user_permissions_table = former_user_permissions_table
 
         # Testing RBAC_ENABLED is set but RBAC_URL isn't - expect an exception

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -102,8 +102,6 @@ if RBAC_ENABLED:
     RBAC_URL = os.getenv('RBAC_URL')
 else:
     RBAC_URL = None
-RBAC_PSK = os.getenv("RBAC_PSK")
-RBAC_CLIENT_ID = os.getenv("RBAC_CLIENT_ID", "advisor")
 KESSEL_ENABLED = string_to_bool(os.getenv("KESSEL_ENABLED", "false"))
 # Note: tests assume that host='device under test' mean 'use the TestZedClient'.
 KESSEL_URL = os.getenv('KESSEL_URL', 'device under test')

--- a/api/advisor/tasks/tests/__init__.py
+++ b/api/advisor/tasks/tests/__init__.py
@@ -203,6 +203,7 @@ class constants(object):
 
     # Kessel permissions
     kessel_std_workspace_id = api_constants.kessel_std_workspace_id
+    kessel_std_workspace_response = api_constants.kessel_std_workspace_response
     kessel_std_org_obj = api_constants.kessel_std_org_obj
     kessel_std_user_obj = api_constants.kessel_std_user_obj
     # Kessel request check values

--- a/api/advisor/tasks/tests/test_rbac.py
+++ b/api/advisor/tasks/tests/test_rbac.py
@@ -154,7 +154,7 @@ class KesselTestCase(TestCase):
     def test_rbac_basic_allowed_full(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
 
         # Check that we can access the basic views
@@ -173,7 +173,7 @@ class KesselTestCase(TestCase):
     def test_rbac_basic_allowed_read_only(self):
         responses.add(
             responses.GET, TEST_RBAC_V2_WKSPC,
-            json={'data': [{'id': constants.kessel_std_workspace_id}]}
+            json=constants.kessel_std_workspace_response
         )
 
         # Check that we can access the basic views


### PR DESCRIPTION
Migrate all service-to-service RBAC calls from pre-shared key (PSK) authentication to OAuth2 service account JWT Bearer tokens, sharing the same credentials already used for Kessel Inventory gRPC calls.

- Add `get_service_account_credentials()` singleton in `kessel.py`, shared between Kessel gRPC and RBAC HTTP auth
- Rewrite `make_rbac_request()` to use JWT Bearer token + `x-rh-rbac-org-id` when credentials are available, preserving `x-rh-identity` passthrough when they are not (this should be effectively dead code now with #169)
- Replace manual workspace HTTP parsing in `get_workspace_id()` with kessel SDK `fetch_default_workspace()` using service account auth
- Remove `RBAC_PSK` and `RBAC_CLIENT_ID` settings entirely
- Update tests: add JWT auth path coverage, remove PSK test variants, align workspace mock responses with kessel SDK expectations

Co-Authored-By: Claude Opus 4.6

## Summary by Sourcery

Switch RBAC service-to-service authentication from PSK headers to OAuth2 service account JWTs and align workspace lookup with the Kessel SDK.

New Features:
- Introduce a shared service account credentials helper reused by both Kessel gRPC and RBAC HTTP requests.
- Add JWT-based RBAC access request handling that injects org and username context when service account auth is available.

Bug Fixes:
- Ensure workspace fetch failures from RBAC are logged consistently while preserving timing information.

Enhancements:
- Replace custom RBAC workspace REST parsing and in-process cache with Kessel SDK workspace fetching and a shared workspace cache keyed by org and workspace.
- Unify Kessel client and RBAC workspace calls on a common OAuth2 service account auth configuration.

Tests:
- Update RBAC-related tests to cover JWT auth and Kessel-based workspace responses, and remove obsolete PSK-specific scenarios.
- Add tests verifying RBAC header behavior for both service-account-authenticated and identity-pass-through requests.