### PR TITLE
feat(RHINENG-27091): update workload filtering logic to OR

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -313,6 +313,7 @@ def filter_multi_param(
     provide an OpenAPI 'Parameter' object to include in the parameter spec.
     """
     end_filter = Q()
+    workload_presence_filters = []
     # Prefix, one or more square-bracketed words, and an optional '[]'
     fre = re.compile(r'^(?P<prefix>\w+)(?P<brackets>(?:\[\w+\])+)(?:\[\])?$')
     comparator_translations = {
@@ -352,6 +353,16 @@ def filter_multi_param(
                 filter_parts = [filter_prefix, 'workloads', 'sap', 'sids'] + filter_parts[2:]
             elif field_name in ('ansible', 'mssql'):
                 filter_parts = [filter_prefix, 'workloads'] + filter_parts[1:]
+
+        # Workload presence checks are ORed together; all other filters are ANDed.
+        # Covers: nil/not_nil on any top-level workload, and the legacy sap_system boolean
+        # (which redirects to workloads.sap.sap_system and represents SAP host presence).
+        is_workload_presence = (
+            filter_prefix == 'system_profile' and
+            len(filter_parts) == 4 and
+            filter_parts[1] == 'workloads' and
+            (filter_parts[3] in ('not_nil', 'nil') or filter_parts[3] == 'sap_system')
+        )
 
         # Keep the filter prefix here though
         operator = filter_parts[-1]
@@ -410,8 +421,17 @@ def filter_multi_param(
             # Invert Q sense if `__ne`.
             if filter_not_equal:
                 this_filter = ~this_filter
-            # Add it to the expression
-            end_filter = end_filter & this_filter
+            # Workload presence checks are ORed; everything else is ANDed.
+            if is_workload_presence:
+                workload_presence_filters.append(this_filter)
+            else:
+                end_filter = end_filter & this_filter
+
+    if workload_presence_filters:
+        or_q = workload_presence_filters[0]
+        for f in workload_presence_filters[1:]:
+            or_q |= f
+        end_filter &= or_q
 
     return end_filter
 
@@ -508,8 +528,16 @@ filter_system_profile_rhel_ai_query_param = OpenApiParameter(
     required=False, type=OpenApiTypes.BOOL,
 )
 
+
+filter_system_profile_sap_query_param = OpenApiParameter(
+    name='filter[system_profile][workloads][sap][not_nil]', location=OpenApiParameter.QUERY,
+    description='Does this system have a SAP workload?',
+    required=False, type=OpenApiTypes.BOOL,
+)
+
 workload_filter_query_params = [
     filter_system_profile_sap_system_query_param,
+    filter_system_profile_sap_query_param,
     filter_system_profile_mssql_query_param,
     filter_system_profile_ansible_query_param,
     filter_system_profile_crowdstrike_query_param,

--- a/api/advisor/api/tests/test_parameter_parsing.py
+++ b/api/advisor/api/tests/test_parameter_parsing.py
@@ -690,20 +690,20 @@ class MultiParamParsingTestCase(TestCase):
 
     def test_multiple_parameters(self):
         # Both parameters match the filter prefix
-        rq = self._make_request_obj('filter[system_profile][sap_system]', 'true')
+        rq = self._make_request_obj('filter[system_profile][arch][nil]', 'true')
         rq.query_params['filter[system_profile][bios_vendor][nil]'] = 'true'
         # Note that AND comparisons on Q objects are order dependent.
         self.assertEqual(
             filter_multi_param(rq, 'system_profile'),
-            Q(system_profile__workloads__sap__sap_system=True) & Q(system_profile__bios_vendor__isnull=True)
+            Q(system_profile__arch__isnull=True) & Q(system_profile__bios_vendor__isnull=True)
         )
         # One parameter doesn't match the filter prefix, the other does
-        rq = self._make_request_obj('filter[system_profile][sap_system]', 'true')
+        rq = self._make_request_obj('filter[system_profile][arch][nil]', 'true')
         rq.query_params['filter[facts][bios_vendor][nil]'] = 'true'
         # Note that AND comparisons on Q objects are order dependent.
         self.assertEqual(
             filter_multi_param(rq, 'system_profile'),
-            Q(system_profile__workloads__sap__sap_system=True)
+            Q(system_profile__arch__isnull=True)
         )
 
     _NEW_WORKLOADS = ('crowdstrike', 'ibm_db2', 'intersystems', 'oracle_db', 'rhel_ai')

--- a/api/advisor/api/tests/test_workloads_field_redirection.py
+++ b/api/advisor/api/tests/test_workloads_field_redirection.py
@@ -129,8 +129,13 @@ class WorkloadsFieldRedirectionTestCase(TestCase):
         self.assertEqual(actual_system_uuids, expected_mssql_systems)
 
     def test_multiple_workloads_fields_new_schema(self):
-        """Test multiple workloads fields together through API."""
-        # Test SAP + Ansible combination
+        """Test SAP (sap_system=true) + Ansible (not_nil) combination uses OR.
+
+        Both are workload presence checks and are ORed together:
+        - sap_system=true: host_01, host_04, host_05, host_e1
+        - ansible not_nil: host_03, host_05
+        OR result: host_01, host_03, host_04, host_05, host_e1
+        """
         response = self.client.get(
             reverse('system-list'),
             data={
@@ -143,13 +148,71 @@ class WorkloadsFieldRedirectionTestCase(TestCase):
         systems = json_data['data']
 
         self.assertIsInstance(systems, list)
-        # Expect exactly 1 system with both SAP and Ansible workloads
-        expected_combined_systems = {constants.host_05_uuid}
+        expected_combined_systems = {
+            constants.host_01_uuid, constants.host_03_uuid,
+            constants.host_04_uuid, constants.host_05_uuid,
+            constants.host_e1_uuid,
+        }
         actual_system_uuids = {system['system_uuid'] for system in systems}
 
-        self.assertEqual(len(systems), 1)
-        self.assertEqual(json_data['meta']['count'], 1)
         self.assertEqual(actual_system_uuids, expected_combined_systems)
+        self.assertEqual(json_data['meta']['count'], len(expected_combined_systems))
+
+    def test_sap_system_param_ored_with_other_workloads(self):
+        """Legacy sap_system=true param participates in OR with other not_nil workloads.
+
+        sap_system=true: host_01, host_04, host_05, host_e1
+        oracle_db not_nil: host_06 (oracle_db host, sap_system=false)
+        OR result: host_01, host_04, host_05, host_06, host_e1
+        host_06 only appears because of oracle_db — confirms OR, not AND.
+        """
+        response = self.client.get(
+            reverse('system-list'),
+            data={
+                'filter[system_profile][sap_system]': 'true',
+                'filter[system_profile][workloads][oracle_db][not_nil]': 'true',
+            },
+            **auth_header_for_testing()
+        )
+        json_data = self._response_is_good(response)
+        systems = json_data['data']
+
+        self.assertIsInstance(systems, list)
+        expected_systems = {
+            constants.host_01_uuid, constants.host_04_uuid,
+            constants.host_05_uuid, constants.host_06_uuid,
+            constants.host_e1_uuid,
+        }
+        actual_system_uuids = {system['system_uuid'] for system in systems}
+
+        self.assertEqual(actual_system_uuids, expected_systems)
+        self.assertEqual(json_data['meta']['count'], len(expected_systems))
+
+    def test_multiple_not_nil_workloads_ored(self):
+        """Multiple not_nil workload filters are ORed, returning hosts with any of them.
+
+        ansible: host_03, host_05
+        ibm_db2: host_03
+        OR result: host_03 (has ibm_db2), host_05 (has ansible)
+        AND result would be: host_03 only (has both) — but we expect OR here.
+        """
+        response = self.client.get(
+            reverse('system-list'),
+            data={
+                'filter[system_profile][ansible][not_nil]': 'true',
+                'filter[system_profile][workloads][ibm_db2][not_nil]': 'true',
+            },
+            **auth_header_for_testing()
+        )
+        json_data = self._response_is_good(response)
+        systems = json_data['data']
+
+        self.assertIsInstance(systems, list)
+        expected_systems = {constants.host_03_uuid, constants.host_05_uuid}
+        actual_system_uuids = {system['system_uuid'] for system in systems}
+
+        self.assertEqual(actual_system_uuids, expected_systems)
+        self.assertEqual(json_data['meta']['count'], len(expected_systems))
 
     def test_non_workloads_fields_unaffected(self):
         """Test that non-workloads fields work normally through API."""


### PR DESCRIPTION
**Workload filtering: switch from AND to OR logic**

Passing multiple workload filters now returns hosts with any of the selected workloads (union), not all (intersection) - this aligns with how the inventory backend (HBI) handles workload presence checks. Non-workload filters (arch, OS version, SAP SIDs, etc.) continue to be ANDed as before.
  

Part of [RHINENG-25895](https://redhat.atlassian.net/browse/RHINENG-25895), Phase 1 (Introduce a consistent “Workload” filter in Inventory-backed application UIs to replace reliance on the Global Filter ahead of its decommissioning.).

[RHINENG-25895]: https://redhat.atlassian.net/browse/RHINENG-25895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update workload filtering to treat multiple workload presence checks as an OR group while keeping other filters ANDed, and extend tests and API schema to cover the new behavior and SAP workload query parameter.

New Features:
- Add a dedicated query parameter for checking SAP workload presence via system_profile.workloads.sap.not_nil.

Enhancements:
- Change workload presence filters (including legacy sap_system) to be ORed together instead of ANDed, aligning API behavior with backend workload semantics.
- Adjust parameter parsing expectations and workload tests to reflect the new OR-based workload filtering logic.

Tests:
- Expand workload filter tests to cover OR behavior across multiple workloads and interaction between legacy sap_system and new workload filters.