### PR TITLE
fix: prevent FK violation in bulk_delete_hosts by explicitly deleting dependent records

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -32,7 +32,7 @@ from advisor_logging import logger
 from feature_flags import (
     feature_flag_is_enabled, FLAG_ENABLE_INVENTORY_REPLICATION
 )
-from api.models import AdvisorInventoryHost, Host
+from api.models import AdvisorInventoryHost, CurrentReport, Host, HostAck, Upload
 
 from kafka_utils import JsonValue, KafkaDispatcher
 
@@ -396,19 +396,25 @@ def bulk_upsert_hosts(upserts: list[ParsedInventoryHost]) -> None:
         prometheus.INVENTORY_HOST_UPSERTED.inc(advisor_inv_upserted)
 
 def bulk_delete_hosts(deletes: list[ParsedDeleteEvent]) -> None:
-    """Bulk delete Host and AdvisorInventoryHost records in a single transaction."""
+    """Bulk delete AdvisorInventoryHost and Host records, including FK-dependent data."""
     requested = len(deletes)
     delete_q = Q()
+    host_q = Q()
     for item in deletes:
         delete_q |= Q(inventory_id=item.inventory_id, org_id=item.org_id)
+        host_q |= Q(host_id=item.inventory_id, org_id=item.org_id)
 
     with transaction.atomic():
-        deleted_hosts = Host.objects.filter(delete_q).delete()
-        logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
-
         deleted_inv_num, _ = AdvisorInventoryHost.objects.filter(delete_q).delete()
         logger.info("Batch deleted %d records based on AdvisorInventoryHost", deleted_inv_num)
         prometheus.INVENTORY_HOST_DELETED.inc(deleted_inv_num)
+
+        Upload.objects.filter(host_q).delete()
+        CurrentReport.objects.filter(host_q).delete()
+        HostAck.objects.filter(host_q).delete()
+
+        deleted_hosts = Host.objects.filter(delete_q).delete()
+        logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
 
     deleted_count = deleted_inv_num
     missing = requested - deleted_count


### PR DESCRIPTION
Two consumers with different Kafka group IDs both process platform.inventory.events delete events. When advisor_inventory_service deleted Host (api_host) before service.py cleaned up the referencing Upload/CurrentReport/HostAck rows, a deferred FK constraint violation occurred at commit time.

Delete AdvisorInventoryHost first, then explicitly remove Upload, CurrentReport and HostAck records before deleting Host, so the transaction no longer relies on ordering between consumers.

## Summary by Sourcery

Prevent foreign key violations during bulk host deletion by ensuring dependent advisor inventory and related records are removed before Host rows within a single transaction.

Bug Fixes:
- Delete AdvisorInventoryHost records before Host records to avoid deferred foreign key constraint violations when processing delete events.
- Explicitly delete Upload, CurrentReport, and HostAck rows associated with hosts being removed to ensure referential integrity during bulk deletions.