### PR TITLE
feat(RHINENG-29490): Add new Satellite workload

### DIFF
--- a/api/advisor/api/filters.py
+++ b/api/advisor/api/filters.py
@@ -475,6 +475,7 @@ display_name_query_param = OpenApiParameter(
 WORKLOAD_NAMES = (
     'sap', 'ansible', 'mssql', 'crowdstrike',
     'ibm_db2', 'intersystems', 'oracle_db', 'rhel_ai',
+    'satellite',
 )
 
 workload_query_param = OpenApiParameter(

--- a/api/advisor/api/fixtures/basic_test_data.json
+++ b/api/advisor/api/fixtures/basic_test_data.json
@@ -451,6 +451,10 @@
               "falcon_aid": "abc123def456",
               "falcon_backend": "bpf",
               "falcon_version": "7.14.0"
+            },
+            "satellite": {
+              "type": "server",
+              "version": "6.17.6.1"
             }
           }
       },

--- a/api/advisor/api/tests/test_inventory_host_model.py
+++ b/api/advisor/api/tests/test_inventory_host_model.py
@@ -66,6 +66,10 @@ class InventoryHostTestCase(TestCase):
                     'falcon_aid': 'abc123def456',
                     'falcon_backend': 'bpf',
                     'falcon_version': '7.14.0'
+                },
+                'satellite': {
+                    'type': 'server',
+                    'version': '6.17.6.1'
                 }
             }
         })

--- a/api/advisor/api/tests/test_parameter_parsing.py
+++ b/api/advisor/api/tests/test_parameter_parsing.py
@@ -706,7 +706,7 @@ class MultiParamParsingTestCase(TestCase):
             Q(system_profile__workloads__sap__sap_system=True)
         )
 
-    _NEW_WORKLOADS = ('crowdstrike', 'ibm_db2', 'intersystems', 'oracle_db', 'rhel_ai')
+    _NEW_WORKLOADS = ('crowdstrike', 'ibm_db2', 'intersystems', 'oracle_db', 'rhel_ai', 'satellite')
 
     def test_new_workloads_canonical_path(self):
         for workload in self._NEW_WORKLOADS:
@@ -755,7 +755,7 @@ class FilterOnWorkloadTestCase(TestCase):
     def test_non_sap_uses_isnull_false(self):
         """Non-SAP workloads check isnull=False."""
         for workload in ('ansible', 'mssql', 'crowdstrike', 'ibm_db2',
-                         'intersystems', 'oracle_db', 'rhel_ai'):
+                         'intersystems', 'oracle_db', 'rhel_ai', 'satellite'):
             with self.subTest(workload=workload):
                 rq = self._make_request(workload)
                 self.assertEqual(

--- a/api/advisor/api/tests/test_workloads_field_redirection.py
+++ b/api/advisor/api/tests/test_workloads_field_redirection.py
@@ -28,7 +28,7 @@ class WorkloadsFieldRedirectionTestCase(TestCase):
     SAP, Ansible, and MSSQL use flat legacy paths (e.g. filter[system_profile][ansible])
     that are redirected internally to filter[system_profile][workloads][*].
 
-    CrowdStrike, IBM Db2, InterSystems, Oracle DB, and RHEL AI were introduced
+    CrowdStrike, IBM Db2, InterSystems, Oracle DB, RHEL AI, and Satellite were introduced
     directly under filter[system_profile][workloads][*] and require no redirection.
     """
     fixtures = [
@@ -182,6 +182,7 @@ class WorkloadsFieldRedirectionTestCase(TestCase):
             ('intersystems', {constants.host_04_uuid}),
             ('oracle_db', {constants.host_06_uuid}),
             ('rhel_ai', {constants.host_05_uuid}),
+            ('satellite', {constants.host_01_uuid}),
         ]
         for workload_name, expected_uuids in cases:
             with self.subTest(workload=workload_name):
@@ -286,6 +287,7 @@ class WorkloadQueryParamTestCase(TestCase):
             ('intersystems', {constants.host_04_uuid}),
             ('oracle_db', {constants.host_06_uuid}),
             ('rhel_ai', {constants.host_05_uuid}),
+            ('satellite', {constants.host_01_uuid}),
         ]
         for workload_name, expected in cases:
             with self.subTest(workload=workload_name):

--- a/api/advisor/sat_compat/tests/test_maintenance_views.py
+++ b/api/advisor/sat_compat/tests/test_maintenance_views.py
@@ -558,11 +558,11 @@ class MaintenanceTestCase(TestCase):
             **auth_header_for_testing()
         )
         self.assertEqual(response.status_code, 400, f"Response: {response.status_code} - {response.content.decode()}")
-        self.assertEqual(response.json(), {'add': [
-            {'rule_id': ['This field is required.']},
-            {'rule_id': ["Rule with ID 'unknown rule' does not exist"]},
-            {'system_id': ["Must be a valid UUID."]},
-        ]})
+        self.assertEqual(response.json(), {'add': {
+            '0': {'rule_id': ['This field is required.']},
+            '1': {'rule_id': ["Rule with ID 'unknown rule' does not exist"]},
+            '2': {'system_id': ["Must be a valid UUID."]},
+        }})
 
     def test_maintenance_update_simple(self):
         # No branch ID, no update.

--- a/api/advisor/tasks/tests/test_executed_task_views.py
+++ b/api/advisor/tasks/tests/test_executed_task_views.py
@@ -682,10 +682,10 @@ class ExecutedTaskViewTestCase(TestCase):
         )
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json(),
-            {'parameters': [{
+            {'parameters': {'0': {
                 'key': ['This field is required.'],
                 'value': ['This field is required.']
-            }]}
+            }}}
         )
         # Value not supplied
         res = self.client.post(
@@ -700,9 +700,9 @@ class ExecutedTaskViewTestCase(TestCase):
         )
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json(),
-            {'parameters': [{
+            {'parameters': {'0': {
                 'value': ['This field is required.']
-            }]}
+            }}}
         )
 
         # Value not in list


### PR DESCRIPTION
Add new Satellite workload
https://redhat.atlassian.net/browse/RHINENG-29490

## Backend Implementation

The backend (HBI + puptoo) now supports Satellite workload detection. 

```
### Schema (`workloads.satellite`)

```json
{
  "workloads": {
    "satellite": {
      "type": "server",       // enum: "server" | "capsule"
      "version": "6.17.6.1"   // string, max 30 chars, supports wildcard filtering
    }
  }
}
```

## Summary by Sourcery

Add Satellite to the set of supported workloads and extend workload-related filters and tests accordingly.

New Features:
- Support filtering and querying hosts by the new Satellite workload type.

Tests:
- Extend workload parameter parsing and field redirection tests to cover the Satellite workload.