### PR TITLE
fix(RHINENG-28754): Add custom inventory prometheus metrics to Django metrics

### DIFF
--- a/api/advisor/api/apps.py
+++ b/api/advisor/api/apps.py
@@ -19,3 +19,7 @@ from django.apps import AppConfig
 
 class ApiConfig(AppConfig):
     name = 'api'
+
+    def ready(self):
+        # include additional metrics from prometheus.py
+        import prometheus  # noqa: F401

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -65,6 +65,7 @@ TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'
 
 _DEFAULT_ALLOWED_HOSTS = ",".join([
     'testserver', 'insights-advisor-api', 'advisor-api', 'localhost', '127.0.0.1',
+    'host.containers.internal',
     '.insights.openshiftapps.com', '.svc.cluster.local'
 ])
 

--- a/api/advisor/prometheus.py
+++ b/api/advisor/prometheus.py
@@ -16,98 +16,26 @@
 # You should have received a copy of the GNU General Public License along
 # with Insights Advisor. If not, see <https://www.gnu.org/licenses/>.
 
-from django.conf import settings
-from prometheus_client import start_http_server, Counter, Enum, Gauge, Histogram, Info
+from prometheus_client import Counter
 
 # Prometheus configuration
-INSIGHTS_ADVISOR_UP = Gauge('insights_advisor_service_up', 'Insights Advisor Service Up')
-INSIGHTS_ADVISOR_STATUS = Enum(
-    'insights_advisor_service_status',
-    'Current Status of Advisor Service',
-    states=['initialized', 'starting', 'running', 'stopped']
-)
-INSIGHTS_ADVISOR_TOTAL_REQUESTS = Counter(
-    'insights_advisor_service_total_requests',
-    'Total Number of Received Requests'
-)
-INSIGHTS_ADVISOR_SUCCESSFUL_REQUESTS = Counter(
-    'insights_advisor_service_successful_requests',
-    'Total Number of Successful Requests'
-)
-INSIGHTS_ADVISOR_MISSING_CONTENT = Counter(
-    'insights_advisor_missing_content',
-    'Number of reports we tried processing but failed to find rule content for'
-)
-INSIGHTS_ADVISOR_DB_ERRORS = Counter(
-    'insights_advisor_db_errors',
-    'Total number of DB errors that have occurred'
-)
-INSIGHTS_ADVISOR_SERVICE_DB_ELAPSED = Histogram(
-    'insights_advisor_service_db_elapsed',
-    'Total time spent processing db calls for an archive'
-)
-THIRD_PARTY_RULE_HIT_REQUEST_RECEIVED = Counter(
-    'insights_advisor_service_third_party_rule_hit_request_received',
-    'A request that is received for a rule hit from a third party'
-)
-INSIGHTS_ADVISOR_SERVICE_HANDLE_ENGINE_RESULTS = Histogram(
-    'insights_advisor_service_handle_engine_results',
-    'Total time spent processing results received from the shared engine'
-)
-INSIGHTS_ADVISOR_SERVICE_RULE_HITS_ELAPSED = Histogram(
-    'insights_advisor_service_rule_hits_elapsed',
-    'Total time spent processing third party rule hits'
-)
-INSIGHTS_ADVISOR_SERVICE_WEBHOOK_EVENTS_ELAPSED = Histogram(
-    'insights_advisor_service_webhook_events_elapsed',
-    'Total time spent processing webhook events'
-)
-THIRD_PARTY_RULE_HIT_MISSING_KEYS = Counter(
-    'insights_advisor_service_rule_hits_missing_keys',
-    'Counter for how many rule hit requests are malformed, missing keys'
-)
-INVENTORY_EVENTS_TOPIC_RECEIVED = Counter(
-    'insights_advisor_service_inventory_event_received',
-    'A request that is received from the inventory service'
-)
-INSIGHTS_ADVISOR_SERVICE_INVENTORY_EVENTS_ELAPSED = Histogram(
-    'insights_advisor_service_inventory_events_elapsed',
-    'Total time spent processing an inventory event'
-)
-
 INVENTORY_EVENT_MISSING_KEYS = Counter(
-    'insights_advisor_service_inventory_event_missing_keys',
+    'insights_advisor_api_inventory_event_missing_keys',
     'Counter for how many inventory event requests are malformed, missing keys'
 )
-INVENTORY_EVENT_ERROR = Counter(
-    'insights_advisor_service_inventory_event_error',
-    'Counter for how many inventory events errored'
-)
 INVENTORY_EVENT_MALFORMED = Counter(
-    'insights_advisor_service_inventory_event_malformed',
+    'insights_advisor_api_inventory_event_malformed',
     'Counter for inventory events that failed validation or parsing'
 )
 INVENTORY_HOST_UPSERTED = Counter(
-    'insights_advisor_service_inventory_host_upserted',
+    'insights_advisor_api_inventory_host_upserted',
     'Count how many inventory hosts were upserted'
 )
 INVENTORY_HOST_DELETED = Counter(
-    'insights_advisor_service_inventory_host_deleted',
+    'insights_advisor_api_inventory_host_deleted',
     'Count how many inventory hosts were deleted'
 )
 INVENTORY_HOST_DELETE_MISSING = Counter(
-    'insights_advisor_service_inventory_host_delete_missing',
+    'insights_advisor_api_inventory_host_delete_missing',
     'Count how many inventory host delete events had no matching record in the DB'
 )
-PAYLOAD_TRACKER_DELIVERY_ERRORS = Counter(
-    'insights_advisor_service_payload_tracker_delivery_errors',
-    'Counter for how many payload tracker messsages failed delivery'
-)
-ADVISOR_SERVICE_VERSION = Info(
-    'insights_advisor_service_version',
-    'Release and versioning information'
-)
-
-
-def start_prometheus():
-    start_http_server(settings.PROMETHEUS_PORT)

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -73,9 +73,12 @@ services:
     build:
       context: .
       dockerfile: Containerfile.localdev
+    ports:
+      - "8001:8001"
     environment:
       - BOOTSTRAP_SERVERS=kafka:29092
       - ADVISOR_DB_HOST=advisor-db
+      - PROMETHEUS_PORT=8001
     command: pipenv run python service/service.py
   advisor-api:
     build:
@@ -134,6 +137,13 @@ services:
       # - MOCK_KESSEL_HOST_GROUPS=uuid1,uuid2
       # - MOCK_KESSEL_WORKSPACE_ID=00000000-0000-0000-0000-000000000000
     command: pipenv run python api/advisor/manage.py mock_rbac
+  prometheus:
+    image: docker.io/prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus_localdev.yml:/etc/prometheus/prometheus.yml:Z
+
   unleash:
     image: quay.io/cloudservices/unleash-docker:5.6.9
     ports:

--- a/prometheus_localdev.yml
+++ b/prometheus_localdev.yml
@@ -1,0 +1,14 @@
+scrape_configs:
+  - job_name: 'advisor-api'
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - 'host.containers.internal:8000'
+
+  - job_name: 'advisor-service'
+    scrape_interval: 15s
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - 'host.containers.internal:8001'


### PR DESCRIPTION
- Plus create prometheus service in localdev environment

## Summary by Sourcery

Integrate inventory-related Prometheus metrics into the Django API and wire up a local Prometheus instance to scrape advisor services in local development.

New Features:
- Expose inventory-related Prometheus counters via the Django API metrics endpoint.
- Add a Prometheus container and configuration for scraping advisor API and service metrics in the local development environment.

Enhancements:
- Simplify Prometheus metric definitions to focus on inventory-related counters and remove unused service metrics.
- Ensure Django loads Prometheus metric definitions at startup via the API app configuration.
- Allow Prometheus in containers to reach the advisor services by adding host.containers.internal to allowed hosts and exposing the advisor-service metrics port in local development.