### PR TITLE
fix: fix prometheus metrics that was doubling for upsert

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -381,7 +381,7 @@ def bulk_upsert_hosts(upserts: list[ParsedInventoryHost]) -> None:
         ))
         logger.debug("Bulk upserted %d Host records", host_upserted)
 
-        prometheus.INVENTORY_HOST_UPSERTED.inc(advisor_inv_upserted + host_upserted)
+        prometheus.INVENTORY_HOST_UPSERTED.inc(advisor_inv_upserted)
 
 def bulk_delete_hosts(deletes: list[ParsedDeleteEvent]) -> None:
     """Bulk delete Host and AdvisorInventoryHost records in a single transaction."""


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the INVENTORY_HOST_UPSERTED Prometheus counter to only increment by advisor inventory upserts instead of including host upserts a second time.