### PR TITLE
fix: commit transaction after managed index creation

### DIFF
--- a/api/advisor/api/scripts/partitioned_table_index_helper.py
+++ b/api/advisor/api/scripts/partitioned_table_index_helper.py
@@ -81,7 +81,8 @@ def _create_partitioned_table_index_managed(
 
     db_connection = connections['default']
     db_connection.ensure_connection()
-    db_connection.connection.commit()
+    original_autocommit = db_connection.get_autocommit()
+
     db_connection.set_autocommit(True)
     try:
         with db_connection.cursor() as cursor:
@@ -93,14 +94,16 @@ def _create_partitioned_table_index_managed(
                     f'CREATE {unique_clause}INDEX CONCURRENTLY IF NOT EXISTS {partition_index_name} '
                     f'ON {qualified_partition} {index_definition};'
                 )
-    finally:
-        db_connection.set_autocommit(False)
 
-    _wait_for_concurrent_indexes()
-    _execute_sql(
-        f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
-        f'ON {qualified_table} {index_definition};'
-    )
+        _wait_for_concurrent_indexes()
+
+        with db_connection.cursor() as cursor:
+            cursor.execute(
+                f'CREATE {unique_clause}INDEX IF NOT EXISTS {index_name} '
+                f'ON {qualified_table} {index_definition};'
+            )
+    finally:
+        db_connection.set_autocommit(original_autocommit)
 
 def create_partitioned_table_index(
     table_name: str,


### PR DESCRIPTION
## Summary

The managed mode path in `_create_partitioned_table_index_managed` left `autocommit=False` with an open transaction after creating the last parent index. The subsequent `django_migrations` INSERT went into this uncommitted transaction and was rolled back when the connection closed, causing Django to re-run the migration on every deploy.

### Root cause

In the managed code path (`MIGRATION_MODE=managed`, used in prod):

1. `set_autocommit(True)` is called for `CREATE INDEX CONCURRENTLY` on partitions
2. `set_autocommit(False)` in the `finally` block starts an implicit transaction
3. The parent index and `_wait_for_concurrent_indexes()` execute inside that transaction
4. The function returns **without committing**

When multiple indexes are created sequentially, the *next* call's `connection.commit()` at the top commits the *previous* call's work. But the **last** call's transaction is never committed — including the `django_migrations` record that Django inserts afterward.

This only affects production (`MIGRATION_MODE=managed`). Stage uses `automated` mode which doesn't toggle autocommit.

### Fix

Restructured to keep `autocommit=True` for the entire function body (partition indexes, wait, and parent index creation), with save/restore of the original autocommit state in a `finally` block. Each statement now auto-commits immediately, eliminating the possibility of dangling transactions.

## Test plan

- [ ] Run `pipenv run testapi` locally to verify no regressions
- [ ] Deploy to prod and verify `django_migrations` record for 0046 is persisted
- [ ] Confirm `idx_advisor_inventory_host_host_type` parent index is created on the parent table