### PR TITLE
fix(RHINENG-25917): Fix creating a new topic

### DIFF
--- a/api/advisor/api/internal_urls.py
+++ b/api/advisor/api/internal_urls.py
@@ -18,7 +18,7 @@ from django.urls import path, include
 
 from rest_framework.routers import APIRootView, DefaultRouter
 
-from api.views import rules, rule_topics
+from api.views import rules
 
 
 class InternalRootView(APIRootView):
@@ -37,7 +37,6 @@ class InternalRouter(DefaultRouter):
 
 router = InternalRouter()
 router.register(r'rule', rules.InternalRuleViewSet, basename='internal-rule')
-router.register(r'ruletopic', rule_topics.InternalRuleTopicViewSet, basename='internal-ruletopic')
 
 urlpatterns = [
     path(r'', include(router.urls)),

--- a/api/advisor/api/tests/test_rule_topic_views.py
+++ b/api/advisor/api/tests/test_rule_topic_views.py
@@ -116,7 +116,7 @@ class RuleTopicViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 405)
         # Nor the internal API either, this gives permission denied.
         response = self.client.patch(
-            reverse('internal-ruletopic-detail', kwargs={'slug': 'Disabled'}),
+            reverse('ruletopic-admin-detail', kwargs={'slug': 'Disabled'}),
             data={'enabled': True},
             content_type=constants.json_mime,
             **self.is_internal_auth
@@ -124,7 +124,7 @@ class RuleTopicViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 403)
         # But using the Turnpike internal API works
         response = self.client.patch(
-            reverse('internal-ruletopic-detail', kwargs={'slug': 'Disabled'}),
+            reverse('ruletopic-admin-detail', kwargs={'slug': 'Disabled'}),
             data={'enabled': True},
             content_type=constants.json_mime,
             **self.turnpike_auth
@@ -150,7 +150,7 @@ class RuleTopicViewsTestCase(TestCase):
         self.assertEqual(topic['enabled'], True)
         # Take an enabled topic, and disable it,
         response = self.client.patch(
-            reverse('internal-ruletopic-detail', kwargs={'slug': 'Active'}),
+            reverse('ruletopic-admin-detail', kwargs={'slug': 'Active'}),
             data={'enabled': False},
             content_type=constants.json_mime,
             **self.turnpike_auth
@@ -229,7 +229,7 @@ class RuleTopicViewsTestCase(TestCase):
 
         # Adding a new topic with a nonexistent tag should report 400
         response = self.client.post(
-            reverse('internal-ruletopic-list'), data={
+            reverse('ruletopic-admin-list'), data={
                 'name': 'New topic',
                 'slug': 'New',
                 'description': 'A new topic created through the API',
@@ -242,7 +242,7 @@ class RuleTopicViewsTestCase(TestCase):
 
         # Adding a new topic should return that data
         response = self.client.post(
-            reverse('internal-ruletopic-list'), data={
+            reverse('ruletopic-admin-list'), data={
                 'name': 'New topic',
                 'slug': 'New',
                 'description': 'A new topic created through the API',
@@ -290,7 +290,7 @@ class RuleTopicViewsTestCase(TestCase):
 
         # Now delete it
         response = self.client.delete(
-            reverse('internal-ruletopic-detail', kwargs={'slug': 'New'}),
+            reverse('ruletopic-admin-detail', kwargs={'slug': 'New'}),
             **self.turnpike_auth
         )
         self.assertEqual(response.status_code, 204)
@@ -326,7 +326,7 @@ class RuleTopicViewsTestCase(TestCase):
         self.assertEqual(response.status_code, 405)
         # Update topic with new details - including slug!
         response = self.client.patch(
-            reverse('internal-ruletopic-detail', kwargs={'slug': 'Active'}), data={
+            reverse('ruletopic-admin-detail', kwargs={'slug': 'Active'}), data={
                 'name': 'Active topic (updated)',
                 'slug': 'Updated',
             },

--- a/api/advisor/api/urls.py
+++ b/api/advisor/api/urls.py
@@ -16,7 +16,7 @@
 
 from django.urls import path, include
 
-from rest_framework.routers import APIRootView, DefaultRouter
+from rest_framework.routers import APIRootView, DefaultRouter, SimpleRouter
 
 # Flake8 doesn't like star imports, and we can't seem to do 'from api import
 # views' and then use views.acks.AckViewSet.  Better solutions welcomed!
@@ -74,6 +74,10 @@ router.register(
     basename='weeklyreportautosubscribe'
 )
 
+# Internal-only routes not shown in the API root listing.
+internal_router = SimpleRouter()
+internal_router.register(r'topic-admin', rule_topics.RuleTopicAdminViewSet, basename='ruletopic-admin')
+
 advisor_schema_settings = {
     'TITLE': 'Insights Advisor API',
     'DESCRIPTION': "The API for viewing Red Hat recommendations for your systems",
@@ -83,6 +87,7 @@ advisor_schema_settings = {
 
 urlpatterns = [
     path(r'', include(router.urls)),
+    path(r'', include(internal_router.urls)),
     path(r'export/', include(export.router.urls), name='export-list'),
     path('openapi/', swagger.spectacular_view, name='advisor-openapi-spec'),
     path('openapi.json', swagger.spectacular_json_view, name='advisor-openapi-spec-json'),

--- a/api/advisor/api/views/rule_topics.py
+++ b/api/advisor/api/views/rule_topics.py
@@ -21,7 +21,7 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 
 from api.filters import (
     value_of_param, host_tags_query_param,
@@ -168,9 +168,17 @@ class RuleTopicViewSet(viewsets.ReadOnlyModelViewSet):
         ).data)
 
 
-class InternalRuleTopicViewSet(viewsets.ModelViewSet):
+@extend_schema_view(
+    list=extend_schema(exclude=True),
+    create=extend_schema(exclude=True),
+    retrieve=extend_schema(exclude=True),
+    update=extend_schema(exclude=True),
+    partial_update=extend_schema(exclude=True),
+    destroy=extend_schema(exclude=True),
+)
+class RuleTopicAdminViewSet(viewsets.ModelViewSet):
     """
-    Internal editing interface for rule topics.
+    Editing interface for rule topics.
 
     This viewset is only available to Red hat associates.
     """


### PR DESCRIPTION
## Summary by Sourcery

Adjust rule topic admin API endpoints and routing to restore topic creation functionality for internal users while keeping the endpoints hidden from the public API schema.

Bug Fixes:
- Fix topic creation, update, enable/disable, and delete operations by switching tests and clients to the new rule topic admin endpoints.

Enhancements:
- Introduce a dedicated internal-only RuleTopicAdminViewSet with schema exclusions so rule topic admin operations are not exposed in the public OpenAPI documentation.
- Refactor URL routing to use a separate internal router for topic admin endpoints and remove the old InternalRuleTopicViewSet registration from internal_urls.