### PR TITLE
fix(deps): pin authzed <1.23.0 to avoid uv-build hermetic build failure

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,7 +24,7 @@ django-stubs = "*"
 
 [packages]
 app-common-python = "*"
-authzed = "*"
+authzed = "<1.23.0"
 boto3 = "*"
 cel-python = "==0.3.0"
 django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7468524f151d1fbb91a22da550d795c75b4c7d533a33544f5c8584c9ce02a9d8"
+            "sha256": "b4aed2b2c364230cd62ecbef3886d869fdb9aa576e7143e35b5c4ce49479f105"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -58,29 +58,29 @@
         },
         "authzed": {
             "hashes": [
-                "sha256:02c9dd7ff27246a5497af484ac7af50024fdbef1814bd3dc0596e7429ae6b82e",
-                "sha256:eb427c266170787684d1202fa0aca6af7edb752489363a832cc40c6cf9e6bbf4"
+                "sha256:6745baf8f9bfb0c39cb0aa67296eeac6ea03364550b29c3c9a21218e86122df7",
+                "sha256:90662ab04b3cbd9596960d015f85402c2755dc81d0783ee3ff90e198e897043a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.10' and python_version < '4'",
-            "version": "==1.24.4"
+            "markers": "python_version >= '3.9' and python_version < '4.0'",
+            "version": "==1.22.1"
         },
         "boto3": {
             "hashes": [
-                "sha256:15544d42af8aa8f775ea636f77c9c97fbc90ff28c0e5a0d1d47c8acd9f5b1982",
-                "sha256:a3d7d7a9489c18cc9c806aca9be689677779d17ddbf919fe300146576c1bdee2"
+                "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f",
+                "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==1.43.32"
+            "version": "==1.43.36"
         },
         "botocore": {
             "hashes": [
-                "sha256:429796537fde1301df90d394808985d88cd51b36a6e769e5c12f6a6877605428",
-                "sha256:88ed52268b8f7e8ff8f9df5adbbf61e5bbb5dc618ee50de4346cabe93a482792"
+                "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d",
+                "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==1.43.32"
+            "version": "==1.43.36"
         },
         "cel-python": {
             "hashes": [
@@ -804,19 +804,28 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326",
-                "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901",
-                "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3",
-                "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a",
-                "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135",
-                "sha256:bd56799fb262994b2c2faa1799693c95cc2e22c62f56fb43af311cae45d26f0e",
-                "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3",
-                "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2",
-                "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593",
-                "sha256:f443a394af5ed23672bc6c486be138628fbe5c651ccbc536873d7da23d1868cf"
+                "sha256:36ade6ff88212e91aef4e687a971a11d7d24d6948a66751abc1b3238648f5d05",
+                "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1",
+                "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86",
+                "sha256:76e07e6567f8baf827137e8d5b8204b6c7b6488bbbff1bf0a72b383f77999c18",
+                "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda",
+                "sha256:831e2da16b6cc9d8f1654c041dd594eda43391affd3c03a91bea7f7f6da106d6",
+                "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6",
+                "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269",
+                "sha256:cb4c86de9cd8a7f3a256b9744220d87b847371c6b2f10bde87768918ef33ba49",
+                "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723",
+                "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==5.29.6"
+        },
+        "protovalidate": {
+            "hashes": [
+                "sha256:46118c1da888395c8e59bf81e5d2463129e5967ec010370fbba8252ededcba11",
+                "sha256:84238060509f97c98dfdb90dce9916b601bf10734088803e9b394c04ac34cf09"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==6.33.6"
+            "version": "==0.12.0"
         },
         "psycopg2": {
             "hashes": [
@@ -968,11 +977,11 @@
         },
         "pydantic-settings": {
             "hashes": [
-                "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de",
-                "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"
+                "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440",
+                "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==2.14.1"
+            "version": "==2.14.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -1505,116 +1514,101 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86",
-                "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd",
-                "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d",
-                "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5",
-                "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42",
-                "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de",
-                "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548",
-                "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1",
-                "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7",
-                "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59",
-                "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906",
-                "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af",
-                "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1",
-                "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d",
-                "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1",
-                "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be",
-                "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02",
-                "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42",
-                "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129",
-                "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e",
-                "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be",
-                "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e",
-                "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65",
-                "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54",
-                "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1",
-                "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5",
-                "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df",
-                "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47",
-                "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f",
-                "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf",
-                "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37",
-                "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4",
-                "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f",
-                "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84",
-                "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1",
-                "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c",
-                "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8",
-                "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e",
-                "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec",
-                "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d",
-                "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54",
-                "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890",
-                "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b",
-                "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d",
-                "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2",
-                "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33",
-                "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9",
-                "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e",
-                "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6",
-                "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce",
-                "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247",
-                "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901",
-                "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36",
-                "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69",
-                "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416",
-                "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5",
-                "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500",
-                "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad",
-                "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1",
-                "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b",
-                "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b",
-                "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a",
-                "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e",
-                "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee",
-                "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07",
-                "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a",
-                "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d",
-                "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c",
-                "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343",
-                "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4",
-                "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2",
-                "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8",
-                "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf",
-                "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb",
-                "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c",
-                "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff",
-                "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e",
-                "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550",
-                "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860",
-                "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793",
-                "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f",
-                "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851",
-                "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7",
-                "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332",
-                "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b",
-                "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2",
-                "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d",
-                "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a",
-                "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef",
-                "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474",
-                "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee",
-                "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43",
-                "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034",
-                "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3",
-                "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c",
-                "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d",
-                "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7",
-                "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e",
-                "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d",
-                "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4",
-                "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9",
-                "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52",
-                "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a",
-                "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c",
-                "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253",
-                "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c"
+                "sha256:0096fd7559178f0cc9cf088f2dbd2a02ef85bacaa69732c633517286b4494610",
+                "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26",
+                "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965",
+                "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a",
+                "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd",
+                "sha256:1551b4caac3e3ec9f2bfcec6bf3776e01c0edbdd2e240431a50ca1a1aac72c27",
+                "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd",
+                "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f",
+                "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5",
+                "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c",
+                "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e",
+                "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a",
+                "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b",
+                "sha256:2e41fd3aab806770008279a93879b0924b16247e09ab537c043d08bbca53b4ab",
+                "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37",
+                "sha256:360bec1f58e7243e3405d3bdf7a1a8115aa9b448d54dc7cd6f7b7e0e9406b62e",
+                "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda",
+                "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845",
+                "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24",
+                "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027",
+                "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92",
+                "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c",
+                "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977",
+                "sha256:4d310baf69a4fbe8a098ce727e4808a34866ac718a6f759ae659cbd3221358bc",
+                "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889",
+                "sha256:583d50d59142f8549470bd6390471d0fe8b8c8d69d6a0f28ac71e05380cef640",
+                "sha256:5952f8c1bda2a5347154450379316e6dfa4d934d62ca35f6784451e6f55074fb",
+                "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf",
+                "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc",
+                "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5",
+                "sha256:6197e5a00183c11a8ce7c6abd18be1a9189fd8399084ffc95196f4f0db4f2137",
+                "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727",
+                "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f",
+                "sha256:64b2055bb6e0dc945af35cdeceb3633e6ed9273475ef3af85592410fd6803803",
+                "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f",
+                "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9",
+                "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0",
+                "sha256:74fdd718d88fe144f4579b8747873a07ec3f04cb837d5faec5a25d9e22fa31a8",
+                "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc",
+                "sha256:7dfe427045520d6abca33687dfef767b4f635015893a1816c5decb12eb72ce18",
+                "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d",
+                "sha256:830c1fca669c572dec37ce9c838224ee45aac5be0f6961edf871e82e49d6537c",
+                "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949",
+                "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed",
+                "sha256:8ac012839ff7e396030f1e94e10553a431d14e4de2ab65cb3acb72bbd5628ca2",
+                "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336",
+                "sha256:8cf0f2509acb4619e2471a1951089054dd58ebea7a912066d2ea56dd4c24ca4a",
+                "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205",
+                "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3",
+                "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665",
+                "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73",
+                "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501",
+                "sha256:9a3f142070eb7b82fc4085a55d887396f9c4e21250bccebe2ba22502c45b9647",
+                "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e",
+                "sha256:a090cbf9521e78ffdb2fcf448b72902afe9f5923ff6a12d5c0d0120200348af9",
+                "sha256:a2335ea5fed26af2e831094964fa3f8fae60b45f7e37fcc2d3b615b2add3ad87",
+                "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7",
+                "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5",
+                "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3",
+                "sha256:a64caee2193563601dbaaa55fe2dcf597debef04a2f8f1fa8a07aa4bb7ac7a1e",
+                "sha256:ac082660de8f429ba0ea363595abb838998570b9a7546777c60f413ab902bbde",
+                "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994",
+                "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784",
+                "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498",
+                "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7",
+                "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de",
+                "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388",
+                "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce",
+                "sha256:c66f9f9d4f1e9712eb9b1de5310f881d4e2188cfcba5065e1a8490f38687f2c4",
+                "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c",
+                "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef",
+                "sha256:cc96aa922e21d4bc5d5ed3c915cef27dfcbc13686f47d5e378d647fbfba655a2",
+                "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f",
+                "sha256:d48400185564042287dc487c1f016a3397f18ab4f4c5d5ec36edc218f7ffa35b",
+                "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891",
+                "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635",
+                "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb",
+                "sha256:e0bb8a6bc7015efdf8a928753b25da1b9ca2d6f24ef04d2ee0688e486f32aae7",
+                "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5",
+                "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d",
+                "sha256:e574801e1d643561594aa021206c46d80b257e9853087090ba97bed8b0a509d3",
+                "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150",
+                "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35",
+                "sha256:eadea7aba74e40adee867a8c0eec17b820b061d308a4b014f7a0e118c2b0aa61",
+                "sha256:ed68faa5e85de2f3e400bc3f122e5c82735a58c8bb24b9f63a2215954ba17b2d",
+                "sha256:f0a47095963cfe054e0df178daca95aec21e680d6076da807c3add28dfe920f7",
+                "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a",
+                "sha256:f82b6bb7d75a2613e85d07cefa3a8c973d0544a8993337f6e2728e4a1e94c305",
+                "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027",
+                "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8",
+                "sha256:fbb8c3a98e779013786ae01d229662aeacbc77100efbd3f2f245219ace5af700"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==7.14.1"
+            "version": "==7.14.3"
         },
         "decorator": {
             "hashes": [
@@ -1635,20 +1629,20 @@
         },
         "django-stubs": {
             "hashes": [
-                "sha256:7742b8e60afc68a8545158e2bdb103376d5a092f7902c17f370920a9c08eb957",
-                "sha256:9fb9eede9b2fc47b36c3dc4a93652eb959dff45466ec4a580e4a22782192d746"
+                "sha256:c488fea05a9eac40ddbdc69887f63a5c0922cb13df285291ee99c9bbc89bc4f1",
+                "sha256:dfc01e052e33c7f8f0c30c3ff8eda0903ee29ac710d1e46d9effd773744a69b0"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==6.0.5"
+            "version": "==6.0.6"
         },
         "django-stubs-ext": {
             "hashes": [
-                "sha256:1cc325e991303849bce70e19748981b225ef08b37256f263e113caf97cd3bcc0",
-                "sha256:a9932c8233d6dd4e34ae0b192026379c1a9be8f0b7c27aa1fa09ae215169773e"
+                "sha256:5470c970f61a3ccf5aae7633feef1a097f944f417b955da200c9ac26ecd9134b",
+                "sha256:e6f09884e48d7c5b250a373dfa22aa3e83bb91b8babbd8d05187f6b92247f232"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==6.0.5"
+            "version": "==6.0.6"
         },
         "drf-spectacular-sidecar": {
             "hashes": [
@@ -1960,12 +1954,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c",
-                "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"
+                "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313",
+                "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==9.1.0"
+            "version": "==9.1.1"
         },
         "pytest-cov": {
             "hashes": [


### PR DESCRIPTION
## Summary

authzed >= 1.23.0 switched its build backend from `poetry-core` to `uv-build`.
`uv-build` sdists ship with stale `Cargo.lock` files that fail hermeto's strict
`cargo vendor --locked` validation during Konflux prefetch, breaking hermetic builds.

Pin authzed to `<1.23.0` so the resolver stays on 1.22.1 (the latest version still
using `poetry-core`), keeping hermetic builds functional on foreman-3.16.

## Changes

- `Pipfile`: `authzed = "*"` → `authzed = "<1.23.0"`
- `Pipfile.lock`: regenerated (authzed 1.24.4 → 1.22.1, minor resolution shifts
  in protobuf, boto3, botocore, pydantic-settings)

## Context

foreman-3.18 is unaffected — authzed was removed entirely in favor of `kessel-sdk`
(PR #42, synced via PR #140). The Kessel SDK migration was intentionally not
backported to foreman-3.16 (PR #74 discussion).

## Summary by Sourcery

Pin the authzed dependency below version 1.23.0 and regenerate Pipfile.lock to maintain hermetic builds on the existing stack.

Build:
- Update Pipfile to constrain authzed to versions <1.23.0 to avoid uv-build-related hermetic build failures.

Chores:
- Regenerate Pipfile.lock to reflect the new authzed constraint and associated dependency resolution changes.