### PR TITLE
fix: filter out inventory events with nil UUID insights_id

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -35,6 +35,8 @@ from api.models import AdvisorInventoryHost, Host
 
 from kafka_utils import JsonValue, KafkaDispatcher
 
+NIL_UUID = '00000000-0000-0000-0000-000000000000'
+
 
 @dataclass
 class ParsedInventoryHost:
@@ -265,11 +267,20 @@ def parse_created_event(message: dict[str, JsonValue]) -> ParsedInventoryHost | 
         return None
 
     if not insights_id:
-        logger.error(
+        # Defensive: HBI always provides insights_id, but guard against upstream changes
+        logger.warning(
             "Request %s: Inventory %s event has null or empty insights_id for host %s",
             request_id, event_type, host_id
         )
         prometheus.INVENTORY_EVENT_MISSING_KEYS.inc()
+        return None
+
+    if insights_id == NIL_UUID:
+        logger.info(
+            "Request %s: Inventory %s event filtered — host %s has nil insights_id",
+            request_id, event_type, host_id
+        )
+        prometheus.INVENTORY_EVENT_INSIGHTS_ONLY_FILTERED.inc()
         return None
 
     system_profile_raw: dict[str, JsonValue] = system_profile_field

--- a/api/advisor/api/tests/test_advisor_inventory_service.py
+++ b/api/advisor/api/tests/test_advisor_inventory_service.py
@@ -27,7 +27,7 @@ from django.core.signals import request_started, request_finished
 from kafka_utils import DummyConsumer, JsonValue, KafkaDispatcher
 # from project_settings import kafka_settings
 from api.management.commands.advisor_inventory_service import (
-    handle_inventory_event, parse_created_event, parse_deleted_event,
+    handle_inventory_event, parse_created_event, parse_deleted_event, NIL_UUID,
 )
 from api.models import AdvisorInventoryHost, CurrentReport, Host, HostAck, InventoryHost, Upload
 from api.tests import constants
@@ -361,6 +361,29 @@ class TestAdvisorInventoryServer(TestCase):
             )
             self.assertIsNotNone(result)
             self.assertIsNone(result.satellite_id)
+
+    @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
+    def test_created_message_filtered_nil_insights_id(self):
+        """
+        Test that hosts with nil UUID insights_id are filtered out (insightsOnly filter).
+        """
+        modified_msg = deepcopy(create_new_host_msg)
+        modified_msg['host']['insights_id'] = NIL_UUID
+
+        with self.assertLogs(logger='advisor-log', level='DEBUG') as logs:
+            handle_inventory_event('topic', [modified_msg])
+            log_lines = [line for line in logs.output if 'Using Cyndi replication view' not in line]
+            self.assertTrue(
+                any("has nil insights_id" in line for line in log_lines),
+                "Should log that nil insights_id was filtered"
+            )
+
+        self.assertFalse(
+            AdvisorInventoryHost.objects.filter(
+                inventory_id=new_host_id, org_id=constants.standard_org
+            ).exists(),
+            "Host with nil insights_id should not be upserted"
+        )
 
     @set_unleash_flag(FLAG_ENABLE_INVENTORY_REPLICATION, True)
     def test_updated_message_success(self):

--- a/api/advisor/prometheus.py
+++ b/api/advisor/prometheus.py
@@ -29,7 +29,7 @@ INVENTORY_EVENT_MALFORMED = Counter(
 )
 INVENTORY_EVENT_INSIGHTS_ONLY_FILTERED = Counter(
     'insights_advisor_api_inventory_event_insights_only_filtered',
-    'Counter for inventory events filtered out due to missing or nil insights_id'
+    'Counter for inventory events filtered out due to nil insights_id (insightsOnly filter)'
 )
 INVENTORY_HOST_UPSERTED = Counter(
     'insights_advisor_api_inventory_host_upserted',

--- a/api/advisor/prometheus.py
+++ b/api/advisor/prometheus.py
@@ -27,6 +27,10 @@ INVENTORY_EVENT_MALFORMED = Counter(
     'insights_advisor_api_inventory_event_malformed',
     'Counter for inventory events that failed validation or parsing'
 )
+INVENTORY_EVENT_INSIGHTS_ONLY_FILTERED = Counter(
+    'insights_advisor_api_inventory_event_insights_only_filtered',
+    'Counter for inventory events filtered out due to missing or nil insights_id'
+)
 INVENTORY_HOST_UPSERTED = Counter(
     'insights_advisor_api_inventory_host_upserted',
     'Count how many inventory hosts were upserted'


### PR DESCRIPTION
Replicate the insightsOnly Kafka Connect filter in the inventory consumer: reject hosts where insights_id equals the nil UUID (00000000-0000-0000-0000-000000000000) in addition to the existing null/empty check. Adds a dedicated prometheus counter for observability.

## Summary by Sourcery

Filter out inventory events where insights_id is the nil UUID and track them via a dedicated Prometheus counter.

New Features:
- Introduce a Prometheus counter for inventory events rejected by the insights-only filter.

Bug Fixes:
- Prevent hosts with a nil UUID insights_id from being ingested in the inventory replication flow.

Enhancements:
- Add explicit constant for the nil UUID and improve logging when inventory events are rejected due to invalid insights_id.

Tests:
- Add a test to verify that inventory events with a nil UUID insights_id are filtered out and not upserted.