### PR TITLE
Add migration debugging to container_init scripts

### DIFF
--- a/container_init.sh
+++ b/container_init.sh
@@ -35,11 +35,17 @@ else
 fi
 set -u
 
+echo "Initializing/updating database environment ..."
 if [ "${ENABLE_INIT_CONTAINER_MIGRATIONS,,}" == "true" ]; then
-    echo "Running database migrations ..."
-    pipenv run python api/advisor/manage.py migrate --noinput
+    echo "Showing database migrations for api and tasks ..."
+    pipenv run python api/advisor/manage.py showmigrations --traceback --verbosity=3 api tasks
+    echo "Running all database migrations ..."
+    pipenv run python api/advisor/manage.py migrate --traceback --noinput --verbosity=3
+    echo "After migrations applied ..."
+    pipenv run python api/advisor/manage.py showmigrations --traceback --verbosity=3 api tasks
 fi
 # Note: don't load data which is loaded by content import - e.g. resolution_risks
+echo "Loading basic fixtures ..."
 pipenv run python api/advisor/manage.py loaddata --verbosity=3 rulesets rule_categories system_types upload_sources
 
 if [ "${ADVISOR_ENV}" != 'dev' ]; then

--- a/container_init_localdev.sh
+++ b/container_init_localdev.sh
@@ -20,9 +20,16 @@
 # -u: Treat unset variables and parameters as failures.
 set -eu -o pipefail
 
-echo "Running database migrations ..."
+echo "Initializing/updating local development database environment ..."
 # podman-compose ensures the advisor-db service is running first
-pipenv run python api/advisor/manage.py migrate --noinput
+echo "Showing database migrations for api and tasks ..."
+pipenv run python api/advisor/manage.py showmigrations --traceback --verbosity=3 api tasks
+echo "Running all database migrations ..."
+pipenv run python api/advisor/manage.py migrate --traceback --noinput --verbosity=3
+echo "After migrations applied ..."
+pipenv run python api/advisor/manage.py showmigrations --traceback --verbosity=3 api tasks
+
+echo "Loading basic fixtures ..."
 pipenv run python api/advisor/manage.py loaddata --verbosity=3 rulesets rule_categories system_types upload_sources
 
 echo "Loading production fixtures for tasks and pathways ..."


### PR DESCRIPTION
## Summary by Sourcery

Add more verbose database initialization and migration logging to container initialization scripts for local development and other environments.

Enhancements:
- Show pending and applied migrations for the api and tasks apps before and after running migrations in container initialization scripts.
- Increase migration command verbosity and include traceback options to aid debugging during container startup.
- Log explicit steps for initializing/updating databases and loading basic fixtures in both local and non-local container init scripts.