### PR TITLE
Another attempt at getting prometheus metrics collection working

### DIFF
--- a/api/advisor/gunicorn_conf.py
+++ b/api/advisor/gunicorn_conf.py
@@ -18,7 +18,16 @@ def post_fork(server, worker):
     """
     import feature_flags
     from feature_flags import Client
+    from prometheus_client import values
 
     server.log.info(f"Worker {worker.pid}: Creating new UnleashClient...")
-
     feature_flags._client = Client().connect()
+
+    server.log.info("Resetting prometheus state so each worker writes to its own .db file...")
+    values.ValueClass = values.MultiProcessValue()
+
+
+def child_exit(server, worker):
+    # Clean up dead worker .db files from /tmp
+    from prometheus_client import multiprocess
+    multiprocess.mark_process_dead(worker.pid)


### PR DESCRIPTION
## Summary by Sourcery

Configure Gunicorn worker lifecycle hooks to correctly handle Prometheus multiprocess metrics state per worker and clean up stale metric files.

Enhancements:
- Reset Prometheus multiprocess state in post-fork so each worker writes metrics to its own database file.
- Mark worker processes as dead on child exit to trigger cleanup of their Prometheus multiprocess metric files.