### PR TITLE
fix(RHINENG-28754): Fix Prometheus metrics on Clowder metrics port 9000

### DIFF
--- a/api/advisor/gunicorn_conf.py
+++ b/api/advisor/gunicorn_conf.py
@@ -6,6 +6,63 @@ from logging_conf import logconfig_dict
 logconfig_dict = logconfig_dict
 
 
+def on_starting(server):
+    """Start a multiprocess-aware Prometheus metrics server on the Clowder metrics port.
+
+    Clowder configures a separate metricsPort (typically 9000) that Prometheus scrapes.
+    django_prometheus's built-in start_http_server() uses the default in-process registry,
+    which doesn't work with gunicorn multiprocess mode — it misses all the per-worker
+    metrics stored in .db files. Instead, we start a custom HTTP server that uses
+    MultiProcessCollector to aggregate metrics from all worker .db files on each scrape.
+    """
+    import os
+    import threading
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+
+    from django.conf import settings
+    from advisor_logging import logger
+
+    metrics_port = getattr(settings, 'PROMETHEUS_PORT', None)
+    if metrics_port is None or metrics_port == int(os.getenv('GUNICORN_PORT', '8000')):
+        return  # Metrics served via Django view on the same port; no separate server needed.
+
+    class MultiProcessMetricsHandler(BaseHTTPRequestHandler):
+        """HTTP handler that collects metrics from all gunicorn worker .db files."""
+
+        def do_GET(self):
+            try:
+                import prometheus_client
+                from prometheus_client import CollectorRegistry, generate_latest, multiprocess
+
+                registry = CollectorRegistry()
+                multiprocess.MultiProcessCollector(registry)
+                output = generate_latest(registry)
+                self.send_response(200)
+                self.send_header('Content-Type', prometheus_client.CONTENT_TYPE_LATEST)
+                self.end_headers()
+                self.wfile.write(output)
+            except Exception:
+                # Return 500 so the endpoint stays available despite collection failures
+                logger("Failed to collect multiprocess Prometheus metrics", exc_info=True)
+                self.send_response(500)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                try:
+                    self.wfile.write(b"Internal Server Error while collecting metrics\n")
+                except Exception:
+                    # If the client has gone away, just swallow the error; logging above is enough
+                    pass
+
+        def log_message(self, format, *args):
+            pass  # Suppress per-request access logs
+
+    addr = getattr(settings, 'PROMETHEUS_METRICS_EXPORT_ADDRESS', '')
+    httpd = HTTPServer((addr, metrics_port), MultiProcessMetricsHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    server.log.info(f"Multiprocess Prometheus metrics server started on port {metrics_port}")
+
+
 def post_fork(server, worker):
     """
     This hook is called after a worker has been forked.

--- a/api/advisor/project_settings/settings.py
+++ b/api/advisor/project_settings/settings.py
@@ -304,9 +304,12 @@ else:
     PROMETHEUS_PATH = os.getenv('PROMETHEUS_PATH', 'metrics')
     PROMETHEUS_PORT = int(os.getenv('PROMETHEUS_PORT', 8000))
 
-# if the prometheus port is not 8000 then export
-if PROMETHEUS_PORT != 8000:
-    PROMETHEUS_METRICS_EXPORT_PORT = int(PROMETHEUS_PORT)
+# Note: We intentionally do NOT set PROMETHEUS_METRICS_EXPORT_PORT here.
+# django_prometheus's start_http_server() uses the default in-process registry,
+# which doesn't work with gunicorn's multiprocess mode (workers write to per-PID
+# .db files via MultiProcessValue, but the standalone server doesn't aggregate
+# them via MultiProcessCollector). Instead, we start a custom multiprocess-aware
+# metrics server in gunicorn_conf.py that properly collects from all worker .db files.
 PROMETHEUS_METRICS_EXPORT_ADDRESS = '0.0.0.0'  # listen on all addresses
 
 DATABASE_ROUTERS = ['project_settings.db_routing.ReadOnlyReplicaRouter']


### PR DESCRIPTION
Clowder assigns a separate metricsPort (9000) that Prometheus scrapes. django_prometheus's start_http_server() was serving on this port using the default in-process registry, which doesn't work with gunicorn's multiprocess mode — workers write metrics to per-PID .db files, but the standalone server never aggregates them via MultiProcessCollector. This caused django_http_* metrics (e.g. responses_total_by_status) to appear empty on the scraped port while being correct on port 8000.

Fix: Remove PROMETHEUS_METRICS_EXPORT_PORT so django_prometheus doesn't start its broken standalone server. Instead, add a gunicorn on_starting hook that starts a custom HTTP server on the metrics port using MultiProcessCollector to properly aggregate all worker .db files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure gunicorn to serve Prometheus metrics on the Clowder metrics port using a multiprocess-aware collector instead of django_prometheus’s built-in standalone server.

Bug Fixes:
- Ensure Prometheus metrics scraped from the Clowder metrics port aggregate data from all gunicorn workers rather than using an incorrect in-process registry.

Enhancements:
- Add a gunicorn on_starting hook that launches a dedicated HTTP server for Prometheus metrics using MultiProcessCollector.
- Clarify Prometheus settings by removing PROMETHEUS_METRICS_EXPORT_PORT configuration and documenting the custom multiprocess metrics server behavior.