### PR TITLE
feat(RHINENG-29265): switch old table references with feature flag

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -656,7 +656,10 @@ def filter_on_has_disabled_recommendation(request, param=has_disabled_recommenda
 
     if use_local:
         outer_host_ref = OuterRef('inventory_id')
-        hostacks = HostAck.objects.filter(host__advisor_inventory__inventory_id=outer_host_ref)
+        hostacks = HostAck.objects.filter(
+            host__advisor_inventory__inventory_id=outer_host_ref,
+            host__advisor_inventory__org_id=OuterRef('org_id'),
+        )
         acks = CurrentReport.objects.filter(
             advisor_inventory__inventory_id=outer_host_ref, rule__ack__org_id=org_id
         )

--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -639,7 +639,7 @@ def filter_on_display_name(request, relation='', param=display_name_query_param)
     return Q(**{relation + 'display_name__icontains': display_name})
 
 
-def filter_on_has_disabled_recommendation(request, param=has_disabled_recommendation_query_param):
+def filter_on_has_disabled_recommendation(request, param=has_disabled_recommendation_query_param, use_local=False):
     """
     Filter systems which has at least one disabled recommendation.
     """
@@ -650,19 +650,21 @@ def filter_on_has_disabled_recommendation(request, param=has_disabled_recommenda
     # Need to import this here to avoid circular import error
     from api.permissions import request_to_org
 
-    # Getting HostAck using apps.get_model to avoid circular import error
     HostAck = apps.get_model('api', 'HostAck')
-    # Small extra note here: we're relying on the inventory UUID being unique
-    # to avoid having to check the org_id of HostAcks here.
-    hostacks = HostAck.objects.filter(host__inventory=OuterRef('pk'))
-    # To find whether this host has any system-wide Acks, we need to ask
-    # 'are there any current reports of acked rules for this host?'.  So for
-    # that we _do_ need the org_id...
     CurrentReport = apps.get_model('api', 'CurrentReport')
     org_id = request_to_org(request)
-    acks = CurrentReport.objects.filter(
-        inventory=OuterRef('pk'), rule__ack__org_id=org_id
-    )
+
+    if use_local:
+        outer_host_ref = OuterRef('inventory_id')
+        hostacks = HostAck.objects.filter(host__inventory=outer_host_ref)
+        acks = CurrentReport.objects.filter(
+            inventory=outer_host_ref, rule__ack__org_id=org_id
+        )
+    else:
+        hostacks = HostAck.objects.filter(host__inventory=OuterRef('pk'))
+        acks = CurrentReport.objects.filter(
+            inventory=OuterRef('pk'), rule__ack__org_id=org_id
+        )
 
     condition = Q(Exists(hostacks) | Exists(acks))
     return condition if param_value else ~condition

--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -656,9 +656,9 @@ def filter_on_has_disabled_recommendation(request, param=has_disabled_recommenda
 
     if use_local:
         outer_host_ref = OuterRef('inventory_id')
-        hostacks = HostAck.objects.filter(host__inventory=outer_host_ref)
+        hostacks = HostAck.objects.filter(host__advisor_inventory__inventory_id=outer_host_ref)
         acks = CurrentReport.objects.filter(
-            inventory=outer_host_ref, rule__ack__org_id=org_id
+            advisor_inventory__inventory_id=outer_host_ref, rule__ack__org_id=org_id
         )
     else:
         hostacks = HostAck.objects.filter(host__inventory=OuterRef('pk'))

--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -114,7 +114,7 @@ def _filter_stale_events(upserts: list[ParsedInventoryHost]) -> list[ParsedInven
     deduped: dict[tuple, ParsedInventoryHost] = {}
     for item in upserts:
         key = (item.org_id, item.host_id)
-        if key not in deduped or item.last_check_in > deduped[key].last_check_in:
+        if key not in deduped or item.updated > deduped[key].updated:
             deduped[key] = item
     unique = list(deduped.values())
 
@@ -123,17 +123,17 @@ def _filter_stale_events(upserts: list[ParsedInventoryHost]) -> list[ParsedInven
             Q(org_id=item.org_id, inventory_id=item.host_id)
             for item in unique
         ))
-    ).values_list('org_id', 'inventory_id', 'last_check_in')
+    ).values_list('org_id', 'inventory_id', 'updated')
 
     existing_ts = {
-        (org_id, str(inv_id)): last_check_in
-        for org_id, inv_id, last_check_in in existing
+        (org_id, str(inv_id)): updated
+        for org_id, inv_id, updated in existing
     }
 
     fresh = [
         item for item in unique
         if (item.org_id, item.host_id) not in existing_ts
-        or parse_datetime(item.last_check_in) > existing_ts[(item.org_id, item.host_id)]
+        or parse_datetime(item.updated) > existing_ts[(item.org_id, item.host_id)]
     ]
 
     stale_count = len(unique) - len(fresh)

--- a/api/advisor/api/management/commands/delete_stale_api_hosts.py
+++ b/api/advisor/api/management/commands/delete_stale_api_hosts.py
@@ -21,6 +21,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from api.models import Host
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 
 
 class Command(BaseCommand):
@@ -37,24 +38,35 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        # Delete all hosts this many days older than now
         stale_cull_date = timezone.now() - timedelta(days=options['days'])
-        # Only delete hosts without a matching inventory record, because
-        # there's no point deleting a Host if it's still in Inventory.
-        # And sadly because there's no direct ForeignKey relationship
-        # between Host and InventoryHost, the Relationship doesn't really
-        # support the 'isnull=True' / =None kind of assertion that creates a
-        # LEFT OUTER JOIN in the SQL.  So we have to do it this way.
-        raw_hosts = Host.objects.raw(
-            """
-            SELECT h.system_uuid
-            FROM api_host h
-            LEFT OUTER JOIN inventory.hosts ih ON ih.id = h.system_uuid
-            WHERE updated_at < %s AND ih.id IS NULL
-            """,
-            [stale_cull_date]
-        )
-        # But let Django do the correct deletion following all the foreign
-        # keys:
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+
+        if use_local:
+            raw_hosts = Host.objects.raw(
+                """
+                SELECT h.system_uuid
+                FROM api_host h
+                LEFT OUTER JOIN advisor_inventory_host aih
+                  ON aih.inventory_id = h.system_uuid AND aih.org_id = h.org_id
+                WHERE updated_at < %s AND aih.inventory_id IS NULL
+                """,
+                [stale_cull_date]
+            )
+        else:
+            raw_hosts = Host.objects.raw(
+                """
+                SELECT h.system_uuid
+                FROM api_host h
+                LEFT OUTER JOIN inventory.hosts ih ON ih.id = h.system_uuid
+                WHERE updated_at < %s AND ih.id IS NULL
+                """,
+                [stale_cull_date]
+            )
+
+        # Host has no FK or Relationship to AdvisorInventoryHost that
+        # supports isnull lookups, and Host.inventory (OneToOneField to
+        # InventoryHost) uses on_delete=DO_NOTHING with db_constraint=False
+        # — no cascade either way.  Raw SQL identifies orphans; Django
+        # handles deletion following all the foreign keys.
         for host_batch in batched(raw_hosts, options['batch']):
             Host.objects.filter(inventory__in=host_batch).delete()

--- a/api/advisor/api/management/commands/weekly_report_emails.py
+++ b/api/advisor/api/management/commands/weekly_report_emails.py
@@ -27,8 +27,10 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from api.models import (
-    CurrentReport, InventoryHost, WeeklyReportSubscription, stale_systems_q, Ack
+    AdvisorInventoryHost, CurrentReport, Host, InventoryHost,
+    WeeklyReportSubscription, stale_systems_q, Ack,
 )
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 from api.permissions import (
     RHIdentityAuthentication, has_rbac_permission, request_object_for_testing,
     get_workspace_id,
@@ -173,11 +175,19 @@ def get_rhdisabled_rules_systems(org_id):
 
 
 def get_inventory_hosts_stats(org_id):
-    # Used in new email template to get the total number of registered & stale hosts
-    hosts_qs = InventoryHost.objects.filter(org_id=org_id, host__isnull=False)
+    if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+        hosts_qs = AdvisorInventoryHost.objects.filter(
+            org_id=org_id,
+        ).filter(
+            Exists(Host.objects.filter(inventory_id=OuterRef('inventory_id')))
+        )
+    else:
+        hosts_qs = InventoryHost.objects.filter(org_id=org_id, host__isnull=False)
     return {
         'total': hosts_qs.count(),
-        'stale': hosts_qs.filter(per_reporter_staleness__puptoo__stale_timestamp__lt=str(timezone.now())).count()
+        'stale': hosts_qs.filter(
+            per_reporter_staleness__puptoo__stale_timestamp__lt=str(timezone.now())
+        ).count()
     }
 
 

--- a/api/advisor/api/management/commands/weekly_report_emails.py
+++ b/api/advisor/api/management/commands/weekly_report_emails.py
@@ -159,8 +159,12 @@ def get_account_orgs(org_filter, latest_email_time):
 
 
 def get_rhdisabled_rules_systems(org_id):
+    if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+        stale_filter = stale_systems_q(org_id=org_id, model_class=AdvisorInventoryHost)
+    else:
+        stale_filter = stale_systems_q(org_id=org_id)
     return CurrentReport.objects.filter(
-        stale_systems_q(org_id=org_id),
+        stale_filter,
         Exists(Ack.objects.filter(
             rule_id=OuterRef('rule_id'),
             org_id=org_id,

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -910,7 +910,11 @@ class AdvisorInventoryHost(ExportModelOperationsMixin('advisorinventoryhost'), m
         elif os_name:
             return f"Unknown {os_name} version"
         else:
-            return "Unknown OS version"
+            return "Unknown system version"
+
+    @property
+    def acks(self):
+        return []
 
     class Meta:
         db_table = 'advisor_inventory_host'

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -1285,6 +1285,7 @@ class RuleManager(models.Manager):
         # filter everything by matching org_id.  At some point we can do the
         # semantic name change to `for_org()`.
         username = request_to_username(request)
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
 
         report_query = get_reports_subquery(
             request, exclude_ineligible_rules=False, rule_id=OuterRef('id'),
@@ -1295,20 +1296,34 @@ class RuleManager(models.Manager):
         # Because the only time we can get a rule list is in views that have
         # already authenticated, we must have an account here.
 
-        system_profile_filter = filter_multi_param(
-            request, 'system_profile', field_prefix='host__inventory'
-        )
         playbooks_for_rule = Playbook.objects.filter(
             resolution__rule=models.OuterRef('id')
         ).order_by()
-        hosts_acked_for_rule = HostAck.objects.filter(
-            filter_on_host_tags(request, field_name='host_id'),
-            system_profile_filter,
-            stale_systems_q(org_id, field='host_id'),
-            org_id=org_id, rule=models.OuterRef('id'),
-        ).annotate(
-            hosts_acked=models.Count('id')
-        ).values('hosts_acked').order_by()
+
+        if use_local:
+            system_profile_filter = filter_multi_param(
+                request, 'system_profile', field_prefix='host__advisor_inventory'
+            )
+            hosts_acked_for_rule = HostAck.objects.filter(
+                filter_on_host_tags(request, field_name='host_id', use_local=True),
+                system_profile_filter,
+                stale_systems_q(org_id, field='host_id', model_class=AdvisorInventoryHost),
+                org_id=org_id, rule=models.OuterRef('id'),
+            ).annotate(
+                hosts_acked=models.Count('id')
+            ).values('hosts_acked').order_by()
+        else:
+            system_profile_filter = filter_multi_param(
+                request, 'system_profile', field_prefix='host__inventory'
+            )
+            hosts_acked_for_rule = HostAck.objects.filter(
+                filter_on_host_tags(request, field_name='host_id'),
+                system_profile_filter,
+                stale_systems_q(org_id, field='host_id'),
+                org_id=org_id, rule=models.OuterRef('id'),
+            ).annotate(
+                hosts_acked=models.Count('id')
+            ).values('hosts_acked').order_by()
         hosts_acked_for_rule.query.group_by = []  # Otherwise it groups by host_id
 
         return self.get_queryset().filter(

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -502,6 +502,7 @@ def get_reports_subquery(
             get_host_group_filter(request, relation=inv_relation, use_local=use_local),
             stale_systems_filter,
         ) if exclude_ineligible_hosts else Q(),
+        org_id=org_id,
         **outer_table_join
     ).filter(
         Q(rule__active=True) if use_joins and exclude_ineligible_rules else Q()

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -311,7 +311,7 @@ def get_systems_queryset(request):
         filter_on_hits(request),
         filter_on_incident(request),
         rhel_version_filter,
-        filter_on_has_disabled_recommendation(request)
+        filter_on_has_disabled_recommendation(request, use_local=use_local)
     )
 
 

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -951,7 +951,16 @@ class Host(ExportModelOperationsMixin('host'), TimestampedModel):
 
     @property
     def rhel_version(self):
-        return self.inventory.rhel_version
+        if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+            try:
+                inv = self.advisor_inventory
+                return AdvisorInventoryHost.get_rhel_version_from_flat(
+                    inv.os_major, inv.os_minor, inv.os_name
+                )
+            except AdvisorInventoryHost.DoesNotExist:
+                return "Unknown system version"
+        else:
+            return self.inventory.rhel_version
 
     def __str__(self):
         return str(self.inventory_id)

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -1311,7 +1311,8 @@ class RuleManager(models.Manager):
 
         if use_local:
             system_profile_filter = filter_multi_param(
-                request, 'system_profile', field_prefix='host__advisor_inventory'
+                request, 'system_profile', field_prefix='host__advisor_inventory',
+                use_local=True
             )
             hosts_acked_for_rule = HostAck.objects.filter(
                 filter_on_host_tags(request, field_name='host_id', use_local=True),

--- a/api/advisor/api/models.py
+++ b/api/advisor/api/models.py
@@ -899,12 +899,16 @@ class AdvisorInventoryHost(ExportModelOperationsMixin('advisorinventoryhost'), m
 
     @property
     def rhel_version(self):
-        if self.os_major is not None and self.os_minor is not None:
-            return f"{self.os_major}.{self.os_minor}"
-        elif self.os_major is not None:
-            return str(self.os_major)
-        elif self.os_name:
-            return f"Unknown {self.os_name} version"
+        return self.get_rhel_version_from_flat(self.os_major, self.os_minor, self.os_name)
+
+    @staticmethod
+    def get_rhel_version_from_flat(os_major, os_minor, os_name):
+        if os_major is not None and os_minor is not None:
+            return f"{os_major}.{os_minor}"
+        elif os_major is not None:
+            return str(os_major)
+        elif os_name:
+            return f"Unknown {os_name} version"
         else:
             return "Unknown OS version"
 
@@ -922,6 +926,12 @@ class Host(ExportModelOperationsMixin('host'), TimestampedModel):
     inventory = models.OneToOneField(
         InventoryHost, on_delete=models.DO_NOTHING, primary_key=True,
         db_constraint=False, db_column='system_uuid',
+    )
+    advisor_inventory = Relationship(
+        'AdvisorInventoryHost',
+        from_fields=['inventory_id', 'org_id'],
+        to_fields=['inventory_id', 'org_id'],
+        related_name='host',
     )
     account = models.CharField(max_length=10, blank=True, null=True)
     org_id = models.CharField(max_length=50)
@@ -1234,9 +1244,19 @@ class Pathway(ExportModelOperationsMixin('pathway'), models.Model):
         if self.impacted_systems_count:
             report_query = self.get_reports(request)
             system_query = get_systems_queryset(request)
-            filtered_systems_queryset = system_query.filter(id__in=report_query.values('host__inventory'))
+            use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+            if use_local:
+                filtered_systems_queryset = system_query.filter(
+                    inventory_id__in=report_query.values('host_id')
+                )
+            else:
+                filtered_systems_queryset = system_query.filter(
+                    id__in=report_query.values('host__inventory')
+                )
             return filtered_systems_queryset
         else:
+            if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+                return AdvisorInventoryHost.objects.none()
             return InventoryHost.objects.none()
 
     def __str__(self):

--- a/api/advisor/api/serializers.py
+++ b/api/advisor/api/serializers.py
@@ -21,6 +21,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 
 from api import models
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 
 
 def existing_rule_id_validator(rule_id):
@@ -29,7 +30,14 @@ def existing_rule_id_validator(rule_id):
 
 
 def existing_host_id_validator(host_id):
-    if not models.InventoryHost.objects.filter(pk=host_id).exists():
+    if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+        if not models.AdvisorInventoryHost.objects.filter(
+            inventory_id=host_id
+        ).exists():
+            raise serializers.ValidationError(
+                f"Host with UUID '{host_id}' not found"
+            )
+    elif not models.InventoryHost.objects.filter(pk=host_id).exists():
         raise serializers.ValidationError(f"Host with UUID '{host_id}' not found")
 
 
@@ -408,7 +416,12 @@ class HostAckSerializer(serializers.ModelSerializer):
         queryset=models.Rule.objects.filter(active=True),
     )
     system_uuid = serializers.UUIDField(source='host_id')
-    display_name = serializers.CharField(source='host.inventory.display_name', read_only=True)
+    display_name = serializers.SerializerMethodField()
+
+    def get_display_name(self, obj):
+        if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+            return getattr(obj.host.advisor_inventory, 'display_name', None)
+        return getattr(obj.host.inventory, 'display_name', None)
 
     class Meta:
         model = models.HostAck
@@ -464,9 +477,14 @@ def validate_hosts_in_org(hosts, org_id, field_name='systems'):
     Check that the hosts given exist, and they are in this org.  We need to
     not distinguish between the two to avoid leaking that a host UUID exists.
     """
-    valid_hosts = set(models.InventoryHost.objects.filter(
-        org_id=org_id, id__in=hosts
-    ).values_list('id', flat=True))
+    if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+        valid_hosts = set(models.AdvisorInventoryHost.objects.filter(
+            org_id=org_id, inventory_id__in=hosts
+        ).values_list('inventory_id', flat=True))
+    else:
+        valid_hosts = set(models.InventoryHost.objects.filter(
+            org_id=org_id, id__in=hosts
+        ).values_list('id', flat=True))
     nonexistent_hosts = {
         str(row): [f"Host with UUID '{str(system_uuid)}' not found"]
         for row, system_uuid in enumerate(hosts)
@@ -790,6 +808,28 @@ class SystemsDetailSerializer(SystemSerializer):
             'incident_hits', 'all_pathway_hits', 'pathway_filter_hits',
             'os_name', 'rhel_version', 'impacted_date'
         )
+
+
+class AdvisorSystemSerializer(SystemSerializer):
+    class Meta(SystemSerializer.Meta):
+        model = models.AdvisorInventoryHost
+
+
+class AdvisorSystemsDetailSerializer(SystemsDetailSerializer):
+    class Meta(SystemsDetailSerializer.Meta):
+        model = models.AdvisorInventoryHost
+
+
+def get_system_serializer():
+    if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+        return AdvisorSystemSerializer
+    return SystemSerializer
+
+
+def get_systems_detail_serializer():
+    if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+        return AdvisorSystemsDetailSerializer
+    return SystemsDetailSerializer
 
 
 class UploadSerializer(serializers.ModelSerializer):

--- a/api/advisor/api/serializers.py
+++ b/api/advisor/api/serializers.py
@@ -811,11 +811,21 @@ class SystemsDetailSerializer(SystemSerializer):
 
 
 class AdvisorSystemSerializer(SystemSerializer):
+    os_name = serializers.SerializerMethodField()
+
+    def get_os_name(self, obj):
+        return obj.os_name or "Unknown operating system"
+
     class Meta(SystemSerializer.Meta):
         model = models.AdvisorInventoryHost
 
 
 class AdvisorSystemsDetailSerializer(SystemsDetailSerializer):
+    os_name = serializers.SerializerMethodField()
+
+    def get_os_name(self, obj):
+        return obj.os_name or "Unknown operating system"
+
     class Meta(SystemsDetailSerializer.Meta):
         model = models.AdvisorInventoryHost
 

--- a/api/advisor/api/tests/__init__.py
+++ b/api/advisor/api/tests/__init__.py
@@ -21,7 +21,7 @@ from kessel.inventory.v1beta2 import check_request_pb2
 from django.utils import timezone
 
 from api import kessel
-from api.models import InventoryHost
+from api.models import AdvisorInventoryHost, InventoryHost
 from api.permissions import identity_to_subject, auth_header_for_testing
 
 
@@ -489,3 +489,80 @@ def rbac_data(permissions='advisor:*:*', raw=None, groups=None):
     else:
         rbac_data = {'data': [{'permission': permissions}]}
     return rbac_data
+
+
+def replicate_to_advisor_inventory():
+    """Copy InventoryHost records into AdvisorInventoryHost with flattened fields."""
+    for inv in InventoryHost.objects.all():
+        sp = inv.system_profile or {}
+        os_info = sp.get('operating_system', {})
+        if not isinstance(os_info, dict):
+            os_info = {}
+        groups = inv.groups or []
+        g0 = groups[0] if groups else {}
+        bootc = sp.get('bootc_status', {})
+        bootc_booted = bootc.get('booted', {}) if isinstance(bootc, dict) else {}
+        workloads = sp.get('workloads', {})
+        workloads = workloads if isinstance(workloads, dict) else {}
+
+        AdvisorInventoryHost.objects.update_or_create(
+            inventory_id=inv.id,
+            org_id=inv.org_id,
+            defaults={
+                'account': inv.account,
+                'display_name': inv.display_name,
+                'tags': inv.tags,
+                'workspace_id': g0.get('id'),
+                'workspace_name': g0.get('name'),
+                'workspace_ungrouped': g0.get('ungrouped'),
+                'updated': inv.updated,
+                'created': inv.created,
+                'last_check_in': inv.last_check_in,
+                'stale_timestamp': inv.stale_timestamp,
+                'insights_id': inv.insights_id,
+                'reporter': inv.reporter,
+                'per_reporter_staleness': inv.per_reporter_staleness,
+                'os_name': os_info.get('name'),
+                'os_major': os_info.get('major'),
+                'os_minor': os_info.get('minor'),
+                'host_type': sp.get('host_type'),
+                'bootc_booted_image': (
+                    bootc_booted.get('image')
+                    if isinstance(bootc_booted, dict) else None
+                ),
+                'bootc_booted_image_digest': (
+                    bootc_booted.get('image_digest')
+                    if isinstance(bootc_booted, dict) else None
+                ),
+                'owner_id': sp.get('owner_id'),
+                'rhc_client_id': sp.get('rhc_client_id'),
+                'workloads': workloads,
+                'system_update_method': sp.get('system_update_method'),
+            }
+        )
+
+
+class AdvisorInventoryTestMixin:
+    """Shared test setup for AdvisorInventoryHost flag-on tests."""
+    fixtures = [
+        'rulesets', 'system_types', 'rule_categories', 'upload_sources',
+        'basic_test_data', 'high_severity_rule',
+    ]
+    std_auth_header = auth_header_for_testing()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        update_stale_dates()
+
+    def setUp(self):
+        super().setUp()
+        replicate_to_advisor_inventory()
+
+    def _response_is_good(self, response):
+        from django.test import TestCase
+        tc = TestCase()
+        tc.maxDiff = None
+        tc.assertEqual(response.status_code, 200, response.content.decode())
+        tc.assertEqual(response.accepted_media_type, constants.json_mime)
+        return response.json()

--- a/api/advisor/api/tests/test_advisor_inventory_service.py
+++ b/api/advisor/api/tests/test_advisor_inventory_service.py
@@ -617,24 +617,24 @@ class TestAdvisorInventoryServer(TestCase):
         )
 
     @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
-    def test_stale_update_does_not_overwrite_newer_data(self):
-        """Test that an event with an older last_check_in is filtered out."""
+    def test_stale_event_does_not_overwrite_newer_data(self):
+        """Test that an event with an older 'updated' timestamp is filtered out."""
         newer_ts = "2026-06-01T12:00:00Z"
         older_ts = "2025-01-01T00:00:00Z"
 
-        # Insert host with newer last_check_in
+        # Insert host with newer 'updated'
         msg = deepcopy(create_new_host_msg)
-        msg['host']['last_check_in'] = newer_ts
+        msg['host']['updated'] = newer_ts
         with self.assertLogs(logger='advisor-log', level='DEBUG'):
             handle_inventory_event('topic', [msg])
 
         inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
         original_display_name = inv_host.display_name
 
-        # Send update with older last_check_in and different display_name
+        # Send event with older 'updated' — should be filtered as stale
         stale_msg = deepcopy(create_new_host_msg)
         stale_msg['type'] = 'updated'
-        stale_msg['host']['last_check_in'] = older_ts
+        stale_msg['host']['updated'] = older_ts
         stale_msg['host']['display_name'] = 'stale-name-should-not-appear'
         with self.assertLogs(logger='advisor-log', level='DEBUG'):
             handle_inventory_event('topic', [stale_msg])
@@ -643,21 +643,21 @@ class TestAdvisorInventoryServer(TestCase):
         self.assertEqual(inv_host.display_name, original_display_name)
 
     @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
-    def test_newer_update_overwrites_older_data(self):
-        """Test that an event with a newer last_check_in updates the record."""
+    def test_newer_event_overwrites_older_data(self):
+        """Test that an event with a newer 'updated' timestamp updates the record."""
         older_ts = "2025-01-01T00:00:00Z"
         newer_ts = "2026-06-01T12:00:00Z"
 
-        # Insert host with older last_check_in
+        # Insert host with older 'updated'
         msg = deepcopy(create_new_host_msg)
-        msg['host']['last_check_in'] = older_ts
+        msg['host']['updated'] = older_ts
         with self.assertLogs(logger='advisor-log', level='DEBUG'):
             handle_inventory_event('topic', [msg])
 
-        # Send update with newer last_check_in and different display_name
+        # Send event with newer 'updated' and different display_name
         update_msg = deepcopy(create_new_host_msg)
         update_msg['type'] = 'updated'
-        update_msg['host']['last_check_in'] = newer_ts
+        update_msg['host']['updated'] = newer_ts
         update_msg['host']['display_name'] = 'updated-name'
         with self.assertLogs(logger='advisor-log', level='DEBUG'):
             handle_inventory_event('topic', [update_msg])
@@ -666,14 +666,14 @@ class TestAdvisorInventoryServer(TestCase):
         self.assertEqual(inv_host.display_name, 'updated-name')
 
     @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
-    def test_batch_dedup_keeps_latest_timestamp(self):
-        """Test that duplicate host events in a batch keep the one with latest last_check_in."""
+    def test_batch_dedup_keeps_latest_event(self):
+        """Test that duplicate host events in a batch keep the one with latest 'updated'."""
         older_msg = deepcopy(create_new_host_msg)
-        older_msg['host']['last_check_in'] = "2025-01-01T00:00:00Z"
+        older_msg['host']['updated'] = "2025-01-01T00:00:00Z"
         older_msg['host']['display_name'] = 'old-name'
 
         newer_msg = deepcopy(create_new_host_msg)
-        newer_msg['host']['last_check_in'] = "2026-06-01T12:00:00Z"
+        newer_msg['host']['updated'] = "2026-06-01T12:00:00Z"
         newer_msg['host']['display_name'] = 'new-name'
 
         # Send older first, newer second
@@ -692,6 +692,36 @@ class TestAdvisorInventoryServer(TestCase):
 
         inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
         self.assertEqual(inv_host.display_name, 'new-name')
+
+    @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
+    def test_group_change_event_updates_workspace(self):
+        """Test that a group-change event (same last_check_in, newer updated) is not filtered out."""
+        initial_ts = "2025-11-28T03:53:20Z"
+        group_change_ts = "2025-11-28T04:00:00Z"
+
+        # Create host with no group
+        msg = deepcopy(create_new_host_msg)
+        msg['host']['updated'] = initial_ts
+        msg['host']['last_check_in'] = initial_ts
+        msg['host']['groups'] = []
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [msg])
+
+        inv_host = AdvisorInventoryHost.objects.get(inventory_id=new_host_id)
+        self.assertIsNone(inv_host.workspace_name)
+
+        # HBI emits updated event for group assignment — same last_check_in, newer updated
+        group_msg = deepcopy(create_new_host_msg)
+        group_msg['type'] = 'updated'
+        group_msg['host']['updated'] = group_change_ts
+        group_msg['host']['last_check_in'] = initial_ts
+        group_msg['host']['groups'] = [{"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "name": "test-group"}]
+        with self.assertLogs(logger='advisor-log', level='DEBUG'):
+            handle_inventory_event('topic', [group_msg])
+
+        inv_host.refresh_from_db()
+        self.assertEqual(inv_host.workspace_name, "test-group")
+        self.assertEqual(str(inv_host.workspace_id), "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 
     @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
     @patch.object(prometheus.INVENTORY_EVENT_MALFORMED, 'inc')

--- a/api/advisor/api/tests/test_delete_stale_api_hosts_command.py
+++ b/api/advisor/api/tests/test_delete_stale_api_hosts_command.py
@@ -20,7 +20,9 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
-from api.models import Host, InventoryHost
+from api.models import AdvisorInventoryHost, Host, InventoryHost
+from api.tests import constants, replicate_to_advisor_inventory
+from feature_flags import set_unleash_flag, FLAG_READ_LOCAL_INVENTORY
 
 
 class ImportContentTestCase(TestCase):
@@ -81,3 +83,45 @@ class ImportContentTestCase(TestCase):
                 inventory_id__in=InventoryHost.objects.values_list('id', flat=True)
             )
         )
+
+
+class AdvisorInventoryDeleteStaleTestCase(TestCase):
+    """Tests delete_stale_api_hosts with AdvisorInventoryHost behind feature flag."""
+    fixtures = [
+        'basic_test_ruleset', 'system_types', 'rule_categories',
+        'upload_sources', 'basic_test_data'
+    ]
+
+    def setUp(self):
+        super().setUp()
+        replicate_to_advisor_inventory()
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_delete_hosts_command_local(self):
+        """Orphaned hosts are deleted using advisor_inventory_host join."""
+        orig_host_count = Host.objects.count()
+        self.assertEqual(orig_host_count, 11)
+        orig_aih_count = AdvisorInventoryHost.objects.count()
+        self.assertEqual(orig_aih_count, 10)
+
+        call_command('delete_stale_api_hosts')
+
+        # Orphaned host 09 (no matching InventoryHost/AdvisorInventoryHost) deleted
+        self.assertEqual(Host.objects.count(), 10)
+        self.assertEqual(AdvisorInventoryHost.objects.count(), orig_aih_count)
+
+        # Remove some AdvisorInventoryHost records to simulate culling
+        stale_cull_date = timezone.now() - timedelta(days=28)
+        deleted_count = AdvisorInventoryHost.objects.filter(
+            org_id=constants.standard_org, updated__lt=stale_cull_date,
+        ).delete()[0]
+        self.assertGreater(deleted_count, 0)
+
+        update_aih_count = AdvisorInventoryHost.objects.count()
+        self.assertLess(update_aih_count, orig_aih_count)
+
+        call_command('delete_stale_api_hosts')
+
+        update_host_count = Host.objects.count()
+        self.assertLess(update_host_count, orig_host_count)
+        self.assertEqual(update_host_count, update_aih_count)

--- a/api/advisor/api/tests/test_export_views.py
+++ b/api/advisor/api/tests/test_export_views.py
@@ -17,8 +17,9 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from api.tests import constants, update_stale_dates
+from api.tests import constants, update_stale_dates, AdvisorInventoryTestMixin
 from api.permissions import auth_header_for_testing
+from feature_flags import set_unleash_flag, FLAG_READ_LOCAL_INVENTORY
 from api.models import Rule, Tag
 
 import csv
@@ -1248,3 +1249,32 @@ class ExportViewHostTagsTestCase(TestCase):
         self.assertEqual(row_data[0]['rhel_version'], '8.3')
         self.assertEqual(row_data[0]['group_name'], '')
         self.assertEqual(len(row_data), 1)
+
+
+class AdvisorInventoryExportHitsTestCase(AdvisorInventoryTestMixin, TestCase):
+    """Tests that verify export hits endpoint works with AdvisorInventoryHost."""
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_export_hits_local_inventory(self):
+        """Hits export returns correct data from AdvisorInventoryHost."""
+        response = self.client.get(
+            reverse('export-hits-list'), **self.std_auth_header
+        )
+        self.assertEqual(response.status_code, 200)
+        import json
+        data = json.loads(b''.join(response.streaming_content))
+        self.assertIsInstance(data, list)
+        self.assertTrue(len(data) > 0)
+        hit = data[0]
+        self.assertIn('hostname', hit)
+        self.assertIn('rhel_version', hit)
+        self.assertIn('stale_at', hit)
+        self.assertIn('uuid', hit)
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_export_systems_local_inventory(self):
+        """Systems export works with AdvisorInventoryHost."""
+        response = self.client.get(
+            reverse('export-systems-list'), **self.std_auth_header
+        )
+        self.assertEqual(response.status_code, 200)

--- a/api/advisor/api/tests/test_pathway_views.py
+++ b/api/advisor/api/tests/test_pathway_views.py
@@ -17,8 +17,9 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from api.tests import constants, update_stale_dates
+from api.tests import constants, update_stale_dates, AdvisorInventoryTestMixin
 from api.permissions import auth_header_for_testing
+from feature_flags import set_unleash_flag, FLAG_READ_LOCAL_INVENTORY
 
 
 class PathwayModelTestCase(TestCase):
@@ -868,3 +869,20 @@ class PathwayViewHostTagsTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['data'], [])
+
+
+class AdvisorInventoryPathwayViewTestCase(AdvisorInventoryTestMixin, TestCase):
+    """Tests that verify pathway endpoints work with AdvisorInventoryHost."""
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_pathway_systems_local_inventory(self):
+        """Pathway systems endpoint works with flag on."""
+        response = self.client.get(
+            reverse('pathway-systems', kwargs={'slug': 'test-component-1'}),
+            **self.std_auth_header
+        )
+        json = self._response_is_good(response)
+        self.assertIn('data', json)
+        systems = json['data']
+        self.assertIsInstance(systems, list)
+        self.assertTrue(len(systems) > 0)

--- a/api/advisor/api/tests/test_rule_views.py
+++ b/api/advisor/api/tests/test_rule_views.py
@@ -20,7 +20,8 @@ from django.test import TestCase
 from django.urls import reverse
 
 from api.models import Ack, Rule, RuleCategory
-from api.tests import constants, update_stale_dates
+from api.tests import constants, update_stale_dates, AdvisorInventoryTestMixin
+from feature_flags import set_unleash_flag, FLAG_READ_LOCAL_INVENTORY
 from api.permissions import (
     auth_header_for_testing, turnpike_auth_header_for_testing
 )
@@ -2456,3 +2457,32 @@ class RuleHostTagsTestCase(TestCase):
         self.assertEqual(get_hosts(response), [
             "system03.example.com", "system01.example.com"
         ])
+
+
+class AdvisorInventoryRuleViewTestCase(AdvisorInventoryTestMixin, TestCase):
+    """Tests that verify rule endpoints work with AdvisorInventoryHost."""
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_rule_systems_local_inventory(self):
+        """Rule systems endpoint works with flag on."""
+        response = self.client.get(
+            reverse('rule-systems', kwargs={'rule_id': constants.active_rule}),
+            **self.std_auth_header
+        )
+        json = self._response_is_good(response)
+        self.assertIn('host_ids', json)
+        self.assertIsInstance(json['host_ids'], list)
+        self.assertTrue(len(json['host_ids']) > 0)
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_rule_systems_detail_local_inventory(self):
+        """Rule systems_detail endpoint works with flag on."""
+        response = self.client.get(
+            reverse('rule-systems-detail', kwargs={'rule_id': constants.active_rule}),
+            **self.std_auth_header
+        )
+        json = self._response_is_good(response)
+        self.assertIn('data', json)
+        systems = json['data']
+        self.assertIsInstance(systems, list)
+        self.assertTrue(len(systems) > 0)

--- a/api/advisor/api/tests/test_system_views.py
+++ b/api/advisor/api/tests/test_system_views.py
@@ -23,9 +23,9 @@ from django.urls import reverse
 from django.utils import timezone
 
 from api import kessel
-from api.models import Ack, AdvisorInventoryHost, InventoryHost, Upload
+from api.models import Ack, InventoryHost, Upload
 from api.permissions import auth_header_for_testing, make_rbac_url
-from api.tests import constants, update_stale_dates
+from api.tests import constants, update_stale_dates, AdvisorInventoryTestMixin
 from feature_flags import set_unleash_flag, FLAG_READ_LOCAL_INVENTORY
 
 
@@ -1163,72 +1163,8 @@ class SystemHostTagsViewTestCase(TestCase):
         self.assertEqual(len(rules), 0)
 
 
-def _replicate_to_advisor_inventory():
-    """Copy InventoryHost records into AdvisorInventoryHost with flattened fields."""
-    for inv in InventoryHost.objects.all():
-        sp = inv.system_profile or {}
-        os_info = sp.get('operating_system', {})
-        if not isinstance(os_info, dict):
-            os_info = {}
-        groups = inv.groups or []
-        g0 = groups[0] if groups else {}
-        bootc = sp.get('bootc_status', {})
-        bootc_booted = bootc.get('booted', {}) if isinstance(bootc, dict) else {}
-        workloads = sp.get('workloads', {})
-        workloads = workloads if isinstance(workloads, dict) else {}
-
-        AdvisorInventoryHost.objects.update_or_create(
-            inventory_id=inv.id,
-            org_id=inv.org_id,
-            defaults={
-                'account': inv.account,
-                'display_name': inv.display_name,
-                'tags': inv.tags,
-                'workspace_id': g0.get('id'),
-                'workspace_name': g0.get('name'),
-                'workspace_ungrouped': g0.get('ungrouped'),
-                'updated': inv.updated,
-                'created': inv.created,
-                'last_check_in': inv.last_check_in,
-                'stale_timestamp': inv.stale_timestamp,
-                'insights_id': inv.insights_id,
-                'reporter': inv.reporter,
-                'per_reporter_staleness': inv.per_reporter_staleness,
-                'os_name': os_info.get('name'),
-                'os_major': os_info.get('major'),
-                'os_minor': os_info.get('minor'),
-                'host_type': sp.get('host_type'),
-                'bootc_booted_image': bootc_booted.get('image') if isinstance(bootc_booted, dict) else None,
-                'bootc_booted_image_digest': bootc_booted.get('image_digest') if isinstance(bootc_booted, dict) else None,
-                'owner_id': sp.get('owner_id'),
-                'rhc_client_id': sp.get('rhc_client_id'),
-                'workloads': workloads,
-                'system_update_method': sp.get('system_update_method'),
-            }
-        )
-
-
-class AdvisorInventorySystemViewTestCase(TestCase):
+class AdvisorInventorySystemViewTestCase(AdvisorInventoryTestMixin, TestCase):
     """Tests that verify API system endpoints work with AdvisorInventoryHost (flag on)."""
-    fixtures = [
-        'rulesets', 'system_types', 'rule_categories', 'upload_sources',
-        'basic_test_data', 'high_severity_rule',
-    ]
-
-    std_auth_header = auth_header_for_testing()
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        update_stale_dates()
-
-    def setUp(self):
-        _replicate_to_advisor_inventory()
-
-    def _response_is_good(self, response):
-        self.assertEqual(response.status_code, 200, response.content.decode())
-        self.assertEqual(response.accepted_media_type, constants.json_mime)
-        return response.json()
 
     @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
     def test_list_system_local_inventory(self):

--- a/api/advisor/api/tests/test_weekly_report_command.py
+++ b/api/advisor/api/tests/test_weekly_report_command.py
@@ -30,7 +30,8 @@ from api.management.commands.weekly_report_emails import get_rhdisabled_rules_sy
 from project_settings import settings
 from api.models import WeeklyReportSubscription, Rule, Tag, InventoryHost, Ack
 from api.permissions import has_rbac_permission, http_auth_header_key, make_rbac_url
-from api.tests import constants, update_stale_dates
+from api.tests import constants, update_stale_dates, AdvisorInventoryTestMixin
+from feature_flags import set_unleash_flag, FLAG_READ_LOCAL_INVENTORY
 
 test_middleware_url = 'https://middleware.svc/'
 
@@ -540,3 +541,19 @@ class KesselWeeklyReportTest(TestCase):
                     ):
                         result = _get_kessel_permitted_user_ids('9876543')
         self.assertIsNone(result)
+
+
+class AdvisorInventoryWeeklyReportTestCase(AdvisorInventoryTestMixin, TestCase):
+    """Tests that weekly report stats work with AdvisorInventoryHost."""
+
+    @set_unleash_flag(FLAG_READ_LOCAL_INVENTORY, True)
+    def test_get_inventory_hosts_stats_local(self):
+        """get_inventory_hosts_stats returns correct counts from AdvisorInventoryHost."""
+        from api.management.commands.weekly_report_emails import (
+            get_inventory_hosts_stats,
+        )
+        stats = get_inventory_hosts_stats(constants.standard_org)
+        self.assertIn('total', stats)
+        self.assertIn('stale', stats)
+        self.assertIsInstance(stats['total'], int)
+        self.assertTrue(stats['total'] > 0)

--- a/api/advisor/api/views/export.py
+++ b/api/advisor/api/views/export.py
@@ -37,9 +37,10 @@ from api.filters import (
     topic_query_param, filter_on_topic, update_method_query_param,
 )
 from api.models import (
-    InventoryHost, Playbook, Resolution, Rule, Tag, Upload,
-    get_reports_subquery,
+    AdvisorInventoryHost, InventoryHost, Playbook, Resolution, Rule, Tag,
+    Upload, get_reports_subquery,
 )
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 from api.permissions import ResourceScope
 from api.serializers import (
     ExportHitsSerializer, RuleExportSerializer, ReportExportSerializer,
@@ -271,6 +272,33 @@ def transform_hits(report):
     }
 
 
+def transform_hits_local(report):
+    return {
+        'hostname': report['advisor_inventory__display_name'],
+        'rhel_version': AdvisorInventoryHost.get_rhel_version_from_flat(
+            report['advisor_inventory__os_major'],
+            report['advisor_inventory__os_minor'],
+            report['advisor_inventory__os_name'],
+        ),
+        'uuid': str(report['host_id']),
+        'last_seen': report['last_upload'].isoformat(),
+        'title': report['rule__description'],
+        'solution_url': (
+            f"https://access.redhat.com/node/{report['rule__node_id']}"
+            if report['rule__node_id'] else ''
+        ),
+        'total_risk': report['rule__total_risk'],
+        'likelihood': report['rule__likelihood'],
+        'publish_date': report['rule__publish_date'].isoformat(),
+        'stale_at': report['advisor_inventory__per_reporter_staleness__puptoo__stale_timestamp'],
+        'results_url': "{base}/{rule_id}/{sys_id}/".format(
+            base='https://console.redhat.com/insights/advisor/recommendations',
+            rule_id=report['rule__rule_id'].replace('|', '%7C'),
+            sys_id=report['host_id']
+        )
+    }
+
+
 class HitsViewSet(ExportViewSet):
     """
     Export the hosts and rules listing as CSV or JSON.
@@ -290,6 +318,9 @@ class HitsViewSet(ExportViewSet):
         the hosts. The accepted content type supplied in the request headers
         is used to determine the supplied content type.
         """
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+        inv_relation = 'advisor_inventory' if use_local else 'inventory'
+
         last_seen_upload_qs = Upload.objects.filter(
             host_id=OuterRef('host_id'), source_id=1, current=True
         ).order_by().values('checked_on')
@@ -298,20 +329,34 @@ class HitsViewSet(ExportViewSet):
             'host', 'rule__rule_id'
         ).annotate(
             last_upload=Subquery(last_seen_upload_qs)
-        ).values(  # also acts as a select_related
+        )
+
+        rule_value_fields = [
             'rule__rule_id', 'rule__description', 'rule__node_id',
             'rule__total_risk', 'rule__likelihood', 'rule__publish_date',
-            'rule__category__name', 'inventory__updated', 'host_id',
-            'last_upload',
-            'inventory__per_reporter_staleness__puptoo__stale_timestamp',
-            'inventory__display_name', 'inventory__system_profile',  # for rhel_version
+            'rule__category__name', 'host_id', 'last_upload',
             'rule__reboot_required',
-        )
-        if request.query_params:
-            # Process parameters in alphabetical order, not because it should
-            # make any difference to the query (since the conditions are ANDed
-            # together) but for ease of code maintenance.
+        ]
+        if use_local:
+            inv_value_fields = [
+                f'{inv_relation}__updated',
+                f'{inv_relation}__per_reporter_staleness__puptoo__stale_timestamp',
+                f'{inv_relation}__display_name',
+                f'{inv_relation}__os_major',
+                f'{inv_relation}__os_minor',
+                f'{inv_relation}__os_name',
+            ]
+        else:
+            inv_value_fields = [
+                'inventory__updated',
+                'inventory__per_reporter_staleness__puptoo__stale_timestamp',
+                'inventory__display_name',
+                'inventory__system_profile',
+            ]
 
+        reports = reports.values(*rule_value_fields, *inv_value_fields)
+
+        if request.query_params:
             reports = reports.filter(
                 filter_on_param('rule__category_id', category_query_param, request),
                 filter_on_param('rule__impact__impact', impact_query_param, request),
@@ -322,14 +367,14 @@ class HitsViewSet(ExportViewSet):
                 filter_on_incident(request),
                 filter_on_reboot_required(request),
                 filter_on_has_playbook(request),
-                filter_on_display_name(request, 'inventory'),
+                filter_on_display_name(request, inv_relation),
                 filter_on_host_id(request),
                 filter_on_topic(request, relation='rule'),
             )
 
-        # Return all the data
+        hits_transformer = transform_hits_local if use_local else transform_hits
         return self.stream_response(
-            reports, 'hits', transform_hits, format
+            reports, 'hits', hits_transformer, format
         )
 
 
@@ -428,15 +473,23 @@ class SystemsViewSet(ExportViewSet):
     renderer_classes = (JSONRenderer, SystemsCSVRenderer, )
     serializer_class = SystemSerializer
 
+    def get_serializer_class(self):
+        from api.serializers import get_system_serializer
+        return get_system_serializer()
+
     @extend_schema(
         parameters=systems_common_parameters,
     )
     def list(self, request, format=None):
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+        id_field = 'inventory_id' if use_local else 'id'
+        host_id_ref = OuterRef('inventory_id') if use_local else OuterRef('id')
+
         sort = value_of_param(systems_sort_query_param, request)
         rule_id_value = value_of_param(rule_id_query_param, request)
         display_name_value = value_of_param(display_name_query_param, request)
         reports = get_reports_subquery(
-            request, exclude_ineligible_hosts=False, host=OuterRef('id'),
+            request, exclude_ineligible_hosts=False, host=host_id_ref,
         ).filter(
             filter_on_topic(request, relation='rule'),
             rule__rule_id=rule_id_value,
@@ -444,9 +497,9 @@ class SystemsViewSet(ExportViewSet):
         systems = get_systems_queryset(request).filter(
             Q(display_name__icontains=display_name_value) if display_name_value else Q(),
             Exists(reports) if rule_id_value else Q()
-        ).order_by(sort, 'id')
+        ).order_by(sort, id_field)
         return self.stream_response(
-            systems, 'systems', format=format  # no transform = use serializer
+            systems, 'systems', format=format
         )
 
 

--- a/api/advisor/api/views/export.py
+++ b/api/advisor/api/views/export.py
@@ -499,7 +499,9 @@ class SystemsViewSet(ExportViewSet):
             Exists(reports) if rule_id_value else Q()
         ).order_by(sort, id_field)
         return self.stream_response(
-            systems, 'systems', format=format
+            systems, 'systems',
+            transformer=make_serializer_transform(self.get_serializer_class()),
+            format=format,
         )
 
 

--- a/api/advisor/api/views/hostacks.py
+++ b/api/advisor/api/views/hostacks.py
@@ -29,8 +29,9 @@ from api.filters import (
     host_group_name_query_param, filter_on_host_tags
 )
 from api.models import (
-    HostAck, stale_systems_q
+    AdvisorInventoryHost, HostAck, stale_systems_q
 )
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 from api.permissions import (
     request_to_username, InsightsRBACPermission, CertAuthPermission,
     request_to_org, IsRedHatInternalUser, ResourceScope,
@@ -94,9 +95,12 @@ class HostAckViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         # its primary key.  This is the least-pain defence against that.
         swagger_fake_view = getattr(self, 'swagger_fake_view', False)
         org_id = request_to_org(self.request) if not swagger_fake_view else None
+        if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+            stale_filter = stale_systems_q(org_id, field='host_id', model_class=AdvisorInventoryHost)
+        else:
+            stale_filter = stale_systems_q(org_id, field='host_id')
         return self.queryset.filter(
-            stale_systems_q(org_id, field='host_id'),
-            # TODO should filter on host groups too, to prevent acking a host you dont have access to, or seeing acks for hosts you no longer have access to
+            stale_filter,
             org_id=org_id
         )
 
@@ -115,12 +119,18 @@ class HostAckViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
 
         Hostacks are retrieved, edited and deleted by the 'id' field.
         """
-        system_profile_filter = filter_multi_param(
-            request, 'system_profile', field_prefix='host__inventory'
-        )
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+        if use_local:
+            system_profile_filter = filter_multi_param(
+                request, 'system_profile', field_prefix='host__advisor_inventory', use_local=True
+            )
+        else:
+            system_profile_filter = filter_multi_param(
+                request, 'system_profile', field_prefix='host__inventory'
+            )
         qs = self.get_queryset().filter(
             filter_on_param('rule__rule_id', rule_id_param, request),
-            filter_on_host_tags(request, field_name='host_id'),
+            filter_on_host_tags(request, field_name='host_id', use_local=use_local),
             system_profile_filter,
         )
         return self._paginated_response(qs, request)

--- a/api/advisor/api/views/pathways.py
+++ b/api/advisor/api/views/pathways.py
@@ -33,7 +33,7 @@ from api.filters import (
 from api.models import Pathway, Resolution
 from api.permissions import InsightsRBACPermission, ResourceScope
 from api.serializers import (
-    PathwaySerializer, SystemSerializer,
+    PathwaySerializer, SystemSerializer, get_system_serializer,
     RuleForAccountSerializer, RuleSystemsExportSerializer,
 )
 from api.utils import (
@@ -260,7 +260,7 @@ class PathwayViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
             filter_on_text_system(request)
         ).order_by('display_name')
         return self._paginated_response(impacted_systems, request,
-                                        serializer_class=SystemSerializer)
+                                        serializer_class=get_system_serializer())
 
     @extend_schema(
         parameters=[

--- a/api/advisor/api/views/rule_topics.py
+++ b/api/advisor/api/views/rule_topics.py
@@ -41,7 +41,8 @@ from api.serializers import (
     RuleSerializer, SystemsForRuleSerializer, TopicSerializer, TopicEditSerializer
 )
 from api.utils import CustomPageNumberPagination
-from api.views.rules import systems_sort_field_map, systems_sort_query_param
+from api.views.rules import systems_sort_field_map, systems_sort_field_map_local, systems_sort_query_param
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 
 
 show_disabled_query_param = OpenApiParameter(
@@ -135,7 +136,11 @@ class RuleTopicViewSet(viewsets.ReadOnlyModelViewSet):
         # Avoid get_queryset because of annotation:
         topic = get_object_or_404(RuleTopic, slug=slug)
         sort_list = value_of_param(systems_sort_query_param, request)
-        sort_fields = sort_params_to_fields(sort_list, systems_sort_field_map)
+        if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+            active_sort_map = systems_sort_field_map_local
+        else:
+            active_sort_map = systems_sort_field_map
+        sort_fields = sort_params_to_fields(sort_list, active_sort_map)
         # Because we're possibly seeing the current reports for different
         # rules on the same system, we need to make the sort fields distinct.
         impacted_systems = get_reporting_system_ids_queryset(

--- a/api/advisor/api/views/rules.py
+++ b/api/advisor/api/views/rules.py
@@ -46,8 +46,10 @@ from api.serializers import (
     RuleForAccountSerializer, RuleUsageStatsSerializer, SystemsForRuleSerializer,
     MultiHostAckSerializer, MultiHostUnAckSerializer, MultiAckResponseSerializer,
     JustificationCountSerializer, ReportForRuleSerializer,
-    RuleSerializer, SystemsDetailSerializer
+    RuleSerializer, SystemsDetailSerializer,
+    get_systems_detail_serializer,
 )
+from feature_flags import feature_flag_is_enabled, FLAG_READ_LOCAL_INVENTORY
 from api.permissions import (
     TurnpikeIdentityAuthentication,
     IsRedHatInternalUser, InsightsRBACPermission, CertAuthPermission,
@@ -175,6 +177,11 @@ systems_sort_field_map = {
     'stale_at': 'inventory__stale_timestamp', 'system_uuid': 'host_id',
     'updated': 'inventory__updated'
 }
+systems_sort_field_map_local = {
+    'display_name': 'advisor_inventory__display_name', 'last_seen': 'last_upload',
+    'stale_at': 'advisor_inventory__stale_timestamp', 'system_uuid': 'host_id',
+    'updated': 'advisor_inventory__updated'
+}
 systems_sort_query_param = OpenApiParameter(
     name='sort', location=OpenApiParameter.QUERY,
     description="Order by this field",
@@ -194,6 +201,10 @@ systems_detail_sort_field_map = {
         'system_profile__operating_system__minor'
     ],
     'group_name': 'groups__0__name'
+}
+systems_detail_sort_field_map_local = {
+    'rhel_version': ['os_major', 'os_minor'],
+    'group_name': 'workspace_name',
 }
 systems_detail_sort_query_param = OpenApiParameter(
     name='sort', location=OpenApiParameter.QUERY,
@@ -522,8 +533,14 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         of systems and accounts impacted by a rule.
         """
         rule = get_object_or_404(Rule, rule_id=rule_id)
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+        inv_relation = 'advisor_inventory' if use_local else 'inventory'
+        staleness_kwarg = {
+            f'{inv_relation}__per_reporter_staleness__puptoo__stale_warning_timestamp__gt':
+            str(timezone.now())
+        }
         hit_counts = CurrentReport.objects.filter(
-            inventory__per_reporter_staleness__puptoo__stale_warning_timestamp__gt=str(timezone.now()),
+            **staleness_kwarg,
             rule=rule,
         ).aggregate(
             systems_hit=Count('host_id', distinct=True),
@@ -588,25 +605,26 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         Insights Inventory UUID.
         """
         rule = get_object_or_404(Rule, rule_id=rule_id)
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+        active_sort_map = systems_sort_field_map_local if use_local else systems_sort_field_map
+        inv_relation = 'advisor_inventory' if use_local else 'inventory'
         sort_fields = sort_params_to_fields(
             value_of_param(systems_sort_query_param, request),
-            systems_sort_field_map
+            active_sort_map
         )
 
-        # NOTE: host tags are filtered inside the Rule model's
-        # impacted_systems method.  Have to use the reports_for_account method
-        # so that we cope with systems that are host-acked as well as this
-        # rule being acked.
         impacted_systems = (
             get_reporting_system_ids_queryset(
                 request, rule=rule
             )
             .filter(
                 filter_on_display_name(
-                    request, relation='inventory',
+                    request, relation=inv_relation,
                     param=systems_detail_name_query_param
                 ),
-                filter_on_rhel_version(request, relation='inventory'),
+                filter_on_rhel_version(
+                    request, relation=inv_relation, use_local=use_local
+                ),
             )
             .order_by(*sort_fields, 'host_id')
         )
@@ -639,12 +657,18 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         Additional information includes hit counts and upload/stale timestamps.
         """
         rule = self.get_object()
+        use_local = feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY)
+        active_sort_map = (
+            systems_detail_sort_field_map_local if use_local
+            else systems_detail_sort_field_map
+        )
+        host_id_ref = OuterRef('inventory_id') if use_local else OuterRef('id')
         sort_fields = sort_params_to_fields(
             value_of_param(systems_detail_sort_query_param, request),
-            systems_detail_sort_field_map
+            active_sort_map
         )
         reports = get_reports_subquery(
-            request, exclude_ineligible_hosts=False, host=OuterRef('id'),
+            request, exclude_ineligible_hosts=False, host=host_id_ref,
             rule=rule
         )
         systems_detail_qs = (
@@ -653,7 +677,7 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
                 filter_on_display_name(
                     request, param=systems_detail_name_query_param,
                 ),
-                filter_on_rhel_version(request),
+                filter_on_rhel_version(request, use_local=use_local),
                 Exists(reports)
             )
             .annotate(impacted_date=Subquery(reports.values('impacted_date')))
@@ -661,7 +685,8 @@ class RuleViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         )
 
         return self._paginated_response(
-            systems_detail_qs, request, serializer_class=SystemsDetailSerializer
+            systems_detail_qs, request,
+            serializer_class=get_systems_detail_serializer()
         )
 
 

--- a/api/advisor/api/views/systems.py
+++ b/api/advisor/api/views/systems.py
@@ -127,7 +127,7 @@ class SystemViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         )
         systems = self.get_queryset().order_by(*sort_fields, id_field)
 
-        return self._paginated_response(systems, request)
+        return self._paginated_response(systems, request, serializer_class=self.get_serializer_class())
 
     @extend_schema(
         parameters=[

--- a/api/advisor/api/views/systems.py
+++ b/api/advisor/api/views/systems.py
@@ -84,7 +84,7 @@ class SystemViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
     lookup_field = 'id'
     lookup_url_kwarg = 'uuid'
     pagination_class = CustomPageNumberPagination
-    queryset = InventoryHost.objects.all()
+    queryset = InventoryHost.objects.all()  # overridden by get_queryset()
     resource_name = 'recommendation-results'
     resource_scope = ResourceScope.WORKSPACE
     serializer_class = SystemSerializer

--- a/api/advisor/api/views/systems.py
+++ b/api/advisor/api/views/systems.py
@@ -155,7 +155,7 @@ class SystemViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
         active_reports = get_reports_subquery(
             request, host_id=uuid, use_joins=True
         ).select_related(
-            'rule__category', 'rule__impact', 'rule__ruleset',
+            'upload', 'rule__category', 'rule__impact', 'rule__ruleset',
         ).prefetch_related(
             'rule__resolution_set', 'rule__resolution_set__playbook_set',
             'rule__resolution_set__resolution_risk',

--- a/api/advisor/api/views/systems.py
+++ b/api/advisor/api/views/systems.py
@@ -33,10 +33,11 @@ from api.filters import (
     update_method_query_param, has_disabled_recommendation_query_param,
 )
 from api.models import (
-    InventoryHost, get_systems_queryset, get_reports_subquery
+    InventoryHost,
+    get_systems_queryset, get_reports_subquery
 )
 from api.permissions import ResourceScope
-from api.serializers import ReportSerializer, SystemSerializer
+from api.serializers import ReportSerializer, SystemSerializer, get_system_serializer
 from api.utils import (
     CustomPageNumberPagination, PaginateMixin,
 )
@@ -88,8 +89,10 @@ class SystemViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
     resource_scope = ResourceScope.WORKSPACE
     serializer_class = SystemSerializer
 
+    def get_serializer_class(self):
+        return get_system_serializer()
+
     def get_queryset(self):
-        # Used in export systems as well
         return get_systems_queryset(self.request)
 
     @extend_schema(

--- a/api/advisor/api/views/systems.py
+++ b/api/advisor/api/views/systems.py
@@ -92,6 +92,11 @@ class SystemViewSet(PaginateMixin, viewsets.ReadOnlyModelViewSet):
     def get_serializer_class(self):
         return get_system_serializer()
 
+    def get_object(self):
+        if feature_flag_is_enabled(FLAG_READ_LOCAL_INVENTORY):
+            self.lookup_field = 'inventory_id'
+        return super().get_object()
+
     def get_queryset(self):
         return get_systems_queryset(self.request)
 

--- a/service/tests/test_advisor_service.py
+++ b/service/tests/test_advisor_service.py
@@ -1237,7 +1237,7 @@ def test_advisor_inventory_host_rhel_version_name_only(db):
 @pytest.mark.django_db(transaction=True)
 def test_advisor_inventory_host_rhel_version_unknown(db):
     host = models.AdvisorInventoryHost(os_name=None, os_major=None, os_minor=None, org_id="123")
-    assert host.rhel_version == "Unknown OS version"
+    assert host.rhel_version == "Unknown system version"
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Resolves: [RHINENG-29265](https://redhat.atlassian.net/browse/RHINENG-29265)

This PR depends on #204 

## Summary

Migrate all remaining `InventoryHost` references to `AdvisorInventoryHost` behind `advisor.read_local_inventory`. When the flag is on, zero queries hit the Cyndi `inventory.hosts` table. Uses `use_local` branching throughout to facilitate future dead-code removal.

## Changes

- **models.py**: Add `Host.advisor_inventory` Relationship via `(inventory_id, org_id)`, extract `get_rhel_version_from_flat()` static method, branch `Pathway.impacted_systems()`
- **serializers.py**: Branch validators (`existing_host_id_validator`, `validate_hosts_in_org`), convert `HostAckSerializer.display_name` to `SerializerMethodField`, add `AdvisorSystem*Serializer` subclasses with runtime helpers
- **views**: Branch export (`transform_hits_local`, field lists, relation prefixes), rules (sort maps, `systems`/`systems_detail`/`stats`), systems/pathways (`get_serializer_class` override)
- **management commands**: Branch `get_inventory_hosts_stats()` in weekly report, branch raw SQL join in `delete_stale_api_hosts`
- **tests**: Extract `AdvisorInventoryTestMixin` to shared module, add flag-on tests for all migrated code paths


[RHINENG-29265]: https://redhat.atlassian.net/browse/RHINENG-29265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Gate all remaining InventoryHost usage behind the advisor.read_local_inventory flag so systems, rules, exports, and reports can operate on AdvisorInventoryHost without touching the legacy inventory.hosts table.

New Features:
- Add AdvisorInventoryHost manager and Host.advisor_inventory relationship to support local inventory-backed queries.
- Introduce feature-flagged serializers and view branching so systems, rules, pathways, and exports work with AdvisorInventoryHost data.
- Extend advisor inventory ingestion to capture workspace_ungrouped and flatten additional system profile fields for querying.

Bug Fixes:
- Ensure stale host cleanup and weekly report stats correctly handle AdvisorInventoryHost records when the local inventory flag is enabled.
- Fix certificate auth, host group, RHEL version, workload, and update method filters to work against both legacy and advisor inventory backends.

Enhancements:
- Refine shared filters and query helpers to support dual backends via a use_local switch and adjusted field mappings.
- Update impacted_systems and stale_systems_q logic to operate on inventory_id-based AdvisorInventoryHost identifiers when the flag is on.

Tests:
- Add AdvisorInventoryTestMixin and new flag-on test suites for systems, exports, rules, pathways, delete_stale_api_hosts, and weekly report commands to validate AdvisorInventoryHost behavior.