### PR TITLE
Make basic_task_test_data fixture host groups consistent with the basic_test_data api fixture

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -914,9 +914,10 @@ required for Kessel mode to grant access to most endpoints.
 
 To allow users access to extra workspaces (host groups) containing specific hosts, add those group UUIDs:
 ```bash
-python api/advisor/manage.py mock_rbac --kessel --host-groups "00000000-0000-0000-0000-000000000000,<test_group_uuid>"
+python api/advisor/manage.py mock_rbac --kessel --host-groups "00000000-0000-0000-0000-000000000000,<group_1_uuid>,<group_2_uuid>,<test_group_uuid>"
 ```
-... with `<test_group_uuid>` being the UUID of the host group containing the host we fake uploaded earlier.
+... with `<group_1_uuid>` being the UUID of `group_1` from the `basic_test_data` fixture
+and `<test_group_uuid>` being the UUID of the host group containing the host we fake uploaded earlier.
 
 #### Inspecting the gRPC server with grpcurl
 

--- a/api/advisor/tasks/fixtures/basic_task_test_data.json
+++ b/api/advisor/tasks/fixtures/basic_task_test_data.json
@@ -7,8 +7,8 @@
       "display_name": "system01.example.com",
       "tags": [],
       "groups": [{
-        "id": "00112233-4455-6677-8899-010101010101",
-        "name": "group01"
+        "id": "11111111-1111-1111-1111-111111111111",
+        "name": "group_1"
       }],
       "created": "2020-01-01T06:00:00Z",
       "updated": "2018-12-04T05:15:38Z",
@@ -48,7 +48,10 @@
       "org_id": "9876543",
       "display_name": "system03.example.com",
       "tags": [],
-      "groups": [],
+      "groups": [{
+        "id": "11111111-1111-1111-1111-222222222222",
+        "name": "group_2"
+      }],
       "created": "2020-01-01T06:00:00Z",
       "updated": "2018-09-22T02:00:51Z",
       "last_check_in": "2018-12-10T23:32:13Z",

--- a/api/advisor/tasks/tests/test_system_views.py
+++ b/api/advisor/tasks/tests/test_system_views.py
@@ -126,7 +126,7 @@ class SystemViewTestCase(TestCase):
         self.assertIn('tags', data[3])
         self.assertEqual(data[3]['tags'], [])
         self.assertIn('groups', data[3])
-        self.assertEqual(data[3]['groups'][0]['name'], 'group01')
+        self.assertEqual(data[3]['groups'][0]['name'], 'group_1')
         self.assertIn('updated', data[3])
         self.assertEqual(data[3]['updated'], '2018-12-04T05:15:38Z')
         self.assertIn('last_check_in', data[3])
@@ -351,7 +351,7 @@ class SystemViewTestCase(TestCase):
         self.assertEqual(data[1]['id'], constants.host_e1_uuid)
 
         # Host group filtering - a group with a matching system
-        res = self.client.get(reverse('tasks-system-list'), data={'groups': 'group01'}, **self.std_auth)
+        res = self.client.get(reverse('tasks-system-list'), data={'groups': 'group_1'}, **self.std_auth)
         self.assertEqual(res.status_code, 200, res.content.decode())
         data = res.json()['data']
         self.assertEqual(len(data), 1)
@@ -500,7 +500,7 @@ class SystemViewTestCase(TestCase):
         self.assertEqual(data['os_version'], 'RHEL 7.5')
         self.assertIn('groups', data)
         self.assertEqual(sorted(data['groups'][0].keys()), ['id', 'name'])
-        self.assertEqual(data['groups'][0]['name'], 'group01')
+        self.assertEqual(data['groups'][0]['name'], 'group_1')
         self.assertIn('connection_type', data)
         self.assertEqual(data['connection_type'], 'direct')
         self.assertIn('last_check_in', data)

--- a/api/advisor/tasks/tests/test_task_views.py
+++ b/api/advisor/tasks/tests/test_task_views.py
@@ -388,24 +388,24 @@ class TaskViewTestCase(TestCase):
         # Test filtering log4shell systems on matching host group
         res = self.client.get(
             reverse('tasks-task-systems', kwargs={'slug': 'log4shell'}),
-            data={'groups': 'group01'},
+            data={'groups': 'group_1'},
             **self.std_auth)
         self.assertEqual(res.status_code, 200, res.content.decode())
         hosts = res.json()['data']
         self.assertEqual(len(hosts), 1)
         self.assertEqual(hosts[0]['display_name'], constants.host_01_name)
-        self.assertEqual(hosts[0]['groups'][0]['name'], 'group01')
+        self.assertEqual(hosts[0]['groups'][0]['name'], 'group_1')
 
         # Test filtering log4shell systems on matching host group & display name
         res = self.client.get(
             reverse('tasks-task-systems', kwargs={'slug': 'log4shell'}),
-            data={'groups': 'group01', 'display_name': 'system01'},
+            data={'groups': 'group_1', 'display_name': 'system01'},
             **self.std_auth)
         self.assertEqual(res.status_code, 200, res.content.decode())
         hosts = res.json()['data']
         self.assertEqual(len(hosts), 1)
         self.assertEqual(hosts[0]['display_name'], constants.host_01_name)
-        self.assertEqual(hosts[0]['groups'][0]['name'], 'group01')
+        self.assertEqual(hosts[0]['groups'][0]['name'], 'group_1')
 
         # Test filtering log4system systems on non-matching host group & display name
         res = self.client.get(
@@ -626,7 +626,7 @@ class TaskViewTestCase(TestCase):
         # system01 is RHEL6 so doesn't meet the requirements of being RHEL7 or 8
         self.assertEqual(hosts[2]['display_name'], constants.host_01_name)
         self.assertEqual(hosts[2]['requirements'], [OS_V7_V8_REQ])
-        self.assertEqual(hosts[2]['groups'][0]['name'], 'group01')
+        self.assertEqual(hosts[2]['groups'][0]['name'], 'group_1')
         self.assertEqual(hosts[2]['connection_type'], 'direct')
         # edge01 is RHEL9 so doesn't meet the requirements of being RHEL7 or 8
         self.assertEqual(hosts[6]['display_name'], constants.host_e1_name)


### PR DESCRIPTION
…ic_test_data api fixture

## Summary by Sourcery

Align host group naming in tests and documentation with the basic_task_test_data fixture

Enhancements:
- Clarify mock RBAC host group examples by including multiple group UUIDs tied to fixture data

Documentation:
- Update README instructions to reference specific fixture host groups for mock RBAC setup

Tests:
- Update task and system view tests to use the new host group name and ensure filtering expectations match