### PR TITLE
fix: use CharField for ExportHits solution_url schema

### DIFF
--- a/api/advisor/api/serializers.py
+++ b/api/advisor/api/serializers.py
@@ -298,7 +298,10 @@ class ExportHitsSerializer(serializers.Serializer):
     uuid = serializers.UUIDField()
     last_seen = serializers.DateTimeField(allow_null=True)
     title = serializers.CharField()
-    solution_url = serializers.URLField(allow_blank=True)
+    # CharField instead of URLField(allow_blank=True) to avoid drf-spectacular
+    # generating a oneOf[uri, maxLength=0] schema that breaks openapi-generator.
+    # See https://github.com/OpenAPITools/openapi-generator/issues/19034
+    solution_url = serializers.CharField(allow_blank=True)
     total_risk = serializers.IntegerField()
     likelihood = serializers.IntegerField()
     publish_date = serializers.DateTimeField()


### PR DESCRIPTION
## What
Change `ExportHitsSerializer.solution_url` from `URLField(allow_blank=True)` to `CharField(allow_blank=True)` to fix the generated OpenAPI schema.

## Why
drf-spectacular generates a `oneOf[uri, maxLength=0]` schema for `URLField(allow_blank=True)`. When `solution_url` is `""` (rules without a KCS node_id), it matches both `oneOf` schemas, causing openapi-generator clients (iqe-bindings v7) to fail with "Multiple matches found". This is the known [openapi-generator#19034](https://github.com/OpenAPITools/openapi-generator/issues/19034) bug.

## How
Changed the serializer field type from `URLField` to `CharField`. This is safe because `ExportHitsSerializer` is only used for OpenAPI schema generation — the actual data is built by `transform_hits()` / `transform_hits_local()` in the export view, which bypass the serializer entirely. The generated schema becomes `{"type": "string"}` instead of the problematic `oneOf`.

## Testing
- Generated the OpenAPI schema locally with drf-spectacular 0.30.0 (same version as production) and confirmed `solution_url` no longer produces the `oneOf`
- Verified the serializer correctly handles both empty strings and real URLs

Assisted-by: Cursor:claude-4.6-opus

## Summary by Sourcery

Enhancements:
- Change solution_url from URLField to CharField to produce a simpler string schema compatible with drf-spectacular and openapi-generator.