### PR TITLE
fix(RHINENG-28055): Increase gunicorn header field size to 16k

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -105,9 +105,10 @@ You can also run Advisor from the host.  Here's how ...
     ```
     - or via gunicorn:
     ```bash
-    $ ./app.sh
-    [2018-06-21 14:30:23 -0400] [31722] [INFO] Starting gunicorn 19.8.1
-    [2018-06-21 14:30:23 -0400] [31722] [INFO] Listening at: http://0.0.0.0:8000 (31722)
+    $ api/app_localdev.sh
+    ...
+    [11:25:52] INFO ... Starting gunicorn 26.0.0
+    [11:25:52] INFO ... Listening at: http://0.0.0.0:8000 (1577131)
     ...
     ```
 

--- a/api/app.sh
+++ b/api/app.sh
@@ -50,6 +50,7 @@ else
     GUNICORN_CONF=${GUNICORN_CONF:-gunicorn_conf.py}
     BIND_ADDR="0.0.0.0:${GUNICORN_PORT:-8000}"
     TIMEOUT=${GUNICORN_TIMEOUT:-120}
+    LIMIT_REQUEST_FIELD_SIZE=${GUNICORN_LIMIT_REQUEST_FIELD_SIZE:-16384} # Use 16k to avoid 431 errors
 
     export PYTHONPATH=${APP_HOME}
     export PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-/metrics}
@@ -59,7 +60,13 @@ else
     # not in that directory the import fails.  So we 'cd' first, then the
     # --chdir option is no longer needed and the config imports work.
     cd ${APP_HOME}
-    CMD="pipenv run gunicorn --preload --config ${GUNICORN_CONF} --bind ${BIND_ADDR} --timeout ${TIMEOUT} ${APP_MODULE}"
+    CMD="pipenv run gunicorn
+      --preload
+      --config ${GUNICORN_CONF}
+      --bind ${BIND_ADDR}
+      --timeout ${TIMEOUT}
+      --limit-request-field_size ${LIMIT_REQUEST_FIELD_SIZE}
+      ${APP_MODULE}"
 fi
 
 echo "Running ${CMD} ..."

--- a/api/app_localdev.sh
+++ b/api/app_localdev.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2016-2024 the Advisor Backend team at Red Hat.
+# This file is part of the Insights Advisor project.
+
+# Insights Advisor is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+
+# Insights Advisor is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along
+# with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
+
+APP_HOME=${APP_HOME:-api/advisor}
+APP_MODULE=${APP_MODULE:-project_settings.wsgi}
+GUNICORN_CONF=${GUNICORN_CONF:-gunicorn_conf.py}
+BIND_ADDR="0.0.0.0:${GUNICORN_PORT:-8000}"
+TIMEOUT=${GUNICORN_TIMEOUT:-120}
+LIMIT_REQUEST_FIELD_SIZE=${GUNICORN_LIMIT_REQUEST_FIELD_SIZE:-16384} # Use 16k to avoid 431 errors
+
+export PYTHONPATH=${APP_HOME}
+cd ${APP_HOME}
+CMD="pipenv run gunicorn
+  --preload
+  --config ${GUNICORN_CONF}
+  --bind ${BIND_ADDR}
+  --timeout ${TIMEOUT}
+  --limit-request-field_size ${LIMIT_REQUEST_FIELD_SIZE}
+  ${APP_MODULE}"
+
+echo "Running ${CMD} ..."
+exec ${CMD}


### PR DESCRIPTION
## Summary by Sourcery

Increase Gunicorn request header field size and add a dedicated local development startup script.

New Features:
- Add a local development script to run the API via Gunicorn with standardized configuration.

Enhancements:
- Configure Gunicorn to use a 16KB request header field size by default to reduce HTTP 431 errors.
- Update README instructions and example output to reference the new local development script and current Gunicorn logging format.