### PR TITLE
fix: try fixing race condition

### DIFF
--- a/api/advisor/api/management/commands/advisor_inventory_service.py
+++ b/api/advisor/api/management/commands/advisor_inventory_service.py
@@ -399,22 +399,27 @@ def bulk_delete_hosts(deletes: list[ParsedDeleteEvent]) -> None:
     """Bulk delete AdvisorInventoryHost and Host records, including FK-dependent data."""
     requested = len(deletes)
     delete_q = Q()
-    host_q = Q()
     for item in deletes:
         delete_q |= Q(inventory_id=item.inventory_id, org_id=item.org_id)
-        host_q |= Q(host_id=item.inventory_id, org_id=item.org_id)
 
     with transaction.atomic():
         deleted_inv_num, _ = AdvisorInventoryHost.objects.filter(delete_q).delete()
         logger.info("Batch deleted %d records based on AdvisorInventoryHost", deleted_inv_num)
         prometheus.INVENTORY_HOST_DELETED.inc(deleted_inv_num)
 
-        Upload.objects.filter(host_q).delete()
-        CurrentReport.objects.filter(host_q).delete()
-        HostAck.objects.filter(host_q).delete()
+        host_ids = list(
+            Host.objects.filter(delete_q)
+            .select_for_update()
+            .values_list('inventory_id', flat=True)
+        )
+        if host_ids:
+            host_id_q = Q(host_id__in=host_ids)
+            Upload.objects.filter(host_id_q).delete()
+            CurrentReport.objects.filter(host_id_q).delete()
+            HostAck.objects.filter(host_id_q).delete()
 
-        deleted_hosts = Host.objects.filter(delete_q).delete()
-        logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
+            deleted_hosts = Host.objects.filter(inventory_id__in=host_ids).delete()
+            logger.info("Batch deleted %d records based on Host: %s.", *deleted_hosts)
 
     deleted_count = deleted_inv_num
     missing = requested - deleted_count


### PR DESCRIPTION
What's actually causing the FK violation
The bulk_delete_hosts function had two bugs:

The org_id filter on dependent deletes was too narrow. The old code built host_q = Q(host_id=..., org_id=...) for Upload/CurrentReport/HostAck deletes. The FK constraint (api_upload.host_id → api_host.system_uuid) is on host_id alone. If any Upload has a different org_id than the delete event, it survives the filter and blocks the Host delete.

No row locking on Host. Under READ COMMITTED, the service can commit a new Upload.objects.update_or_create(host_id=...) between the Upload-delete and Host-delete statements in bulk_delete_hosts, causing the FK violation at commit.

What the fix does
Locks Host rows first with select_for_update() — this prevents the service from creating new Uploads against a Host that's being deleted (the service's update_or_create will block until the delete transaction commits)
Removes org_id from dependent filters — deletes all Uploads/Reports/HostAcks by host_id alone, matching the actual FK constraint

## Summary by Sourcery

Fix host bulk deletion to avoid foreign key violations and race conditions when removing hosts and their dependent records.

Bug Fixes:
- Ensure dependent Upload, CurrentReport, and HostAck records are deleted by host identifier only, matching the foreign key constraint.
- Lock Host rows during bulk deletion to prevent concurrent creation of dependent records that would block host deletion.