### PR TITLE
fix: start Prometheus HTTP server in inventory replication service

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -23,6 +23,7 @@ import prometheus
 import signal
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from prometheus_client import start_http_server
 from django.db import transaction
 from django.db.models import Q
 from django.utils.dateparse import parse_datetime
@@ -416,6 +417,8 @@ class Command(BaseCommand):
         Run the handler loop continuously until interrupted by SIGTERM.
         """
         logger.info('Advisor Inventory replication service starting up')
+        start_http_server(settings.PROMETHEUS_PORT)
+        logger.info('Prometheus metrics server started on port %d', settings.PROMETHEUS_PORT)
         settings.KAFKA_SETTINGS.update({
             'group.id': settings.GROUP_ID,
             'enable.auto.commit': False,


### PR DESCRIPTION
The advisor_inventory_service management command increments Prometheus counters but never exposed them via an HTTP endpoint for scraping. Start start_http_server on the Clowder metricsPort so Prometheus can discover and collect the metrics.

## Summary by Sourcery

Bug Fixes:
- Ensure Prometheus counters emitted by the advisor inventory replication service are accessible to Prometheus via an HTTP endpoint.